### PR TITLE
fix: 兼容 /v1/responses 扁平工具结构避免上游 Improperly formed request

### DIFF
--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -947,6 +947,61 @@ type OpenAITool struct {
 	} `json:"function"`
 }
 
+// UnmarshalJSON 兼容两种工具格式：
+//   - Chat Completions（嵌套）：{"type":"function","function":{"name","description","parameters"}}
+//   - Responses API（扁平）：    {"type":"function","name","description","parameters"}
+//
+// codex-tui 等 Responses API 客户端发送扁平结构，若仅按嵌套结构解析会导致
+// name/description/parameters 全部为空，进而被上游判定为 Improperly formed request。
+func (t *OpenAITool) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Type        string          `json:"type"`
+		Name        string          `json:"name"`
+		Description string          `json:"description"`
+		Parameters  json.RawMessage `json:"parameters"`
+		Function    *struct {
+			Name        string          `json:"name"`
+			Description string          `json:"description"`
+			Parameters  json.RawMessage `json:"parameters"`
+		} `json:"function"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	t.Type = raw.Type
+
+	// 优先使用嵌套 function 字段（Chat Completions），缺失时回退到扁平字段（Responses API）。
+	name, desc, params := raw.Name, raw.Description, raw.Parameters
+	if raw.Function != nil {
+		if raw.Function.Name != "" {
+			name = raw.Function.Name
+		}
+		if raw.Function.Description != "" {
+			desc = raw.Function.Description
+		}
+		if len(raw.Function.Parameters) > 0 {
+			params = raw.Function.Parameters
+		}
+	}
+
+	// 扁平结构常省略 type，但带有 name 时即为 function 工具，补齐以免被跳过。
+	if t.Type == "" && name != "" {
+		t.Type = "function"
+	}
+
+	t.Function.Name = name
+	t.Function.Description = desc
+	if len(params) > 0 {
+		var parsed interface{}
+		if err := json.Unmarshal(params, &parsed); err != nil {
+			return err
+		}
+		t.Function.Parameters = parsed
+	}
+	return nil
+}
+
 type OpenAIResponse struct {
 	ID      string         `json:"id"`
 	Object  string         `json:"object"`
@@ -1482,7 +1537,12 @@ func convertOpenAITools(tools []OpenAITool) []KiroToolWrapper {
 
 	result := make([]KiroToolWrapper, 0, len(tools))
 	for _, tool := range tools {
-		if tool.Type != "function" {
+		// 接受函数工具：显式 type=function，或扁平结构（无 type 但带 name）。
+		if tool.Type != "" && tool.Type != "function" {
+			continue
+		}
+		// 名称为空的工具会被上游判定为 Improperly formed request，直接跳过而非污染整个请求。
+		if strings.TrimSpace(tool.Function.Name) == "" {
 			continue
 		}
 		desc := tool.Function.Description

--- a/proxy/translator_test.go
+++ b/proxy/translator_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -337,6 +338,74 @@ func TestEnsureObjectSchemaRemovesKiroRejectedFieldsRecursively(t *testing.T) {
 	}
 	if _, stillPresent := input["additionalProperties"]; !stillPresent {
 		t.Fatalf("expected sanitizer not to mutate caller schema")
+	}
+}
+
+func TestOpenAIToolUnmarshalSupportsFlatResponsesShape(t *testing.T) {
+	// Responses API（codex-tui 等）发送扁平工具结构，name/description/parameters 与 type 同级。
+	flat := []byte(`{"type":"function","name":"read_file","description":"Read a file","parameters":{"type":"object","properties":{"path":{"type":"string"}}}}`)
+	var tool OpenAITool
+	if err := json.Unmarshal(flat, &tool); err != nil {
+		t.Fatalf("unmarshal flat tool: %v", err)
+	}
+	if tool.Function.Name != "read_file" {
+		t.Fatalf("expected flat tool name to be parsed, got %q", tool.Function.Name)
+	}
+	if tool.Function.Description != "Read a file" {
+		t.Fatalf("expected flat tool description, got %q", tool.Function.Description)
+	}
+	if tool.Function.Parameters == nil {
+		t.Fatalf("expected flat tool parameters to be parsed")
+	}
+}
+
+func TestOpenAIToolUnmarshalSupportsNestedChatCompletionsShape(t *testing.T) {
+	// Chat Completions 发送嵌套结构，必须继续兼容。
+	nested := []byte(`{"type":"function","function":{"name":"get_weather","description":"Weather","parameters":{"type":"object"}}}`)
+	var tool OpenAITool
+	if err := json.Unmarshal(nested, &tool); err != nil {
+		t.Fatalf("unmarshal nested tool: %v", err)
+	}
+	if tool.Function.Name != "get_weather" {
+		t.Fatalf("expected nested tool name to be parsed, got %q", tool.Function.Name)
+	}
+	if tool.Function.Description != "Weather" {
+		t.Fatalf("expected nested tool description, got %q", tool.Function.Description)
+	}
+}
+
+func TestConvertOpenAIToolsFromFlatResponsesPayloadHasNames(t *testing.T) {
+	// 回归测试：扁平工具经反序列化与转换后，name 不能为空，否则上游会回 Improperly formed request。
+	raw := []byte(`[{"type":"function","name":"shell","description":"Run shell","parameters":{"type":"object"}},{"type":"function","name":"apply_patch","parameters":{"type":"object"}}]`)
+	var tools []OpenAITool
+	if err := json.Unmarshal(raw, &tools); err != nil {
+		t.Fatalf("unmarshal tools: %v", err)
+	}
+	converted := convertOpenAITools(tools)
+	if len(converted) != 2 {
+		t.Fatalf("expected 2 converted tools, got %d", len(converted))
+	}
+	for i, w := range converted {
+		if strings.TrimSpace(w.ToolSpecification.Name) == "" {
+			t.Fatalf("converted tool %d has empty name: %#v", i, w.ToolSpecification)
+		}
+	}
+}
+
+func TestConvertOpenAIToolsSkipsEmptyName(t *testing.T) {
+	// 名称为空的工具必须被跳过，避免污染整个上游请求。
+	var named OpenAITool
+	named.Type = "function"
+	named.Function.Name = "ok_tool"
+	var empty OpenAITool
+	empty.Type = "function"
+
+	converted := convertOpenAITools([]OpenAITool{empty, named})
+	if len(converted) != 1 {
+		t.Fatalf("expected empty-name tool to be skipped, got %d tools", len(converted))
+	}
+	if converted[0].ToolSpecification.Name != "ok_tool" {
+		t.Fatalf("expected only the named tool to survive, got %q", converted[0].ToolSpecification.Name)
 	}
 }
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.1",
-  "changelog": "✨ Added and fixed several improvements across the project.\n✨ 新增并修复了一些内容，包含若干功能改进与问题修复。",
+  "version": "1.1.2",
+  "changelog": "🐛 Fixed /v1/responses tools being sent upstream with empty names, which caused AmazonQ to reject requests with \"Improperly formed request\".\n🐛 修复 /v1/responses 工具因扁平结构未被正确解析导致 name 为空、被上游判定为 Improperly formed request 的问题。",
   "download": "https://github.com/Quorinex/Kiro-Go"
 }


### PR DESCRIPTION
## 问题

通过 `/v1/responses` 端点（如 codex-tui 客户端）携带工具发起请求时，上游会以 HTTP 400 拒绝：

```
HTTP 400 from AmazonQ: {"message":"Improperly formed request.","reason":null}
```

CodeWhisperer、AmazonQ、Kiro IDE 三个端点均返回同样的错误，但模型和账号本身都正常。

## 根因

抓取 `[KiroAPI] Request payload` 调试日志后发现，转发给上游的工具规格 `name` 全部为空：

```json
"tools":[{"toolSpecification":{"name":"","description":"Tool: ","inputSchema":{"json":{"type":"object"}}}}, ...]
```

OpenAI 的 **Responses API**（codex-tui 等客户端使用）发送的 function 工具是**扁平结构**：

```json
{"type":"function","name":"shell","description":"...","parameters":{...}}
```

而 `OpenAITool` 只按 **Chat Completions** 的**嵌套结构**解析：

```json
{"type":"function","function":{"name":"shell","description":"...","parameters":{...}}}
```

由于扁平负载没有 `function` 对象，`Function.Name` / `Description` / `Parameters` 全部为零值，于是走了兜底逻辑（`name=""`、`description="Tool: "`、schema 为 `{"type":"object"}`）。`type:"function"` 因为在两种格式中都是同级字段而保留，所以工具没有被 `convertOpenAITools` 跳过，最终把空 name 的工具发给了上游，触发 `Improperly formed request`。

## 改动

- 为 `OpenAITool` 增加自定义 `UnmarshalJSON`，同时兼容嵌套（Chat Completions）与扁平（Responses API）两种工具格式；扁平结构缺失 `type` 时按 `function` 补齐。
- `convertOpenAITools` 放宽 `type` 守卫以接受扁平工具，并跳过 `name` 为空的工具，避免单个异常工具污染整个上游请求。
- 补充单元测试：扁平/嵌套解析、转换后 name 非空、空 name 跳过。
- 版本号升级至 `1.1.2`。

## 测试

```bash
go build ./...
go test ./proxy/
```

均通过。并已在本地 Docker 部署后用 codex-tui 实测：`/v1/responses` 携带工具的请求不再触发 `Improperly formed request`，调试日志中工具的 `name` 已是真实名称（`shell`、`apply_patch` 等）。

## 影响范围

仅影响工具的反序列化与转换逻辑，Chat Completions 的嵌套格式保持完全兼容。
