### PR TITLE
feat(web): support line-format credentials import

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1703,7 +1703,7 @@
       '<p class="help-block">' + escapeHtml(t('modal.credentialsDesc')) + '</p>' +
       '<p class="help-block">' + escapeHtml(t('credentials.batchHint')) + '</p>' +
       '<div class="form-group"><label>' + escapeHtml(t('credentials.label')) + '</label>' +
-      '<textarea id="credJson" class="font-mono" placeholder=\'[{"refreshToken":"xxx","provider":"BuilderID"}]\'></textarea>' +
+      '<textarea id="credJson" class="font-mono" placeholder=\'[{"refreshToken":"xxx","provider":"BuilderID"}]&#10;or&#10;email----password----refreshToken----clientId----clientSecret\'></textarea>' +
       '</div>' +
       '<div class="modal-footer">' +
       '<button class="btn btn-secondary" data-modal-goto="add" type="button">' + escapeHtml(t('common.back')) + '</button>' +
@@ -1781,9 +1781,11 @@
     } else toastError(t('common.failed') + ': ' + (d.error || ''));
   }
   async function importCredentials() {
+    const raw = $('credJson').value.trim();
+    if (!raw) { toastWarning(t('credentials.jsonError')); return; }
+    let items;
     try {
-      const json = JSON.parse($('credJson').value.trim());
-      let items;
+      const json = JSON.parse(raw);
       if (json.accounts && Array.isArray(json.accounts)) {
         items = json.accounts.map(a => {
           const c = a.credentials || {};
@@ -1799,39 +1801,67 @@
       } else {
         items = Array.isArray(json) ? json : [json];
       }
-      let ok = 0, fail = 0, newIds = [];
-      for (const item of items) {
-        if (!item.refreshToken) { fail++; continue; }
-        let authMethod = item.authMethod || '';
-        if (item.clientId && item.clientSecret) authMethod = 'idc';
-        else if (!authMethod || authMethod === 'social') authMethod = 'social';
-        else authMethod = authMethod.toLowerCase() === 'idc' ? 'idc' : 'social';
-        let provider = item.provider || '';
-        if (!provider && authMethod === 'social') provider = 'Google';
-        if (!provider && authMethod === 'idc') provider = 'BuilderId';
-        const payload = {
-          refreshToken: item.refreshToken,
-          accessToken: item.accessToken || '',
-          clientId: item.clientId || '',
-          clientSecret: item.clientSecret || '',
-          authMethod, provider,
-          region: item.region || 'us-east-1'
-        };
-        try {
-          const res = await api('/auth/credentials', { method: 'POST', body: JSON.stringify(payload) });
-          const d = await res.json();
-          if (d.success) { ok++; if (d.account?.id) newIds.push(d.account.id); }
-          else fail++;
-        } catch { fail++; }
+    } catch {
+      items = parseLineCredentials(raw);
+      if (items.length === 0) {
+        toastWarning(t('credentials.jsonError'));
+        return;
       }
-      closeModal(); loadAccounts(); loadStats();
-      let msg = t('sso.importSuccess', ok);
-      if (fail > 0) msg += t('sso.importPartial', fail);
-      toastPrimary(msg, { duration: 5200 });
-      newIds.forEach(autoRefreshNewAccount);
-    } catch (e) {
-      toastWarning(t('credentials.jsonError'));
     }
+    let ok = 0, fail = 0, newIds = [];
+    for (const item of items) {
+      if (!item.refreshToken) { fail++; continue; }
+      let authMethod = item.authMethod || '';
+      if (item.clientId && item.clientSecret) authMethod = 'idc';
+      else if (!authMethod || authMethod === 'social') authMethod = 'social';
+      else authMethod = authMethod.toLowerCase() === 'idc' ? 'idc' : 'social';
+      let provider = item.provider || '';
+      if (!provider && authMethod === 'social') provider = 'Google';
+      if (!provider && authMethod === 'idc') provider = 'BuilderId';
+      const payload = {
+        refreshToken: item.refreshToken,
+        accessToken: item.accessToken || '',
+        clientId: item.clientId || '',
+        clientSecret: item.clientSecret || '',
+        authMethod, provider,
+        region: item.region || 'us-east-1'
+      };
+      try {
+        const res = await api('/auth/credentials', { method: 'POST', body: JSON.stringify(payload) });
+        const d = await res.json();
+        if (d.success) { ok++; if (d.account?.id) newIds.push(d.account.id); }
+        else fail++;
+      } catch { fail++; }
+    }
+    closeModal(); loadAccounts(); loadStats();
+    let msg = t('sso.importSuccess', ok);
+    if (fail > 0) msg += t('sso.importPartial', fail);
+    toastPrimary(msg, { duration: 5200 });
+    newIds.forEach(autoRefreshNewAccount);
+  }
+  function parseLineCredentials(text) {
+    const items = [];
+    for (const line of text.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let parts;
+      if (trimmed.includes('----')) {
+        parts = trimmed.split('----').map(s => s.trim());
+      } else if (trimmed.includes('\t')) {
+        parts = trimmed.split(/\t+/).map(s => s.trim());
+      } else {
+        parts = trimmed.split(/\s+/).map(s => s.trim());
+      }
+      if (parts.length < 5) continue;
+      const refreshToken = parts[2];
+      if (!refreshToken) continue;
+      items.push({
+        refreshToken,
+        clientId: parts[3],
+        clientSecret: parts[4],
+      });
+    }
+    return items;
   }
   async function importFromCookie() {
     const refreshToken = $('cookieRefreshToken').value.trim();

--- a/web/app.js
+++ b/web/app.js
@@ -1784,6 +1784,7 @@
     const raw = $('credJson').value.trim();
     if (!raw) { toastWarning(t('credentials.jsonError')); return; }
     let items;
+    let skipped = 0;
     try {
       const json = JSON.parse(raw);
       if (json.accounts && Array.isArray(json.accounts)) {
@@ -1802,9 +1803,15 @@
         items = Array.isArray(json) ? json : [json];
       }
     } catch {
-      items = parseLineCredentials(raw);
-      if (items.length === 0) {
+      const parsed = parseLineCredentials(raw);
+      items = parsed.items;
+      skipped = parsed.skipped;
+      if (items.length === 0 && skipped === 0) {
         toastWarning(t('credentials.jsonError'));
+        return;
+      }
+      if (items.length === 0) {
+        toastWarning(t('credentials.lineParseAllSkipped', skipped));
         return;
       }
     }
@@ -1836,11 +1843,13 @@
     closeModal(); loadAccounts(); loadStats();
     let msg = t('sso.importSuccess', ok);
     if (fail > 0) msg += t('sso.importPartial', fail);
+    if (skipped > 0) msg += t('credentials.lineParseSkipped', skipped);
     toastPrimary(msg, { duration: 5200 });
     newIds.forEach(autoRefreshNewAccount);
   }
   function parseLineCredentials(text) {
     const items = [];
+    let skipped = 0;
     for (const line of text.split(/\r?\n/)) {
       const trimmed = line.trim();
       if (!trimmed) continue;
@@ -1852,16 +1861,16 @@
       } else {
         parts = trimmed.split(/\s+/).map(s => s.trim());
       }
-      if (parts.length < 5) continue;
+      if (parts.length < 5) { skipped++; continue; }
       const refreshToken = parts[2];
-      if (!refreshToken) continue;
+      if (!refreshToken) { skipped++; continue; }
       items.push({
         refreshToken,
         clientId: parts[3],
         clientSecret: parts[4],
       });
     }
-    return items;
+    return { items, skipped };
   }
   async function importFromCookie() {
     const refreshToken = $('cookieRefreshToken').value.trim();

--- a/web/locales/en.json
+++ b/web/locales/en.json
@@ -250,6 +250,8 @@
   "credentials.social": "Social (AWS Builder ID / Google / GitHub)",
   "credentials.idc": "IAM Identity Center (Enterprise SSO)",
   "credentials.jsonError": "Invalid JSON format",
+  "credentials.lineParseSkipped": ", skipped {0} malformed line(s)",
+  "credentials.lineParseAllSkipped": "{0} line(s) were malformed; no accounts could be parsed (each line needs 5 fields: email----password----refreshToken----clientId----clientSecret)",
   "credentials.batchHint": "Supports JSON (single object, array, or Kiro Account Manager export), or line format: email----password----refreshToken----clientId----clientSecret, one account per line, delimiter auto-detected (----, Tab, space). Required: refreshToken. Optional: provider (BuilderID/Enterprise/GitHub/Google), clientId, clientSecret",
   "common.save": "Save Settings",
   "common.saved": "Saved",

--- a/web/locales/en.json
+++ b/web/locales/en.json
@@ -250,7 +250,7 @@
   "credentials.social": "Social (AWS Builder ID / Google / GitHub)",
   "credentials.idc": "IAM Identity Center (Enterprise SSO)",
   "credentials.jsonError": "Invalid JSON format",
-  "credentials.batchHint": "Supports single object, JSON array, or Kiro Account Manager export format. Required: refreshToken. Optional: provider (BuilderID/Enterprise/GitHub/Google), clientId, clientSecret",
+  "credentials.batchHint": "Supports JSON (single object, array, or Kiro Account Manager export), or line format: email----password----refreshToken----clientId----clientSecret, one account per line, delimiter auto-detected (----, Tab, space). Required: refreshToken. Optional: provider (BuilderID/Enterprise/GitHub/Google), clientId, clientSecret",
   "common.save": "Save Settings",
   "common.saved": "Saved",
   "common.copy": "Copy",

--- a/web/locales/zh.json
+++ b/web/locales/zh.json
@@ -250,7 +250,7 @@
   "credentials.social": "Social (AWS Builder ID / Google / GitHub)",
   "credentials.idc": "IAM Identity Center (企业 SSO)",
   "credentials.jsonError": "JSON 格式错误",
-  "credentials.batchHint": "支持单个对象、JSON 数组或 Kiro Account Manager 导出格式批量导入。必填: refreshToken。可选: provider (BuilderID/Enterprise/GitHub/Google), clientId, clientSecret",
+  "credentials.batchHint": "支持 JSON（单个对象、数组或 Kiro Account Manager 导出格式），也可使用行格式：邮箱----密码----RefreshToken----ClientId----ClientSecret，每行一个账号，分隔符自动识别（----、Tab、空格）。必填: refreshToken。可选: provider (BuilderID/Enterprise/GitHub/Google), clientId, clientSecret",
   "common.save": "保存设置",
   "common.saved": "保存",
   "common.copy": "复制",

--- a/web/locales/zh.json
+++ b/web/locales/zh.json
@@ -250,6 +250,8 @@
   "credentials.social": "Social (AWS Builder ID / Google / GitHub)",
   "credentials.idc": "IAM Identity Center (企业 SSO)",
   "credentials.jsonError": "JSON 格式错误",
+  "credentials.lineParseSkipped": "，跳过 {0} 行格式不完整",
+  "credentials.lineParseAllSkipped": "{0} 行格式不完整，未能解析任何账号（每行需包含 5 个字段：邮箱----密码----RefreshToken----ClientId----ClientSecret）",
   "credentials.batchHint": "支持 JSON（单个对象、数组或 Kiro Account Manager 导出格式），也可使用行格式：邮箱----密码----RefreshToken----ClientId----ClientSecret，每行一个账号，分隔符自动识别（----、Tab、空格）。必填: refreshToken。可选: provider (BuilderID/Enterprise/GitHub/Google), clientId, clientSecret",
   "common.save": "保存设置",
   "common.saved": "保存",


### PR DESCRIPTION
## Summary

Adds a fallback path in the credentials import textarea: when the input fails JSON parsing, parse it line-by-line as `email----password----refreshToken----clientId----clientSecret` rows.

- `feat(web): support line-format credentials import` (fa438ef)
  - Delimiter auto-detected (`----` > tab > whitespace)
  - Email and password are discarded (the backend derives identity from the refresh token)
  - Existing JSON import path is unchanged
- `fix(web): surface skipped lines in line-format credentials import` (98336c6)
  - `parseLineCredentials()` previously dropped malformed rows silently — users saw "imported N" with no hint that some lines were bad
  - Returns `{items, skipped}`; toast appends "skipped N malformed line(s)" when `skipped > 0`
  - When all lines are malformed, surface a dedicated message explaining the expected 5-field shape

## 中文摘要

- 凭证导入新增行格式降级：JSON 解析失败时按行解析 `邮箱----密码----RefreshToken----ClientId----ClientSecret`
- 分隔符自动识别（`----` > Tab > 空格），邮箱/密码读后丢弃
- 之前 malformed 行静默跳过，用户看不到，现在 toast 末尾追加 "跳过 N 行格式不完整"
- 全部 malformed 时给一条单独提示，说明每行需要 5 个字段
- 不影响原有 JSON 导入

## Test plan

- [x] 手测 JSON 导入路径完全不变
- [x] 手测纯行格式 / 混合 / 全 malformed 三种 case 的提示