### PR TITLE
fix: sanitize tool schemas for Kiro

### DIFF
--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -711,69 +711,91 @@ func convertClaudeTools(tools []ClaudeTool) ([]KiroToolWrapper, map[string]strin
 		}
 		w := KiroToolWrapper{}
 		w.ToolSpecification.Name = sanitized
-		w.ToolSpecification.Description = desc
+		w.ToolSpecification.Description = normalizeToolDesc(desc, sanitized)
 		w.ToolSpecification.InputSchema = InputSchema{JSON: ensureObjectSchema(tool.InputSchema)}
 		result = append(result, w)
 	}
 	return result, nameMap
 }
 
-// ensureObjectSchema ensures the JSON schema has "type": "object" at the top level
-// and removes invalid null values from "required" fields (recursively).
-// Kiro API rejects tool schemas with "required": null.
+// ensureObjectSchema 确保工具 schema 顶层是 object，并清理 Kiro 不接受的字段。
 func ensureObjectSchema(schema interface{}) interface{} {
 	m, ok := schema.(map[string]interface{})
 	if !ok {
 		return map[string]interface{}{"type": "object"}
 	}
-	cleanSchema(m)
-	if _, hasType := m["type"]; !hasType {
-		m["type"] = "object"
+	cleaned := cloneSchemaMap(m)
+	cleanSchema(cleaned)
+	if _, hasType := cleaned["type"]; !hasType {
+		cleaned["type"] = "object"
 	}
-	return m
+	return cleaned
 }
 
-// cleanSchema recursively removes or fixes invalid "required": null entries
-// in a JSON Schema tree.
+func cloneSchemaMap(m map[string]interface{}) map[string]interface{} {
+	cloned := make(map[string]interface{}, len(m))
+	for k, v := range m {
+		cloned[k] = cloneSchemaValue(v)
+	}
+	return cloned
+}
+
+func cloneSchemaValue(v interface{}) interface{} {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		return cloneSchemaMap(val)
+	case []interface{}:
+		cloned := make([]interface{}, 0, len(val))
+		for _, item := range val {
+			cloned = append(cloned, cloneSchemaValue(item))
+		}
+		return cloned
+	default:
+		return v
+	}
+}
+
+// cleanSchema 递归清理会导致 Kiro 400 的 schema 字段。
 func cleanSchema(m map[string]interface{}) {
-	// Fix "required" field: must be array or absent
+	delete(m, "additionalProperties")
+
+	// required 必须是非空数组，否则 Kiro 会报 Improperly formed request。
 	if req, exists := m["required"]; exists {
-		if req == nil {
+		switch arr := req.(type) {
+		case nil:
 			delete(m, "required")
-		} else if arr, ok := req.([]interface{}); ok && len(arr) == 0 {
-			delete(m, "required")
-		}
-	}
-
-	// Recurse into "properties"
-	if props, ok := m["properties"].(map[string]interface{}); ok {
-		for _, v := range props {
-			if sub, ok := v.(map[string]interface{}); ok {
-				cleanSchema(sub)
+		case []interface{}:
+			if len(arr) == 0 {
+				delete(m, "required")
 			}
+		case []string:
+			if len(arr) == 0 {
+				delete(m, "required")
+			}
+		default:
+			delete(m, "required")
 		}
 	}
 
-	// Recurse into "items"
-	if items, ok := m["items"].(map[string]interface{}); ok {
-		cleanSchema(items)
-	}
-
-	// Recurse into nested object schemas (e.g., additionalProperties, allOf, oneOf, anyOf)
-	for _, key := range []string{"additionalProperties"} {
-		if sub, ok := m[key].(map[string]interface{}); ok {
-			cleanSchema(sub)
-		}
-	}
-	for _, key := range []string{"allOf", "oneOf", "anyOf"} {
-		if arr, ok := m[key].([]interface{}); ok {
-			for _, item := range arr {
+	for _, v := range m {
+		switch val := v.(type) {
+		case map[string]interface{}:
+			cleanSchema(val)
+		case []interface{}:
+			for _, item := range val {
 				if sub, ok := item.(map[string]interface{}); ok {
 					cleanSchema(sub)
 				}
 			}
 		}
 	}
+}
+
+func normalizeToolDesc(desc, name string) string {
+	if strings.TrimSpace(desc) != "" {
+		return desc
+	}
+	return "Tool: " + name
 }
 
 // sanitizeToolName normalizes a tool name to characters the Kiro API accepts.
@@ -1442,8 +1464,8 @@ func convertOpenAITools(tools []OpenAITool) []KiroToolWrapper {
 		}
 		wrapper := KiroToolWrapper{}
 		wrapper.ToolSpecification.Name = shortenToolName(tool.Function.Name)
-		wrapper.ToolSpecification.Description = desc
-		wrapper.ToolSpecification.InputSchema = InputSchema{JSON: tool.Function.Parameters}
+		wrapper.ToolSpecification.Description = normalizeToolDesc(desc, wrapper.ToolSpecification.Name)
+		wrapper.ToolSpecification.InputSchema = InputSchema{JSON: ensureObjectSchema(tool.Function.Parameters)}
 		result = append(result, wrapper)
 	}
 	return result

--- a/proxy/translator_test.go
+++ b/proxy/translator_test.go
@@ -277,3 +277,90 @@ func TestToolResultsContinuationIncludesInstructionPrefix(t *testing.T) {
 		t.Fatalf("expected tool result text in continuation content, got %q", content)
 	}
 }
+
+func TestEnsureObjectSchemaRemovesKiroRejectedFieldsRecursively(t *testing.T) {
+	input := map[string]interface{}{
+		"type":                 "object",
+		"required":             []interface{}{},
+		"additionalProperties": false,
+		"properties": map[string]interface{}{
+			"path": map[string]interface{}{
+				"type":                 "string",
+				"required":             nil,
+				"additionalProperties": map[string]interface{}{"type": "string"},
+			},
+			"options": map[string]interface{}{
+				"type":                 "object",
+				"additionalProperties": false,
+				"properties": map[string]interface{}{
+					"force": map[string]interface{}{"type": "boolean"},
+				},
+			},
+		},
+		"anyOf": []interface{}{
+			map[string]interface{}{
+				"type":                 "object",
+				"required":             []interface{}{},
+				"additionalProperties": false,
+			},
+		},
+	}
+
+	got := ensureObjectSchema(input).(map[string]interface{})
+	if schemaContainsKey(got, "additionalProperties") {
+		t.Fatalf("expected additionalProperties to be removed recursively, got %#v", got)
+	}
+	if schemaContainsKey(got, "required") {
+		t.Fatalf("expected empty/nil required fields to be removed recursively, got %#v", got)
+	}
+	if _, stillPresent := input["additionalProperties"]; !stillPresent {
+		t.Fatalf("expected sanitizer not to mutate caller schema")
+	}
+}
+
+func TestConvertOpenAIToolsSanitizesSchemaAndDescription(t *testing.T) {
+	var tool OpenAITool
+	tool.Type = "function"
+	tool.Function.Name = "read_file"
+	tool.Function.Parameters = map[string]interface{}{
+		"type":                 "object",
+		"required":             []string{},
+		"additionalProperties": false,
+	}
+
+	tools := convertOpenAITools([]OpenAITool{tool})
+	if len(tools) != 1 {
+		t.Fatalf("expected one converted tool, got %d", len(tools))
+	}
+	if strings.TrimSpace(tools[0].ToolSpecification.Description) == "" {
+		t.Fatalf("expected fallback tool description")
+	}
+	schema := tools[0].ToolSpecification.InputSchema.JSON.(map[string]interface{})
+	if schemaContainsKey(schema, "additionalProperties") {
+		t.Fatalf("expected OpenAI tool schema to be sanitized, got %#v", schema)
+	}
+	if schemaContainsKey(schema, "required") {
+		t.Fatalf("expected empty required field to be removed, got %#v", schema)
+	}
+}
+
+func schemaContainsKey(value interface{}, key string) bool {
+	switch v := value.(type) {
+	case map[string]interface{}:
+		if _, ok := v[key]; ok {
+			return true
+		}
+		for _, child := range v {
+			if schemaContainsKey(child, key) {
+				return true
+			}
+		}
+	case []interface{}:
+		for _, child := range v {
+			if schemaContainsKey(child, key) {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

This PR improves tool conversion compatibility with the Kiro API by sanitizing tool input schemas and ensuring every converted tool has a non-empty description.

## Changes

- Sanitize tool schemas before sending them to Kiro.
- Remove `additionalProperties` recursively because Kiro rejects these fields in tool schemas.
- Remove invalid or empty `required` values, including `nil`, empty arrays, and unsupported types.
- Ensure schema sanitization does not mutate the original caller-provided schema.
- Apply schema normalization to both Claude and OpenAI tool conversion paths.
- Add fallback tool descriptions when upstream tool descriptions are empty.
- Add tests covering recursive schema cleanup, OpenAI tool conversion, fallback descriptions, and non-mutating behavior.

## Testing

- Ran `go test ./...`
- Ran `git diff --check`

## Notes

These changes reduce `Improperly formed request` errors from Kiro when tools include schema fields that are accepted by other providers but rejected by Kiro.