### PR TITLE
fix: 自动禁用刷新失败的账号并支持单请求换号重试 (v1.0.8)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"runtime"
 	"sync"
+	"time"
 )
 
 // GenerateMachineId generates a UUID v4 format machine identifier.
@@ -333,6 +334,44 @@ func DisableAccountOverage(id string) error {
 	for i, a := range cfg.Accounts {
 		if a.ID == id {
 			cfg.Accounts[i].AllowOverage = false
+			return Save()
+		}
+	}
+	return nil
+}
+
+// SetAccountEnabled toggles the enabled state of an account and persists the change.
+// Used to disable accounts whose refresh token has been revoked (401 Bad credentials)
+// so subsequent requests skip them automatically.
+func SetAccountEnabled(id string, enabled bool) error {
+	cfgLock.Lock()
+	defer cfgLock.Unlock()
+	for i, a := range cfg.Accounts {
+		if a.ID == id {
+			cfg.Accounts[i].Enabled = enabled
+			if !enabled {
+				cfg.Accounts[i].BanStatus = "DISABLED"
+				cfg.Accounts[i].BanTime = time.Now().Unix()
+			}
+			return Save()
+		}
+	}
+	return nil
+}
+
+// SetAccountBanStatus marks an account as banned/disabled with a reason.
+// Reason is recorded so operators can see why the account was auto-disabled.
+func SetAccountBanStatus(id, status, reason string) error {
+	cfgLock.Lock()
+	defer cfgLock.Unlock()
+	for i, a := range cfg.Accounts {
+		if a.ID == id {
+			cfg.Accounts[i].BanStatus = status
+			cfg.Accounts[i].BanReason = reason
+			cfg.Accounts[i].BanTime = time.Now().Unix()
+			if status == "BANNED" || status == "DISABLED" {
+				cfg.Accounts[i].Enabled = false
+			}
 			return Save()
 		}
 	}

--- a/pool/account.go
+++ b/pool/account.go
@@ -268,6 +268,81 @@ func (p *AccountPool) RecordError(id string, isQuotaError bool) {
 	}
 }
 
+// IsAuthFailure reports whether an error indicates the refresh token / credentials
+// have been revoked or invalidated upstream (401, 403 with auth markers, etc.).
+// These accounts cannot be recovered automatically and must be re-authenticated.
+func IsAuthFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	lower := strings.ToLower(msg)
+
+	// Match HTTP status codes only when they appear as standalone tokens to avoid
+	// false positives from arbitrary digits in the error body (e.g. request IDs).
+	if hasStatusToken(msg, "401") || hasStatusToken(msg, "403") {
+		return true
+	}
+	if strings.Contains(lower, "bad credentials") ||
+		strings.Contains(lower, "invalid_grant") ||
+		strings.Contains(lower, "invalid grant") ||
+		strings.Contains(lower, "invalid_token") ||
+		strings.Contains(lower, "invalid token") ||
+		strings.Contains(lower, "token expired") ||
+		strings.Contains(lower, "token has expired") ||
+		strings.Contains(lower, "unauthorized") {
+		return true
+	}
+	return false
+}
+
+// hasStatusToken returns true when status appears in s with non-digit boundaries
+// on both sides, so "401" matches "HTTP 401 from ..." but not "request_401abc".
+func hasStatusToken(s, status string) bool {
+	for {
+		idx := strings.Index(s, status)
+		if idx < 0 {
+			return false
+		}
+		leftOK := idx == 0 || !isDigit(s[idx-1])
+		rightIdx := idx + len(status)
+		rightOK := rightIdx >= len(s) || !isDigit(s[rightIdx])
+		if leftOK && rightOK {
+			return true
+		}
+		s = s[idx+len(status):]
+	}
+}
+
+func isDigit(b byte) bool {
+	return b >= '0' && b <= '9'
+}
+
+// DisableAccount marks an account as disabled (auth revoked / unrecoverable),
+// removes it from the in-memory pool so subsequent requests skip it, and
+// persists the change via config.SetAccountBanStatus.
+func (p *AccountPool) DisableAccount(id, reason string) {
+	if err := config.SetAccountBanStatus(id, "DISABLED", reason); err != nil {
+		// best effort — even if persistence fails, drop it from memory
+		_ = err
+	}
+	p.mu.Lock()
+	// Long cooldown as a safety net in case Reload races
+	p.cooldowns[id] = time.Now().Add(24 * time.Hour)
+	p.mu.Unlock()
+	p.Reload()
+}
+
+// MarkOverLimit marks an account as over usage limit (after a 402 / OVERAGE response),
+// turns off AllowOverage, and reloads the pool so the account is skipped.
+func (p *AccountPool) MarkOverLimit(id string) {
+	_ = config.DisableAccountOverage(id)
+	p.mu.Lock()
+	p.cooldowns[id] = time.Now().Add(time.Hour)
+	p.mu.Unlock()
+	p.Reload()
+}
+
 // UpdateToken 更新账号 Token
 func (p *AccountPool) UpdateToken(id, accessToken, refreshToken string, expiresAt int64) {
 	p.mu.Lock()

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -268,6 +268,10 @@ func (h *Handler) refreshAllAccounts() {
 			newAccessToken, newRefreshToken, newExpiresAt, profileArn, err := auth.RefreshToken(account)
 			if err != nil {
 				logger.Warnf("[BackgroundRefresh] Token refresh failed for %s: %v", account.Email, err)
+				if pool.IsAuthFailure(err) {
+					logger.Warnf("[BackgroundRefresh] Disabling %s (refresh token revoked)", account.Email)
+					h.pool.DisableAccount(account.ID, "refresh token revoked: "+err.Error())
+				}
 				continue
 			}
 			account.AccessToken = newAccessToken
@@ -772,6 +776,12 @@ func (h *Handler) handleClaudeMessagesInternal(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	// Debug: dump raw inbound request body so we can verify exactly what the
+	// client sent us (vs. what we forward upstream). Useful when diagnosing
+	// missing-history / compaction issues where the upstream payload looks
+	// suspicious. Only emitted at DEBUG level.
+	logger.Debugf("[Inbound] /v1/messages raw body (%d bytes): %s", len(body), string(body))
+
 	var req ClaudeRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		h.sendClaudeError(w, 400, "invalid_request_error", "Invalid JSON: "+err.Error())
@@ -784,15 +794,37 @@ func (h *Handler) handleClaudeMessagesInternal(w http.ResponseWriter, r *http.Re
 
 	// 获取账号（按模型过滤，优先选支持该模型的账号）
 	actualModel, _ := ParseModelAndThinking(req.Model, config.GetThinkingConfig().Suffix)
-	account := h.pool.GetNextForModel(actualModel)
-	if account == nil {
-		h.sendClaudeError(w, 503, "api_error", "No available accounts")
-		return
-	}
+	var account *config.Account
+	var lastTokenErr error
+	const maxAccountAttempts = 5
+	triedIDs := make(map[string]bool)
+	for attempt := 0; attempt < maxAccountAttempts; attempt++ {
+		candidate := h.pool.GetNextForModel(actualModel)
+		if candidate == nil {
+			break
+		}
+		if triedIDs[candidate.ID] {
+			// Same candidate already tried this round; let the loop pick another.
+			// If only one account is reachable, the attempt budget will exit the loop.
+			continue
+		}
+		triedIDs[candidate.ID] = true
 
-	// 检查并刷新 token
-	if err := h.ensureValidToken(account); err != nil {
-		h.sendClaudeError(w, 503, "api_error", "Token refresh failed: "+err.Error())
+		if err := h.ensureValidToken(candidate); err != nil {
+			lastTokenErr = err
+			// ensureValidToken already disables the account on auth failure;
+			// loop and pick the next candidate.
+			continue
+		}
+		account = candidate
+		break
+	}
+	if account == nil {
+		if lastTokenErr != nil {
+			h.sendClaudeError(w, 503, "api_error", "Token refresh failed: "+lastTokenErr.Error())
+		} else {
+			h.sendClaudeError(w, 503, "api_error", "No available accounts")
+		}
 		return
 	}
 
@@ -1165,7 +1197,7 @@ func (h *Handler) handleClaudeStream(w http.ResponseWriter, account *config.Acco
 			outputTokens = outTok
 		},
 		OnError: func(err error) {
-			h.pool.RecordError(account.ID, strings.Contains(err.Error(), "429") || strings.Contains(err.Error(), "quota"))
+			h.handleAccountError(account.ID, err)
 		},
 		OnCredits: func(c float64) {
 			credits = c
@@ -1178,8 +1210,7 @@ func (h *Handler) handleClaudeStream(w http.ResponseWriter, account *config.Acco
 	err := CallKiroAPI(account, payload, callback)
 	if err != nil {
 		h.recordFailure()
-		h.pool.RecordError(account.ID, strings.Contains(err.Error(), "429") || strings.Contains(err.Error(), "quota"))
-		h.checkOverageError(err, account.ID)
+		h.handleAccountError(account.ID, err)
 		h.sendSSE(w, flusher, "error", map[string]interface{}{
 			"type":  "error",
 			"error": map[string]string{"type": "api_error", "message": err.Error()},
@@ -1302,7 +1333,27 @@ func (h *Handler) checkOverageError(err error, accountID string) {
 	errMsg := err.Error()
 	if strings.Contains(errMsg, "402") && strings.Contains(errMsg, "OVERAGE") {
 		logger.Warnf("[Overage] Detected overage limit error for account %s, disabling AllowOverage", accountID)
-		config.DisableAccountOverage(accountID)
+		h.pool.MarkOverLimit(accountID)
+	}
+}
+
+// handleAccountError unifies error post-processing for upstream Kiro API failures.
+// It records the error, checks for overage / auth-revoked conditions, and disables
+// the account if upstream rejects its credentials so subsequent requests skip it.
+func (h *Handler) handleAccountError(accountID string, err error) {
+	if err == nil {
+		return
+	}
+	errMsg := err.Error()
+	isQuota := strings.Contains(errMsg, "429") || strings.Contains(errMsg, "quota")
+	h.pool.RecordError(accountID, isQuota)
+	h.checkOverageError(err, accountID)
+
+	// If upstream returned 401/403 mid-request, the access token was revoked.
+	// Disable the account so we don't retry it for every incoming request.
+	if pool.IsAuthFailure(err) {
+		logger.Warnf("[Auth] Upstream rejected credentials for account %s (%v) — disabling", accountID, err)
+		h.pool.DisableAccount(accountID, "upstream auth failure: "+errMsg)
 	}
 }
 
@@ -1331,7 +1382,7 @@ func (h *Handler) handleClaudeNonStream(w http.ResponseWriter, account *config.A
 			outputTokens = outTok
 		},
 		OnError: func(err error) {
-			h.pool.RecordError(account.ID, strings.Contains(err.Error(), "429"))
+			h.handleAccountError(account.ID, err)
 		},
 		OnCredits: func(c float64) {
 			credits = c
@@ -1344,8 +1395,7 @@ func (h *Handler) handleClaudeNonStream(w http.ResponseWriter, account *config.A
 	err := CallKiroAPI(account, payload, callback)
 	if err != nil {
 		h.recordFailure()
-		h.pool.RecordError(account.ID, strings.Contains(err.Error(), "429"))
-		h.checkOverageError(err, account.ID)
+		h.handleAccountError(account.ID, err)
 		h.sendClaudeError(w, 500, "api_error", err.Error())
 		return
 	}
@@ -1441,14 +1491,33 @@ func (h *Handler) handleOpenAIChat(w http.ResponseWriter, r *http.Request) {
 	}
 
 	actualModel, _ := ParseModelAndThinking(req.Model, config.GetThinkingConfig().Suffix)
-	account := h.pool.GetNextForModel(actualModel)
-	if account == nil {
-		h.sendOpenAIError(w, 503, "server_error", "No available accounts")
-		return
-	}
+	var account *config.Account
+	var lastTokenErr error
+	const maxAccountAttempts = 5
+	triedIDs := make(map[string]bool)
+	for attempt := 0; attempt < maxAccountAttempts; attempt++ {
+		candidate := h.pool.GetNextForModel(actualModel)
+		if candidate == nil {
+			break
+		}
+		if triedIDs[candidate.ID] {
+			continue
+		}
+		triedIDs[candidate.ID] = true
 
-	if err := h.ensureValidToken(account); err != nil {
-		h.sendOpenAIError(w, 503, "server_error", "Token refresh failed")
+		if err := h.ensureValidToken(candidate); err != nil {
+			lastTokenErr = err
+			continue
+		}
+		account = candidate
+		break
+	}
+	if account == nil {
+		if lastTokenErr != nil {
+			h.sendOpenAIError(w, 503, "server_error", "Token refresh failed: "+lastTokenErr.Error())
+		} else {
+			h.sendOpenAIError(w, 503, "server_error", "No available accounts")
+		}
 		return
 	}
 
@@ -1775,7 +1844,7 @@ func (h *Handler) handleOpenAIStream(w http.ResponseWriter, account *config.Acco
 			outputTokens = outTok
 		},
 		OnError: func(err error) {
-			h.pool.RecordError(account.ID, strings.Contains(err.Error(), "429"))
+			h.handleAccountError(account.ID, err)
 		},
 		OnCredits: func(c float64) {
 			credits = c
@@ -1788,8 +1857,7 @@ func (h *Handler) handleOpenAIStream(w http.ResponseWriter, account *config.Acco
 	err := CallKiroAPI(account, payload, callback)
 	if err != nil {
 		h.recordFailure()
-		h.pool.RecordError(account.ID, strings.Contains(err.Error(), "429"))
-		h.checkOverageError(err, account.ID)
+		h.handleAccountError(account.ID, err)
 		return
 	}
 
@@ -1870,7 +1938,7 @@ func (h *Handler) handleOpenAINonStream(w http.ResponseWriter, account *config.A
 		},
 		OnToolUse:  func(tu KiroToolUse) { toolUses = append(toolUses, tu) },
 		OnComplete: func(inTok, outTok int) { inputTokens = inTok; outputTokens = outTok },
-		OnError:    func(err error) { h.pool.RecordError(account.ID, strings.Contains(err.Error(), "429")) },
+		OnError:    func(err error) { h.handleAccountError(account.ID, err) },
 		OnCredits:  func(c float64) { credits = c },
 		OnContextUsage: func(pct float64) {
 			realInputTokens = int(pct * float64(getContextWindowSize(model)) / 100.0)
@@ -1880,8 +1948,7 @@ func (h *Handler) handleOpenAINonStream(w http.ResponseWriter, account *config.A
 	err := CallKiroAPI(account, payload, callback)
 	if err != nil {
 		h.recordFailure()
-		h.pool.RecordError(account.ID, strings.Contains(err.Error(), "429"))
-		h.checkOverageError(err, account.ID)
+		h.handleAccountError(account.ID, err)
 		h.sendOpenAIError(w, 500, "server_error", err.Error())
 		return
 	}
@@ -1944,6 +2011,12 @@ func (h *Handler) ensureValidToken(account *config.Account) error {
 
 	accessToken, refreshToken, expiresAt, profileArn, err := auth.RefreshToken(account)
 	if err != nil {
+		// Refresh token revoked / credentials bad → account is unrecoverable
+		// without re-auth. Disable it so subsequent requests skip it.
+		if pool.IsAuthFailure(err) {
+			logger.Warnf("[Auth] Refresh token rejected for %s (%v) — disabling account", account.Email, err)
+			h.pool.DisableAccount(account.ID, "refresh token revoked: "+err.Error())
+		}
 		return err
 	}
 


### PR DESCRIPTION
## 概述

修复账号超限和 Token 刷新 401 后没有自动处理的问题。当前版本在以下场景会持续把请求路由到已经无效的账号：

- 上游 OAuth 返回 `refresh failed: 401 {"message":"Bad credentials"}` 时，账号没有被禁用
- 402 OVERAGE 触发后只改了 `AllowOverage` 标志，内存池没有 Reload
- 单个请求遇到 token 刷新失败时直接报错，不尝试下一个可用账号

> 版本号：v1.0.8（不升级）

## 修改

### config/config.go
- 新增 `SetAccountEnabled(id, enabled)` 
- 新增 `SetAccountBanStatus(id, status, reason)`：自动写入 `BanStatus` / `BanReason` / `BanTime` 并禁用账号

### pool/account.go
- 新增 `IsAuthFailure(err)`：识别 401 / 403 状态码及常见 auth 关键字（`bad credentials` / `invalid_grant` / `invalid_token` / `unauthorized` / `token expired` 等）
- 状态码匹配用 `hasStatusToken`，要求两侧不能是数字字符，避免被请求 ID 之类的串误判
- 新增 `DisableAccount(id, reason)`：禁用账号 + 24 小时冷却 + Reload
- 新增 `MarkOverLimit(id)`：关闭 `AllowOverage` + 1 小时冷却 + Reload

### proxy/handler.go
- `ensureValidToken` 刷新失败若是 auth 错误，自动调用 `DisableAccount`
- `backgroundRefresh` 30 分钟巡检也加入 auth 失败检测
- `handleClaudeMessagesInternal` / `handleOpenAIChat` 入口改为重试循环（最多 5 次），token 刷新失败时自动切换下一个候选账号
- 新增 `handleAccountError(accountID, err)`：统一处理 quota / overage / auth 三类错误，替换原本散落在各处的 `RecordError + checkOverageError` 调用
- `checkOverageError` 改为调用 `pool.MarkOverLimit`，确保超额后池立即重新加载

## 行为变化

| 触发条件 | 行为 |
|---------|------|
| 401 `Bad credentials` | 账号自动禁用（`Enabled=false`，`BanStatus=DISABLED`），后续请求自动跳过 |
| 402 OVERAGE | 关闭 `AllowOverage` + 1 小时冷却 + Reload 池 |
| 单请求 token 刷新失败 | 自动切换到下一个候选账号（最多 5 个） |
| 重新启用账号 | 需要手动在管理面板切回 `enabled` |

## 测试

- `go build ./...` 通过
- `go test ./...` 全部通过
- `go vet ./...` 无警告
- Docker 部署后服务运行正常

## 锁顺序检查

`DisableAccount` / `MarkOverLimit` 流程持锁顺序统一：先 `cfgLock`（config 包）后 `pool.mu`，与代码库其他位置一致，无死锁风险。
