### PR TITLE
fix: reduce proxy-induced continuation bias in translated turns

### DIFF
--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -61,6 +61,77 @@ func allowTagSource(source *thinkingStreamSource) bool {
 	return *source == thinkingSourceTagBlock
 }
 
+func validateClaudeRequestShape(req *ClaudeRequest) string {
+	if len(req.Messages) == 0 {
+		return "messages must not be empty"
+	}
+
+	hasUserContext := false
+	lastRole := ""
+	for _, msg := range req.Messages {
+		role := strings.TrimSpace(msg.Role)
+		if role == "" {
+			continue
+		}
+		lastRole = role
+		if role != "user" {
+			continue
+		}
+
+		text, images, toolResults := extractClaudeUserContent(msg.Content)
+		if normalizeUserContent(text, len(images) > 0) != "" || len(toolResults) > 0 {
+			hasUserContext = true
+		}
+	}
+
+	if lastRole == "assistant" {
+		return "assistant-prefill final message is not supported; last message must be user"
+	}
+	if !hasUserContext {
+		return "at least one non-empty user message is required"
+	}
+	return ""
+}
+
+func validateOpenAIRequestShape(req *OpenAIRequest) string {
+	if len(req.Messages) == 0 {
+		return "messages must not be empty"
+	}
+
+	hasNonSystem := false
+	hasUserContext := false
+	lastRole := ""
+	for _, msg := range req.Messages {
+		role := strings.TrimSpace(msg.Role)
+		if role == "" {
+			continue
+		}
+		if role != "system" {
+			hasNonSystem = true
+			lastRole = role
+		}
+
+		if role != "user" {
+			continue
+		}
+		text, images := extractOpenAIUserContent(msg.Content)
+		if normalizeUserContent(text, len(images) > 0) != "" {
+			hasUserContext = true
+		}
+	}
+
+	if !hasNonSystem {
+		return "at least one non-system message is required"
+	}
+	if lastRole == "assistant" {
+		return "assistant-prefill final message is not supported; last message must be user or tool"
+	}
+	if !hasUserContext {
+		return "at least one non-empty user message is required"
+	}
+	return ""
+}
+
 func NewHandler() *Handler {
 	totalReq, successReq, failedReq, totalTokens, totalCredits := config.GetStats()
 	h := &Handler{
@@ -429,6 +500,10 @@ func (h *Handler) handleClaudeMessagesInternal(w http.ResponseWriter, r *http.Re
 	var req ClaudeRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		h.sendClaudeError(w, 400, "invalid_request_error", "Invalid JSON: "+err.Error())
+		return
+	}
+	if msg := validateClaudeRequestShape(&req); msg != "" {
+		h.sendClaudeError(w, 400, "invalid_request_error", msg)
 		return
 	}
 
@@ -1023,6 +1098,10 @@ func (h *Handler) handleOpenAIChat(w http.ResponseWriter, r *http.Request) {
 	var req OpenAIRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		h.sendOpenAIError(w, 400, "invalid_request_error", "Invalid JSON")
+		return
+	}
+	if msg := validateOpenAIRequestShape(&req); msg != "" {
+		h.sendOpenAIError(w, 400, "invalid_request_error", msg)
 		return
 	}
 

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -48,3 +48,53 @@ func TestThinkingSourceSameSourceRemainsAllowed(t *testing.T) {
 		t.Fatalf("expected repeated reasoning source selection to stay allowed")
 	}
 }
+
+func TestValidateOpenAIRequestShapeRejectsAssistantPrefill(t *testing.T) {
+	req := &OpenAIRequest{
+		Messages: []OpenAIMessage{
+			{Role: "user", Content: "hello"},
+			{Role: "assistant", Content: "prefill"},
+		},
+	}
+
+	if msg := validateOpenAIRequestShape(req); msg == "" {
+		t.Fatalf("expected assistant-prefill final message to be rejected")
+	}
+}
+
+func TestValidateOpenAIRequestShapeAllowsToolResultFinalTurn(t *testing.T) {
+	req := &OpenAIRequest{
+		Messages: []OpenAIMessage{
+			{Role: "user", Content: "find weather"},
+			{
+				Role: "assistant",
+				ToolCalls: []ToolCall{{
+					ID:   "call_1",
+					Type: "function",
+					Function: struct {
+						Name      string `json:"name"`
+						Arguments string `json:"arguments"`
+					}{Name: "get_weather", Arguments: "{}"},
+				}},
+			},
+			{Role: "tool", ToolCallID: "call_1", Content: "sunny"},
+		},
+	}
+
+	if msg := validateOpenAIRequestShape(req); msg != "" {
+		t.Fatalf("expected tool-result final turn to be valid, got %q", msg)
+	}
+}
+
+func TestValidateClaudeRequestShapeRejectsAssistantPrefill(t *testing.T) {
+	req := &ClaudeRequest{
+		Messages: []ClaudeMessage{
+			{Role: "user", Content: "hello"},
+			{Role: "assistant", Content: "prefill"},
+		},
+	}
+
+	if msg := validateClaudeRequestShape(req); msg == "" {
+		t.Fatalf("expected assistant-prefill final message to be rejected")
+	}
+}

--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -44,6 +44,7 @@ const ThinkingModePrompt = `<thinking_mode>enabled</thinking_mode>
 <max_thinking_length>200000</max_thinking_length>`
 
 const minimalFallbackUserContent = "."
+const toolResultsContinuationPrefix = "Tool results:"
 
 // ParseModelAndThinking 解析模型名称，返回实际模型和是否启用 thinking
 func ParseModelAndThinking(model string, thinkingSuffix string) (string, bool) {
@@ -199,21 +200,12 @@ func ClaudeToKiro(req *ClaudeRequest, thinking bool) *KiroPayload {
 		}
 	}
 
-	// 确保 history 以 user 开始
-	if len(history) > 0 && history[0].AssistantResponseMessage != nil {
-		history = append([]KiroHistoryMessage{{
-			UserInputMessage: &KiroUserInputMessage{
-				Content: "Begin conversation",
-				ModelID: modelID,
-				Origin:  origin,
-			},
-		}}, history...)
-	}
+	history = trimLeadingAssistantHistory(history)
 
 	// 构建最终内容
 	finalContent := ""
 	if systemPrompt != "" {
-		finalContent = "--- SYSTEM PROMPT ---\n" + systemPrompt + "\n--- END SYSTEM PROMPT ---\n\n"
+		finalContent = strings.TrimSpace(systemPrompt) + "\n\n"
 	}
 	if currentContent != "" {
 		finalContent += currentContent
@@ -830,11 +822,27 @@ func buildToolResultsContinuation(toolResults []KiroToolResult) string {
 		return minimalFallbackUserContent
 	}
 
-	joined := strings.Join(parts, "\n\n")
+	joined := toolResultsContinuationPrefix + "\n\n" + strings.Join(parts, "\n\n")
 	if len(joined) > 4000 {
 		return joined[:4000]
 	}
 	return joined
+}
+
+func trimLeadingAssistantHistory(history []KiroHistoryMessage) []KiroHistoryMessage {
+	idx := 0
+	for idx < len(history) && history[idx].AssistantResponseMessage != nil {
+		idx++
+	}
+
+	if idx == 0 {
+		return history
+	}
+	if idx >= len(history) {
+		return nil
+	}
+
+	return history[idx:]
 }
 
 func firstClaudeConversationAnchor(messages []ClaudeMessage) string {
@@ -847,15 +855,7 @@ func firstClaudeConversationAnchor(messages []ClaudeMessage) string {
 			return strings.TrimSpace(text)
 		}
 		if len(toolResults) > 0 {
-			return buildToolResultsContinuation(toolResults)
-		}
-	}
-
-	for _, msg := range messages {
-		if strings.TrimSpace(msg.Role) != "" {
-			if text := extractOpenAIMessageText(msg.Content); strings.TrimSpace(text) != "" {
-				return strings.TrimSpace(text)
-			}
+			continue
 		}
 	}
 
@@ -873,23 +873,30 @@ func firstOpenAIConversationAnchor(messages []OpenAIMessage) string {
 		}
 	}
 
-	for _, msg := range messages {
-		text := extractOpenAIMessageText(msg.Content)
-		if strings.TrimSpace(text) != "" {
-			return strings.TrimSpace(text)
-		}
-	}
-
 	return ""
 }
 
 func buildConversationID(modelID, systemPrompt, anchor string) string {
 	anchor = strings.TrimSpace(anchor)
-	if anchor == "" {
+	if isSyntheticConversationAnchor(anchor) {
 		return uuid.New().String()
 	}
 	seed := strings.Join([]string{modelID, strings.TrimSpace(systemPrompt), anchor}, "\n")
 	return uuid.NewSHA1(uuid.NameSpaceURL, []byte(seed)).String()
+}
+
+func isSyntheticConversationAnchor(anchor string) bool {
+	if strings.TrimSpace(anchor) == "" {
+		return true
+	}
+
+	normalized := strings.ToLower(strings.Join(strings.Fields(anchor), " "))
+	switch normalized {
+	case ".", "begin conversation", "please analyze the attached image.", strings.ToLower(minimalFallbackUserContent):
+		return true
+	default:
+		return false
+	}
 }
 
 func extractOpenAITextPart(part map[string]interface{}) (string, bool) {

--- a/proxy/translator_test.go
+++ b/proxy/translator_test.go
@@ -76,8 +76,8 @@ func TestOpenAIToKiroPreservesStructuredAssistantAndToolContent(t *testing.T) {
 	}
 
 	cur := payload.ConversationState.CurrentMessage.UserInputMessage
-	if cur.Content != "tool-result-structured" {
-		t.Fatalf("expected tool-result continuation content, got %q", cur.Content)
+	if !strings.Contains(cur.Content, "tool-result-structured") {
+		t.Fatalf("expected tool-result continuation content to include tool text, got %q", cur.Content)
 	}
 	if cur.UserInputMessageContext == nil || len(cur.UserInputMessageContext.ToolResults) != 1 {
 		t.Fatalf("expected one tool result in current context")
@@ -194,5 +194,69 @@ func TestClaudeConversationIDStableFromAnchor(t *testing.T) {
 	}
 	if payloadA.ConversationState.ConversationID != payloadB.ConversationState.ConversationID {
 		t.Fatalf("expected stable conversation ID across turns, got %q vs %q", payloadA.ConversationState.ConversationID, payloadB.ConversationState.ConversationID)
+	}
+}
+
+func TestOpenAIConversationIDRandomForSyntheticAnchor(t *testing.T) {
+	req := &OpenAIRequest{
+		Model: "claude-sonnet-4.5",
+		Messages: []OpenAIMessage{
+			{Role: "assistant", Content: "prefill"},
+		},
+	}
+
+	payloadA := OpenAIToKiro(req, false)
+	payloadB := OpenAIToKiro(req, false)
+
+	if payloadA.ConversationState.ConversationID == payloadB.ConversationState.ConversationID {
+		t.Fatalf("expected synthetic anchor to generate non-deterministic conversation IDs")
+	}
+}
+
+func TestClaudeToKiroDropsLeadingAssistantHistory(t *testing.T) {
+	req := &ClaudeRequest{
+		Model: "claude-sonnet-4.5",
+		Messages: []ClaudeMessage{
+			{Role: "assistant", Content: "prefill"},
+			{Role: "user", Content: "real user message"},
+		},
+	}
+
+	payload := ClaudeToKiro(req, false)
+
+	if len(payload.ConversationState.History) != 0 {
+		t.Fatalf("expected leading assistant-only history to be dropped, got %d entries", len(payload.ConversationState.History))
+	}
+
+	if strings.Contains(payload.ConversationState.CurrentMessage.UserInputMessage.Content, "Begin conversation") {
+		t.Fatalf("unexpected synthetic Begin conversation injection in current content: %q", payload.ConversationState.CurrentMessage.UserInputMessage.Content)
+	}
+}
+
+func TestToolResultsContinuationIncludesInstructionPrefix(t *testing.T) {
+	req := &OpenAIRequest{
+		Model: "claude-sonnet-4.5",
+		Messages: []OpenAIMessage{
+			{Role: "user", Content: "find data"},
+			{Role: "assistant", ToolCalls: []ToolCall{{
+				ID:   "call_1",
+				Type: "function",
+				Function: struct {
+					Name      string `json:"name"`
+					Arguments string `json:"arguments"`
+				}{Name: "fetch", Arguments: "{}"},
+			}}},
+			{Role: "tool", ToolCallID: "call_1", Content: "result-1"},
+		},
+	}
+
+	payload := OpenAIToKiro(req, false)
+	content := payload.ConversationState.CurrentMessage.UserInputMessage.Content
+
+	if !strings.Contains(content, toolResultsContinuationPrefix) {
+		t.Fatalf("expected tool continuation prefix, got %q", content)
+	}
+	if !strings.Contains(content, "result-1") {
+		t.Fatalf("expected tool result text in continuation content, got %q", content)
 	}
 }


### PR DESCRIPTION
## Summary
- Remove translator behaviors that bias prompts toward continuation-style outputs by trimming assistant-prefill history and tightening conversation anchoring.
- Add request-shape validation for both `/v1/messages` and `/v1/chat/completions` to reject assistant-prefill final turns and empty user-context payloads early.
- Keep tool-result continuation explicit but neutral (`Tool results:`), and add regression tests for synthetic-anchor ID behavior and validator coverage.

## Verification
- `go test ./...`
- `go build ./...`