### PR TITLE
fix: stabilize prompt cache fingerprints

### DIFF
--- a/proxy/cache_tracker.go
+++ b/proxy/cache_tracker.go
@@ -254,9 +254,10 @@ func flattenClaudeCacheBlocks(req *ClaudeRequest) []cacheablePromptBlock {
 			"description":  tool.Description,
 			"input_schema": tool.InputSchema,
 		}
+		fingerprintValue := stripCachePositionKeys(toolValue)
 		blocks = append(blocks, cacheablePromptBlock{
-			Value:  toolValue,
-			Tokens: estimateApproxTokens(canonicalizeCacheValue(toolValue)),
+			Value:  fingerprintValue,
+			Tokens: estimateApproxTokens(canonicalizeCacheValue(fingerprintValue)),
 			TTL:    normalizePromptCacheTTL(extractPromptCacheTTL(tool)),
 		})
 	}
@@ -357,59 +358,52 @@ func appendPromptBlock(blocks *[]cacheablePromptBlock, wrapper map[string]interf
 	blockValue := wrapper["block"]
 	ttl := normalizePromptCacheTTL(extractPromptCacheTTL(blockValue))
 
-	// Normalize volatile text (e.g. Claude Code's x-anthropic-billing-header
-	// which drifts on every request) so that fingerprints remain stable across
-	// requests within the same conversation.
-	if normalized, changed := normalizeCacheBlockContent(blockValue); changed {
-		cloned := make(map[string]interface{}, len(wrapper))
-		for k, v := range wrapper {
-			cloned[k] = v
-		}
-		cloned["block"] = normalized
-		wrapper = cloned
+	// Drop volatile billing metadata from the cache fingerprint. Claude Code's
+	// x-anthropic-billing-header can drift, appear, or disappear across
+	// otherwise identical requests, and it does not change model semantics.
+	if isAnthropicBillingHeaderBlock(blockValue) {
+		return
 	}
 
-	canonical := canonicalizeCacheValue(wrapper)
+	fingerprintValue := stripCachePositionKeys(wrapper)
+	canonical := canonicalizeCacheValue(fingerprintValue)
 	*blocks = append(*blocks, cacheablePromptBlock{
-		Value:        wrapper,
+		Value:        fingerprintValue,
 		Tokens:       estimateApproxTokens(canonical),
 		TTL:          ttl,
 		IsMessageEnd: isMessageEnd,
 	})
 }
 
-// normalizeCacheBlockContent replaces volatile but semantically irrelevant
-// fields with a placeholder so that the cumulative fingerprint stays stable
-// across requests in the same session. Currently handles:
-//   - Claude Code's "x-anthropic-billing-header: ..." system text block
-//     whose content drifts on every request (version, telemetry hash, etc.)
-func normalizeCacheBlockContent(value interface{}) (interface{}, bool) {
+func stripCachePositionKeys(value map[string]interface{}) map[string]interface{} {
+	cloned := make(map[string]interface{}, len(value))
+	for key, item := range value {
+		if isCachePositionKey(key) {
+			continue
+		}
+		cloned[key] = item
+	}
+	return cloned
+}
+
+func isAnthropicBillingHeaderBlock(value interface{}) bool {
 	blockMap, ok := value.(map[string]interface{})
 	if !ok {
-		return value, false
+		return false
 	}
 
 	// Only normalize text blocks (or blocks without an explicit type but containing text).
 	if t, ok := blockMap["type"].(string); ok && t != "" && t != "text" {
-		return value, false
+		return false
 	}
 
 	text, ok := blockMap["text"].(string)
 	if !ok {
-		return value, false
+		return false
 	}
 
 	trimmed := strings.TrimLeft(text, " \t\r\n")
-	if !strings.HasPrefix(strings.ToLower(trimmed), "x-anthropic-billing-header:") {
-		return value, false
-	}
-
-	cloned := make(map[string]interface{}, len(blockMap))
-	for k, v := range blockMap {
-		cloned[k] = v
-	}
-	cloned["text"] = "__anthropic_billing_header__"
-	return cloned, true
+	return strings.HasPrefix(strings.ToLower(trimmed), "x-anthropic-billing-header:")
 }
 
 func extractPromptCacheTTL(value interface{}) time.Duration {
@@ -587,6 +581,15 @@ func writeCanonicalJSON(buf *bytes.Buffer, value interface{}) {
 	default:
 		encoded, _ := json.Marshal(v)
 		buf.Write(encoded)
+	}
+}
+
+func isCachePositionKey(key string) bool {
+	switch key {
+	case "tool_index", "system_index", "message_index", "block_index":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/proxy/cache_tracker_test.go
+++ b/proxy/cache_tracker_test.go
@@ -77,7 +77,7 @@ func TestBuildClaudeUsageMapIncludesCacheFields(t *testing.T) {
 // TestPromptCacheStableAcrossBillingHeaderDrift verifies that Claude Code's
 // per-request "x-anthropic-billing-header: cc_version=...; cch=...;" system
 // block (whose content drifts on every request) does not break cache hits.
-// The normalization logic should ensure the same conversation still matches.
+// The tracker should ignore that metadata when fingerprinting cached prefixes.
 func TestPromptCacheStableAcrossBillingHeaderDrift(t *testing.T) {
 	tracker := newPromptCacheTracker(time.Hour)
 	mainSystem := strings.Repeat("You are a helpful coding assistant with deep knowledge of Go, Rust, Python, and TypeScript. ", 80)
@@ -121,6 +121,92 @@ func TestPromptCacheStableAcrossBillingHeaderDrift(t *testing.T) {
 	second := tracker.Compute("acct-1", profile2)
 	if second.CacheReadInputTokens == 0 {
 		t.Fatalf("expected cache read after billing header drift, got %+v", second)
+	}
+}
+
+func TestPromptCacheStableWhenBillingHeaderAppearsOrDisappears(t *testing.T) {
+	tracker := newPromptCacheTracker(time.Hour)
+	mainSystem := strings.Repeat("You are a helpful coding assistant with deep knowledge of Go, Rust, Python, and TypeScript. ", 80)
+
+	build := func(includeBilling bool) *ClaudeRequest {
+		system := []interface{}{}
+		if includeBilling {
+			system = append(system, map[string]interface{}{
+				"type": "text",
+				"text": "x-anthropic-billing-header: cc_version=2.1.87.1; cch=aaaa;",
+			})
+		}
+		system = append(system, map[string]interface{}{
+			"type": "text",
+			"text": mainSystem,
+			"cache_control": map[string]interface{}{
+				"type": "ephemeral",
+			},
+		})
+		return &ClaudeRequest{
+			Model:    "claude-sonnet-4.5",
+			System:   system,
+			Messages: []ClaudeMessage{{Role: "user", Content: "hello world"}},
+		}
+	}
+
+	withBilling := tracker.BuildClaudeProfile(build(true), 2048)
+	if withBilling == nil {
+		t.Fatalf("profile with billing header should be built")
+	}
+	tracker.Update("acct-1", withBilling)
+
+	withoutBilling := tracker.BuildClaudeProfile(build(false), 2048)
+	if withoutBilling == nil {
+		t.Fatalf("profile without billing header should be built")
+	}
+	result := tracker.Compute("acct-1", withoutBilling)
+	if result.CacheReadInputTokens == 0 {
+		t.Fatalf("expected cache read when billing header disappears, got %+v", result)
+	}
+}
+
+func TestCanonicalCacheValueIgnoresPositionKeys(t *testing.T) {
+	first := canonicalizeCacheValue(stripCachePositionKeys(map[string]interface{}{
+		"kind":         "system",
+		"system_index": 0,
+		"block": map[string]interface{}{
+			"type": "text",
+			"text": "stable",
+		},
+	}))
+	second := canonicalizeCacheValue(stripCachePositionKeys(map[string]interface{}{
+		"kind":         "system",
+		"system_index": 1,
+		"block": map[string]interface{}{
+			"type": "text",
+			"text": "stable",
+		},
+	}))
+	if first != second {
+		t.Fatalf("expected position keys to be ignored, got %q vs %q", first, second)
+	}
+}
+
+func TestCanonicalCacheValuePreservesSemanticPositionKeys(t *testing.T) {
+	first := canonicalizeCacheValue(map[string]interface{}{
+		"kind": "system",
+		"block": map[string]interface{}{
+			"type":        "text",
+			"text":        "stable",
+			"block_index": 1,
+		},
+	})
+	second := canonicalizeCacheValue(map[string]interface{}{
+		"kind": "system",
+		"block": map[string]interface{}{
+			"type":        "text",
+			"text":        "stable",
+			"block_index": 2,
+		},
+	})
+	if first == second {
+		t.Fatalf("expected semantic block_index fields to remain fingerprinted")
 	}
 }
 


### PR DESCRIPTION
## Summary
- exclude Claude Code's volatile `x-anthropic-billing-header` system block from prompt cache fingerprints
- ignore wrapper position keys (`system_index`, `message_index`, `block_index`, `tool_index`) when canonicalizing cache blocks because order is already encoded by the cumulative hash stream
- add regression coverage for billing-header drift and billing-header appearance/disappearance

## Validation
I reproduced a cache miss against a running Kiro-Go deployment caused only by billing-header appearance/disappearance:

- call 1 with billing header: `cache_creation_input_tokens: 2084`
- call 2 without billing header, same semantic system prefix: `cache_creation_input_tokens: 2036` instead of a cache read
- call 3 with billing header again: `cache_read_input_tokens: 2084`

This patch targets that false miss in Kiro-Go's Claude-compatible prompt cache tracker. It does not change the outbound Kiro request payload.

## Rationale
`x-anthropic-billing-header` is request metadata rather than semantic prompt content, so including it in cache fingerprints can create false misses when the metadata changes, appears, or disappears across requests.

## Testing
- `go test ./...`
- `go build ./...`