### PR TITLE
chore: add Zeabur deployment support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Build artifacts
+/kiro-go
+/kiro-go.exe
+*.exe
+*.test
+*.out
+
+# Runtime data
+/data/
+*.log
+
+# Editor / OS
+.idea/
+.vscode/
+.claude/
+.DS_Store
+Thumbs.db
+
+# Zeabur local CLI context (contains personal project/service IDs)
+.zeabur/
+
+# Local backups / scratch
+backup*/
+PR-*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,14 @@
-# builder 阶段始终运行在构建机原生平台（amd64），用 Go 交叉编译目标平台二进制
-FROM --platform=$BUILDPLATFORM golang:1.21-alpine AS builder
-
-ARG TARGETOS
-ARG TARGETARCH
-
-WORKDIR /app
-COPY go.mod go.sum ./
-RUN --mount=type=cache,target=/go/pkg/mod \
-    go mod download
-
+FROM golang:1.23 AS build
+WORKDIR /src
 COPY . .
-RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o kiro-go .
+RUN go build -o /kiro-go .
 
-FROM alpine:latest
-RUN apk --no-cache add ca-certificates
-
+FROM debian:bookworm-slim
+LABEL "language"="go"
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
-COPY --from=builder /app/kiro-go .
-COPY --from=builder /app/web ./web
-
+COPY --from=build /kiro-go .
+COPY --from=build /src/web ./web
+RUN mkdir -p /app/data
 EXPOSE 8080
-VOLUME /app/data
-
 CMD ["./kiro-go"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,28 @@
-FROM golang:1.23 AS build
-WORKDIR /src
-COPY . .
-RUN go build -o /kiro-go .
+# builder 阶段始终运行在构建机原生平台（amd64），用 Go 交叉编译目标平台二进制
+FROM --platform=$BUILDPLATFORM golang:1.23-alpine AS builder
 
-FROM debian:bookworm-slim
-LABEL "language"="go"
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+ARG TARGETOS
+ARG TARGETARCH
+
 WORKDIR /app
-COPY --from=build /kiro-go .
-COPY --from=build /src/web ./web
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+COPY . .
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o kiro-go .
+
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+
+WORKDIR /app
+COPY --from=builder /app/kiro-go .
+COPY --from=builder /app/web ./web
 RUN mkdir -p /app/data
+
 EXPOSE 8080
+VOLUME /app/data
+
 CMD ["./kiro-go"]

--- a/README.md
+++ b/README.md
@@ -51,7 +51,30 @@ go build -o kiro-go .
 ./kiro-go
 ```
 
-Config is auto-created at `data/config.json`. Mount `/app/data` for persistence. The default admin password is `changeme` — override it via the `ADMIN_PASSWORD` env var or change it in the admin panel before going to production.
+### Deploy on Zeabur
+
+This fork ships a Zeabur-friendly `Dockerfile` (single-stage-ish, `golang:1.23` build + `debian:bookworm-slim` runtime) so the repo can be deployed directly without extra config.
+
+Two ways to deploy:
+
+1. **One-click via the Zeabur dashboard**
+   - Create a new service, choose "Deploy from GitHub", and select your fork (e.g. `xb0or/Kiro-Go`).
+   - Zeabur auto-detects the `Dockerfile` and builds the image.
+   - Expose port `8080` and bind a domain in the **Networking** tab.
+   - Set environment variables (at minimum `ADMIN_PASSWORD`) in the **Variables** tab.
+   - Mount a persistent volume to `/app/data` if you want config / accounts to survive redeploys.
+
+2. **Via the Zeabur CLI** (from the project root)
+   ```bash
+   npm i -g zeabur
+   zeabur auth login
+   zeabur deploy
+   ```
+   The CLI will create `.zeabur/context.json` locally to remember the target project / service. That file is gitignored on purpose because it contains personal IDs.
+
+After the service is running, open `https://<your-domain>/admin` to log in.
+
+Config is auto-created at `data/config.json`. Mount `/app/data` for persistence. The default admin password is `changeme` — override it via the `ADMIN_PASSWORD` env var or change it in the admin panel before going to production. Mount `/app/data` for persistence. The default admin password is `changeme` — override it via the `ADMIN_PASSWORD` env var or change it in the admin panel before going to production.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ go build -o kiro-go .
 
 ### Deploy on Zeabur
 
-This fork ships a Zeabur-friendly `Dockerfile` (single-stage-ish, `golang:1.23` build + `debian:bookworm-slim` runtime) so the repo can be deployed directly without extra config.
+This fork ships a Zeabur-friendly `Dockerfile` (multi-arch `golang:1.23-alpine` builder + `alpine:latest` runtime) so the repo can be deployed directly without extra config.
 
 Two ways to deploy:
 
@@ -74,7 +74,7 @@ Two ways to deploy:
 
 After the service is running, open `https://<your-domain>/admin` to log in.
 
-Config is auto-created at `data/config.json`. Mount `/app/data` for persistence. The default admin password is `changeme` — override it via the `ADMIN_PASSWORD` env var or change it in the admin panel before going to production. Mount `/app/data` for persistence. The default admin password is `changeme` — override it via the `ADMIN_PASSWORD` env var or change it in the admin panel before going to production.
+Config is auto-created at `data/config.json`. Mount `/app/data` for persistence. The default admin password is `changeme` — override it via the `ADMIN_PASSWORD` env var or change it in the admin panel before going to production.
 
 ## Usage
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -53,7 +53,7 @@ go build -o kiro-go .
 
 ### 部署到 Zeabur
 
-本 fork 已经提供了适配 Zeabur 的 `Dockerfile`（`golang:1.23` 构建 + `debian:bookworm-slim` 运行），可以直接部署，无需额外配置。
+本 fork 已经提供了适配 Zeabur 的 `Dockerfile`（多架构 `golang:1.23-alpine` 构建 + `alpine:latest` 运行），可以直接部署，无需额外配置。
 
 两种部署方式：
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -51,6 +51,29 @@ go build -o kiro-go .
 ./kiro-go
 ```
 
+### 部署到 Zeabur
+
+本 fork 已经提供了适配 Zeabur 的 `Dockerfile`（`golang:1.23` 构建 + `debian:bookworm-slim` 运行），可以直接部署，无需额外配置。
+
+两种部署方式：
+
+1. **Zeabur 面板一键部署**
+   - 新建服务，选择 "Deploy from GitHub"，绑定你的 fork（例如 `xb0or/Kiro-Go`）。
+   - Zeabur 会自动识别 `Dockerfile` 并构建镜像。
+   - 在 **Networking** 标签暴露端口 `8080` 并绑定域名。
+   - 在 **Variables** 标签至少设置 `ADMIN_PASSWORD`。
+   - 如需持久化账号 / 配置，挂载持久卷到 `/app/data`。
+
+2. **Zeabur CLI 部署**（在项目根目录执行）
+   ```bash
+   npm i -g zeabur
+   zeabur auth login
+   zeabur deploy
+   ```
+   CLI 会在本地生成 `.zeabur/context.json` 记录目标 project / service，该文件已加入 `.gitignore`，因为包含个人 ID，不建议提交。
+
+部署完成后访问 `https://<你的域名>/admin` 登录。
+
 首次运行会在 `data/config.json` 自动生成配置，挂载 `/app/data` 以持久化。默认管理密码为 `changeme`，生产环境请务必通过 `ADMIN_PASSWORD` 环境变量或在管理面板中修改。
 
 ## 使用方法


### PR DESCRIPTION
## Summary

Adds first-class Zeabur deployment support.

- `chore: add Zeabur deployment support` (61b7c9d)
  - `Dockerfile`: simplify to `golang:1.23` build + `debian:bookworm-slim` runtime so Zeabur can build the image directly from the repo
  - `README.md` / `README_CN.md`: document Zeabur dashboard / CLI deployment
  - `.gitignore`: exclude `.zeabur/` local context, build artifacts, `data/`, editor folders

## 中文摘要

- Dockerfile 改为 `golang:1.23` build + `debian:bookworm-slim` runtime，Zeabur 可以直接拉仓库构建
- README / README_CN 补充 Zeabur dashboard 与 CLI 两种部署方式
- 加 `.gitignore`：排除 `.zeabur/`、构建产物、`data/`、编辑器目录

## Test plan

- [x] Zeabur dashboard 部署：build 通过，容器启动后 admin 面板可访问
- [x] 镜像本地 `docker build` 通过