### PR TITLE
feat: 添加允许超额使用设置 (v1.0.7)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -113,6 +113,11 @@ type Config struct {
 	// Defaults to true. Set to false to only use the preferred endpoint.
 	EndpointFallback *bool `json:"endpointFallback,omitempty"`
 
+	// AllowOverUsage allows accounts to continue serving requests even when their
+	// usage quota has been exhausted. When enabled, the pool will not skip accounts
+	// solely because usageCurrent >= usageLimit.
+	AllowOverUsage bool `json:"allowOverUsage,omitempty"`
+
 	// Proxy configuration: optional outbound proxy for Kiro API requests
 	// Format: "socks5://host:port", "socks5://user:pass@host:port",
 	//         "http://host:port",  "http://user:pass@host:port"
@@ -503,6 +508,21 @@ func UpdateProxySettings(proxyURL string) error {
 	cfgLock.Lock()
 	defer cfgLock.Unlock()
 	cfg.ProxyURL = proxyURL
+	return Save()
+}
+
+// GetAllowOverUsage returns whether over-usage is allowed when account quota is exhausted.
+func GetAllowOverUsage() bool {
+	cfgLock.RLock()
+	defer cfgLock.RUnlock()
+	return cfg.AllowOverUsage
+}
+
+// UpdateAllowOverUsage sets the over-usage setting and persists the change.
+func UpdateAllowOverUsage(allow bool) error {
+	cfgLock.Lock()
+	defer cfgLock.Unlock()
+	cfg.AllowOverUsage = allow
 	return Save()
 }
 

--- a/pool/account.go
+++ b/pool/account.go
@@ -63,6 +63,7 @@ func (p *AccountPool) GetNext() *config.Account {
 		return nil
 	}
 
+	allowOverUsage := config.GetAllowOverUsage()
 	now := time.Now()
 	n := len(p.accounts)
 	seen := make(map[string]bool)
@@ -88,8 +89,8 @@ func (p *AccountPool) GetNext() *config.Account {
 			continue
 		}
 
-		// 跳过额度已用尽的账号（适用于所有订阅类型）
-		if acc.UsageLimit > 0 && acc.UsageCurrent >= acc.UsageLimit {
+		// 跳过额度已用尽的账号（如果未开启超额使用）
+		if !allowOverUsage && acc.UsageLimit > 0 && acc.UsageCurrent >= acc.UsageLimit {
 			seen[acc.ID] = true
 			continue
 		}
@@ -97,13 +98,13 @@ func (p *AccountPool) GetNext() *config.Account {
 		return acc
 	}
 
-	// 无可用账号，返回冷却时间最短的（排除额度用尽的）
+	// 无可用账号，返回冷却时间最短的（排除额度用尽的，除非允许超额）
 	var best *config.Account
 	var earliest time.Time
 	for i := range p.accounts {
 		acc := &p.accounts[i]
-		// 额度用尽的账号不作为 fallback
-		if acc.UsageLimit > 0 && acc.UsageCurrent >= acc.UsageLimit {
+		// 额度用尽的账号不作为 fallback（除非允许超额使用）
+		if !allowOverUsage && acc.UsageLimit > 0 && acc.UsageCurrent >= acc.UsageLimit {
 			continue
 		}
 		if cooldown, ok := p.cooldowns[acc.ID]; ok {

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -1095,6 +1095,7 @@ func (h *Handler) handleClaudeStream(w http.ResponseWriter, account *config.Acco
 	if err != nil {
 		h.recordFailure()
 		h.pool.RecordError(account.ID, strings.Contains(err.Error(), "429") || strings.Contains(err.Error(), "quota"))
+		h.checkOverageError(err)
 		h.sendSSE(w, flusher, "error", map[string]interface{}{
 			"type":  "error",
 			"error": map[string]string{"type": "api_error", "message": err.Error()},
@@ -1209,6 +1210,18 @@ func (h *Handler) recordFailure() {
 	atomic.AddInt64(&h.failedRequests, 1)
 }
 
+// checkOverageError 检测 402 超额错误，自动关闭超额使用设置
+func (h *Handler) checkOverageError(err error) {
+	if err == nil {
+		return
+	}
+	errMsg := err.Error()
+	if strings.Contains(errMsg, "402") && strings.Contains(errMsg, "OVERAGE") {
+		logger.Warnf("[Overage] Detected overage limit error, disabling allowOverUsage setting")
+		config.UpdateAllowOverUsage(false)
+	}
+}
+
 // handleClaudeNonStream Claude 非流式响应
 func (h *Handler) handleClaudeNonStream(w http.ResponseWriter, account *config.Account, payload *KiroPayload, model string, thinking bool, thinkingOpts claudeThinkingResponseOptions, estimatedInputTokens int, cacheUsage promptCacheUsage, cacheProfile *promptCacheProfile) {
 	var content string
@@ -1248,6 +1261,7 @@ func (h *Handler) handleClaudeNonStream(w http.ResponseWriter, account *config.A
 	if err != nil {
 		h.recordFailure()
 		h.pool.RecordError(account.ID, strings.Contains(err.Error(), "429"))
+		h.checkOverageError(err)
 		h.sendClaudeError(w, 500, "api_error", err.Error())
 		return
 	}
@@ -1690,6 +1704,7 @@ func (h *Handler) handleOpenAIStream(w http.ResponseWriter, account *config.Acco
 	if err != nil {
 		h.recordFailure()
 		h.pool.RecordError(account.ID, strings.Contains(err.Error(), "429"))
+		h.checkOverageError(err)
 		return
 	}
 
@@ -1781,6 +1796,7 @@ func (h *Handler) handleOpenAINonStream(w http.ResponseWriter, account *config.A
 	if err != nil {
 		h.recordFailure()
 		h.pool.RecordError(account.ID, strings.Contains(err.Error(), "429"))
+		h.checkOverageError(err)
 		h.sendOpenAIError(w, 500, "server_error", err.Error())
 		return
 	}
@@ -2550,18 +2566,20 @@ func (h *Handler) apiGetStatus(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) apiGetSettings(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(map[string]interface{}{
-		"apiKey":        config.GetApiKey(),
-		"requireApiKey": config.IsApiKeyRequired(),
-		"port":          config.GetPort(),
-		"host":          config.GetHost(),
+		"apiKey":         config.GetApiKey(),
+		"requireApiKey":  config.IsApiKeyRequired(),
+		"port":           config.GetPort(),
+		"host":           config.GetHost(),
+		"allowOverUsage": config.GetAllowOverUsage(),
 	})
 }
 
 func (h *Handler) apiUpdateSettings(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		ApiKey        string `json:"apiKey"`
-		RequireApiKey bool   `json:"requireApiKey"`
-		Password      string `json:"password"`
+		ApiKey         string `json:"apiKey"`
+		RequireApiKey  bool   `json:"requireApiKey"`
+		Password       string `json:"password"`
+		AllowOverUsage *bool  `json:"allowOverUsage,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		w.WriteHeader(400)
@@ -2573,6 +2591,15 @@ func (h *Handler) apiUpdateSettings(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(500)
 		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 		return
+	}
+
+	// 更新超额使用设置
+	if req.AllowOverUsage != nil {
+		if err := config.UpdateAllowOverUsage(*req.AllowOverUsage); err != nil {
+			w.WriteHeader(500)
+			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			return
+		}
 	}
 
 	json.NewEncoder(w).Encode(map[string]bool{"success": true})

--- a/proxy/kiro.go
+++ b/proxy/kiro.go
@@ -313,8 +313,8 @@ func CallKiroAPI(account *config.Account, payload *KiroPayload, callback *KiroSt
 			errBody, _ := io.ReadAll(resp.Body)
 			resp.Body.Close()
 			lastErr = fmt.Errorf("HTTP %d from %s: %s", resp.StatusCode, ep.Name, string(errBody))
-			// Authentication errors are not retried across endpoints.
-			if resp.StatusCode == 401 || resp.StatusCode == 403 {
+			// Authentication errors and payment errors are not retried across endpoints.
+			if resp.StatusCode == 401 || resp.StatusCode == 403 || resp.StatusCode == 402 {
 				return lastErr
 			}
 			logger.Warnf("[KiroAPI] Endpoint %s error: %v", ep.Name, lastErr)

--- a/web/index.html
+++ b/web/index.html
@@ -970,6 +970,19 @@
                 <button class="btn btn-primary" onclick="saveSettings()" data-i18n="common.save"></button>
             </div>
             <div class="card">
+                <div class="card-header"><span class="card-title" data-i18n="settings.usageSettings"></span></div>
+                <div class="form-group">
+                    <label style="display:flex;align-items:center;gap:10px">
+                        <label class="switch"><input type="checkbox" id="allowOverUsage"><span
+                                class="slider"></span></label>
+                        <span data-i18n="settings.allowOverUsage"></span>
+                    </label>
+                    <small style="color:#64748b;font-size:12px;margin-top:4px;display:block"
+                        data-i18n="settings.allowOverUsageHint"></small>
+                </div>
+                <button class="btn btn-primary" onclick="saveOverUsageConfig()" data-i18n="common.save"></button>
+            </div>
+            <div class="card">
                 <div class="card-header"><span class="card-title" data-i18n="settings.thinkingSettings"></span></div>
                 <div class="form-group">
                     <label data-i18n="settings.thinkingSuffix"></label>
@@ -1160,6 +1173,10 @@
                 'settings.enableApiKey': '启用 API Key 验证',
                 'settings.apiKeyPlaceholder': '留空则不验证',
                 'settings.generateApiKey': '随机生成',
+                'settings.usageSettings': '用量控制',
+                'settings.allowOverUsage': '允许超额使用',
+                'settings.allowOverUsageHint': '开启后，即使账号额度用尽也会继续使用该账号处理请求，不再因余额不足而报错',
+                'settings.overUsageSaved': '超额使用设置已保存',
                 'settings.thinkingSettings': 'Thinking 模式设置',
                 'settings.thinkingSuffix': '触发后缀',
                 'settings.thinkingSuffixHint': '模型名称加此后缀即启用思考模式，如 claude-sonnet-4.5-thinking',
@@ -1378,6 +1395,10 @@
                 'settings.enableApiKey': 'Enable API Key Verification',
                 'settings.apiKeyPlaceholder': 'Leave empty to disable',
                 'settings.generateApiKey': 'Generate',
+                'settings.usageSettings': 'Usage Control',
+                'settings.allowOverUsage': 'Allow Over-Usage',
+                'settings.allowOverUsageHint': 'When enabled, accounts will continue to serve requests even after their quota is exhausted',
+                'settings.overUsageSaved': 'Over-usage settings saved',
                 'settings.thinkingSettings': 'Thinking Mode Settings',
                 'settings.thinkingSuffix': 'Trigger Suffix',
                 'settings.thinkingSuffixHint': 'Add this suffix to model name to enable thinking mode, e.g. claude-sonnet-4.5-thinking',
@@ -2050,6 +2071,7 @@
             const d = await res.json();
             document.getElementById('requireApiKey').checked = d.requireApiKey;
             document.getElementById('apiKeyInput').value = d.apiKey || '';
+            document.getElementById('allowOverUsage').checked = d.allowOverUsage || false;
             loadThinkingConfig();
             loadEndpointConfig();
             loadProxyConfig();
@@ -2146,6 +2168,14 @@
                 body: JSON.stringify({ requireApiKey, apiKey: apiKeyInput.value })
             });
             alert(t('detail.saved'));
+        }
+        async function saveOverUsageConfig() {
+            const allowOverUsage = document.getElementById('allowOverUsage').checked;
+            await fetch('/admin/api/settings', {
+                method: 'POST', headers: { 'Content-Type': 'application/json', 'X-Admin-Password': password },
+                body: JSON.stringify({ allowOverUsage })
+            });
+            alert(t('settings.overUsageSaved'));
         }
         async function changePassword() {
             const newPwd = document.getElementById('newPassword').value;


### PR DESCRIPTION
## v1.0.7 - 添加允许超额使用设置

当账号余额用完后，允许开启超额使用设置继续使用。

### 改动内容

- **config/config.go**: 新增 `AllowOverUsage` 配置字段及对应的 Get/Update 函数
- **pool/account.go**: `GetNext()` 在超额使用开启时不再跳过额度用尽的账号
- **proxy/handler.go**: Settings API 支持读写 `allowOverUsage`；新增 `checkOverageError` 检测 402 超额错误并自动关闭设置
- **proxy/kiro.go**: 402 错误不再跨端点重试
- **web/index.html**: 设置页面新增「用量控制」卡片，支持中英文

### 行为逻辑

1. 用户在设置页面开启「允许超额使用」
2. 账号额度用尽后仍可继续处理请求
3. 当上游 API 返回 `402 Payment Required` 且包含 `OVERAGE` 关键字时，自动关闭超额设置并记录日志
4. 后续请求将恢复正常的额度检查逻辑

### 版本信息

- 版本号: v1.0.7
- 基于分支: main