### PR TITLE
Fix token refresh timing and concurrency

### DIFF
--- a/pool/account.go
+++ b/pool/account.go
@@ -10,15 +10,16 @@ import (
 )
 
 const overageFrequencyScale = 10
+const tokenRefreshSkewSeconds int64 = 30
 
 // AccountPool 账号池
 type AccountPool struct {
-	mu           sync.RWMutex
-	accounts     []config.Account
+	mu            sync.RWMutex
+	accounts      []config.Account
 	totalAccounts int
-	currentIndex uint64
-	cooldowns    map[string]time.Time // 账号冷却时间
-	errorCounts  map[string]int       // 连续错误计数
+	currentIndex  uint64
+	cooldowns     map[string]time.Time // 账号冷却时间
+	errorCounts   map[string]int       // 连续错误计数
 }
 
 var (
@@ -90,7 +91,7 @@ func (p *AccountPool) GetNext() *config.Account {
 		}
 
 		// 跳过即将过期的 Token
-		if acc.ExpiresAt > 0 && time.Now().Unix() > acc.ExpiresAt-300 {
+		if acc.ExpiresAt > 0 && time.Now().Unix() > acc.ExpiresAt-tokenRefreshSkewSeconds {
 			seen[acc.ID] = true
 			continue
 		}

--- a/pool/account_test.go
+++ b/pool/account_test.go
@@ -1,8 +1,9 @@
 package pool
 
 import (
-	"kiro-api-proxy/config"
+	"kiro-go/config"
 	"testing"
+	"time"
 )
 
 func TestOverageAccountsAreSkippedByDefault(t *testing.T) {
@@ -50,5 +51,24 @@ func TestOverageWeightIsLowerThanNormalWeight(t *testing.T) {
 
 	if overageWeight >= normalWeight {
 		t.Fatalf("expected overage weight %d to be lower than normal weight %d", overageWeight, normalWeight)
+	}
+}
+
+func TestGetNextKeepsFiveMinuteTokenAvailable(t *testing.T) {
+	p := &AccountPool{}
+	account := config.Account{
+		ID:          "acct-1",
+		AccessToken: "access-token",
+		ExpiresAt:   time.Now().Unix() + 300,
+	}
+
+	p.accounts = []config.Account{account}
+
+	got := p.GetNext()
+	if got == nil {
+		t.Fatalf("expected five-minute token to be available")
+	}
+	if got.ID != account.ID {
+		t.Fatalf("expected account %q, got %q", account.ID, got.ID)
 	}
 }

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -17,6 +17,8 @@ import (
 	"github.com/google/uuid"
 )
 
+const tokenRefreshSkewSeconds int64 = 30
+
 // Handler HTTP 处理器
 type Handler struct {
 	pool *pool.AccountPool
@@ -35,6 +37,7 @@ type Handler struct {
 	modelsCacheMu   sync.RWMutex
 	modelsCacheTime int64
 	promptCache     *promptCacheTracker
+	tokenRefreshMu  sync.Mutex
 }
 
 type thinkingStreamSource int
@@ -261,7 +264,7 @@ func (h *Handler) refreshAllAccounts() {
 		}
 
 		// 检查 token 是否需要刷新
-		if account.ExpiresAt > 0 && time.Now().Unix() > account.ExpiresAt-300 {
+		if account.ExpiresAt > 0 && time.Now().Unix() > account.ExpiresAt-tokenRefreshSkewSeconds {
 			newAccessToken, newRefreshToken, newExpiresAt, profileArn, err := auth.RefreshToken(account)
 			if err != nil {
 				logger.Warnf("[BackgroundRefresh] Token refresh failed for %s: %v", account.Email, err)
@@ -1823,8 +1826,22 @@ func (h *Handler) sendOpenAIError(w http.ResponseWriter, status int, errType, me
 
 // ensureValidToken 确保 token 有效
 func (h *Handler) ensureValidToken(account *config.Account) error {
-	if account.ExpiresAt == 0 || time.Now().Unix() < account.ExpiresAt-300 {
+	if account.ExpiresAt == 0 || time.Now().Unix() < account.ExpiresAt-tokenRefreshSkewSeconds {
 		return nil
+	}
+
+	h.tokenRefreshMu.Lock()
+	defer h.tokenRefreshMu.Unlock()
+
+	// Another concurrent request may have refreshed this account while we waited.
+	if latest := h.pool.GetByID(account.ID); latest != nil {
+		account.AccessToken = latest.AccessToken
+		account.RefreshToken = latest.RefreshToken
+		account.ExpiresAt = latest.ExpiresAt
+		account.ProfileArn = latest.ProfileArn
+		if account.ExpiresAt == 0 || time.Now().Unix() < account.ExpiresAt-tokenRefreshSkewSeconds {
+			return nil
+		}
 	}
 
 	accessToken, refreshToken, expiresAt, profileArn, err := auth.RefreshToken(account)
@@ -2656,7 +2673,7 @@ func (h *Handler) apiRefreshAccount(w http.ResponseWriter, r *http.Request, id s
 	}
 
 	// 检查 token 是否快过期，先刷新
-	if account.ExpiresAt > 0 && time.Now().Unix() > account.ExpiresAt-300 {
+	if account.ExpiresAt > 0 && time.Now().Unix() > account.ExpiresAt-tokenRefreshSkewSeconds {
 		if err := refreshTokenIfNeeded(); err != nil {
 			w.WriteHeader(500)
 			json.NewEncoder(w).Encode(map[string]string{"error": "Token refresh failed: " + err.Error()})


### PR DESCRIPTION
## Summary
- Reduce token refresh skew from 300s to 30s so 5-minute access tokens are not refreshed immediately.
- Serialize request-path token refreshes and re-check account state after waiting to avoid concurrent refresh token reuse.
- Add coverage that keeps 5-minute tokens available in the account pool.
- Fix the pool test import path to match the current module name.

## Testing
- go test ./...