### PR TITLE
fix: skip profile ARN resolution for GitHub accounts

### DIFF
--- a/proxy/kiro.go
+++ b/proxy/kiro.go
@@ -191,12 +191,19 @@ func getSortedEndpoints(preferred string) []kiroEndpoint {
 	return []kiroEndpoint{kiroEndpoints[0], kiroEndpoints[1]}
 }
 
+func shouldResolveProfileArn(account *config.Account) bool {
+	if account == nil {
+		return false
+	}
+	return !strings.EqualFold(strings.TrimSpace(account.Provider), "GitHub")
+}
+
 // CallKiroAPI 调用 Kiro API（流式），双端点自动 fallback
 func CallKiroAPI(account *config.Account, payload *KiroPayload, callback *KiroStreamCallback) error {
 	if _, err := json.Marshal(payload); err != nil {
 		return err
 	}
-	if payload != nil && strings.TrimSpace(payload.ProfileArn) == "" {
+	if payload != nil && strings.TrimSpace(payload.ProfileArn) == "" && shouldResolveProfileArn(account) {
 		if profileArn, err := ResolveProfileArn(account); err == nil {
 			payload.ProfileArn = profileArn
 		} else {

--- a/proxy/kiro_test.go
+++ b/proxy/kiro_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"kiro-go/config"
 	"net/http"
 	"net/url"
 	"testing"
@@ -38,6 +39,17 @@ func TestNormalizeChunkOverlapDelta(t *testing.T) {
 
 	if got := normalizeChunk("world!!!", &prev); got != "!!!" {
 		t.Fatalf("expected overlap suffix delta, got %q", got)
+	}
+}
+
+func TestShouldResolveProfileArnSkipsGitHubProvider(t *testing.T) {
+	account := &config.Account{
+		AuthMethod: "social",
+		Provider:   "GitHub",
+	}
+
+	if shouldResolveProfileArn(account) {
+		t.Fatal("expected GitHub provider to skip profile ARN resolution")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Skip automatic profile ARN resolution when the account provider is GitHub
- Avoid calling ListAvailableProfiles for GitHub/social accounts that do not expose Kiro profiles
- Add a regression test for GitHub provider detection

## Test Plan
- go test ./proxy -run TestShouldResolveProfileArnSkipsGitHubProvider -count=1
- go test ./...
