### PR TITLE
fix: 归一化历史消息严格交替避免上游 Improperly formed request

### DIFF
--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -265,6 +265,9 @@ func ClaudeToKiro(req *ClaudeRequest, thinking bool) *KiroPayload {
 	// 转换工具
 	kiroTools, toolNameMap := convertClaudeTools(req.Tools)
 
+	// 强制历史严格交替，避免连续同角色被上游判定为 Improperly formed request。
+	history = normalizeHistoryAlternation(history)
+
 	// 构建 payload
 	payload := &KiroPayload{}
 	payload.ToolNameMap = toolNameMap
@@ -1107,6 +1110,9 @@ func OpenAIToKiro(req *OpenAIRequest, thinking bool) *KiroPayload {
 	// 转换工具
 	kiroTools := convertOpenAITools(req.Tools)
 
+	// 强制历史严格交替，避免连续同角色被上游判定为 Improperly formed request。
+	history = normalizeHistoryAlternation(history)
+
 	// 构建 payload
 	payload := &KiroPayload{}
 	payload.ConversationState.ChatTriggerType = "MANUAL"
@@ -1266,6 +1272,87 @@ func trimLeadingAssistantHistory(history []KiroHistoryMessage) []KiroHistoryMess
 		return nil
 	}
 	return history[idx:]
+}
+
+// normalizeHistoryAlternation 强制让历史消息严格按 user/assistant 交替。
+//
+// AmazonQ/CodeWhisperer 要求 conversationState.history 严格交替（user→assistant→…）。
+// 在 Codex 等 agent 场景里，一轮回复常被拆成「文本说明 + 多个并行 tool_use」多条 assistant 消息，
+// 紧接着又是多条 tool 结果 / 排队的 user 消息，导致出现连续同角色条目，
+// 被上游判定为 "Improperly formed request" (HTTP 400)。
+//
+// 这里把连续同角色的条目合并为一条（assistant 合并 content 与 toolUses，
+// user 合并 content、images 与 toolResults），从而恢复严格交替且不丢失信息。
+func normalizeHistoryAlternation(history []KiroHistoryMessage) []KiroHistoryMessage {
+	if len(history) <= 1 {
+		return history
+	}
+
+	merged := make([]KiroHistoryMessage, 0, len(history))
+	for _, h := range history {
+		if len(merged) == 0 {
+			merged = append(merged, h)
+			continue
+		}
+		last := &merged[len(merged)-1]
+
+		switch {
+		case last.UserInputMessage != nil && h.UserInputMessage != nil:
+			mergeUserHistory(last.UserInputMessage, h.UserInputMessage)
+		case last.AssistantResponseMessage != nil && h.AssistantResponseMessage != nil:
+			mergeAssistantHistory(last.AssistantResponseMessage, h.AssistantResponseMessage)
+		default:
+			merged = append(merged, h)
+		}
+	}
+	return merged
+}
+
+// mergeUserHistory 把 src 用户消息合并进 dst（content 换行拼接，images/toolResults/tools 追加）。
+func mergeUserHistory(dst, src *KiroUserInputMessage) {
+	dst.Content = joinHistoryContent(dst.Content, src.Content)
+	if dst.ModelID == "" {
+		dst.ModelID = src.ModelID
+	}
+	if dst.Origin == "" {
+		dst.Origin = src.Origin
+	}
+	if len(src.Images) > 0 {
+		dst.Images = append(dst.Images, src.Images...)
+	}
+	if src.UserInputMessageContext != nil {
+		if dst.UserInputMessageContext == nil {
+			dst.UserInputMessageContext = &UserInputMessageContext{}
+		}
+		if len(src.UserInputMessageContext.Tools) > 0 {
+			dst.UserInputMessageContext.Tools = append(dst.UserInputMessageContext.Tools, src.UserInputMessageContext.Tools...)
+		}
+		if len(src.UserInputMessageContext.ToolResults) > 0 {
+			dst.UserInputMessageContext.ToolResults = append(dst.UserInputMessageContext.ToolResults, src.UserInputMessageContext.ToolResults...)
+		}
+	}
+}
+
+// mergeAssistantHistory 把 src 助手消息合并进 dst（content 换行拼接，toolUses 追加）。
+func mergeAssistantHistory(dst, src *KiroAssistantResponseMessage) {
+	dst.Content = joinHistoryContent(dst.Content, src.Content)
+	if len(src.ToolUses) > 0 {
+		dst.ToolUses = append(dst.ToolUses, src.ToolUses...)
+	}
+}
+
+// joinHistoryContent 用换行拼接两段内容，自动忽略空串。
+func joinHistoryContent(a, b string) string {
+	a = strings.TrimRight(a, "\n")
+	b = strings.TrimLeft(b, "\n")
+	switch {
+	case strings.TrimSpace(a) == "":
+		return b
+	case strings.TrimSpace(b) == "":
+		return a
+	default:
+		return a + "\n" + b
+	}
 }
 
 func firstClaudeConversationAnchor(messages []ClaudeMessage) string {

--- a/proxy/translator_test.go
+++ b/proxy/translator_test.go
@@ -340,6 +340,94 @@ func TestEnsureObjectSchemaRemovesKiroRejectedFieldsRecursively(t *testing.T) {
 	}
 }
 
+func TestNormalizeHistoryAlternationMergesConsecutiveSameRole(t *testing.T) {
+	history := []KiroHistoryMessage{
+		{UserInputMessage: &KiroUserInputMessage{Content: "u1"}},
+		{UserInputMessage: &KiroUserInputMessage{Content: "u2"}},
+		{UserInputMessage: &KiroUserInputMessage{Content: "u3"}},
+		{AssistantResponseMessage: &KiroAssistantResponseMessage{Content: "a1"}},
+		{AssistantResponseMessage: &KiroAssistantResponseMessage{Content: "", ToolUses: []KiroToolUse{{ToolUseID: "t1", Name: "shell"}}}},
+		{AssistantResponseMessage: &KiroAssistantResponseMessage{Content: "", ToolUses: []KiroToolUse{{ToolUseID: "t2", Name: "apply_patch"}}}},
+		{UserInputMessage: &KiroUserInputMessage{Content: "u4"}},
+	}
+
+	got := normalizeHistoryAlternation(history)
+
+	// 期望折叠为 U, A, U 三条严格交替。
+	if len(got) != 3 {
+		t.Fatalf("expected 3 alternating entries, got %d", len(got))
+	}
+	if got[0].UserInputMessage == nil || got[1].AssistantResponseMessage == nil || got[2].UserInputMessage == nil {
+		t.Fatalf("expected U/A/U pattern, got %#v", got)
+	}
+	if got[0].UserInputMessage.Content != "u1\nu2\nu3" {
+		t.Fatalf("expected merged user content, got %q", got[0].UserInputMessage.Content)
+	}
+	if got[1].AssistantResponseMessage.Content != "a1" {
+		t.Fatalf("expected assistant content preserved, got %q", got[1].AssistantResponseMessage.Content)
+	}
+	if len(got[1].AssistantResponseMessage.ToolUses) != 2 {
+		t.Fatalf("expected merged tool uses, got %d", len(got[1].AssistantResponseMessage.ToolUses))
+	}
+	if got[2].UserInputMessage.Content != "u4" {
+		t.Fatalf("expected trailing user content, got %q", got[2].UserInputMessage.Content)
+	}
+}
+
+func TestNormalizeHistoryAlternationMergesUserToolResults(t *testing.T) {
+	history := []KiroHistoryMessage{
+		{UserInputMessage: &KiroUserInputMessage{
+			Content:                 "first",
+			UserInputMessageContext: &UserInputMessageContext{ToolResults: []KiroToolResult{{ToolUseID: "a"}}},
+		}},
+		{UserInputMessage: &KiroUserInputMessage{
+			Content:                 "second",
+			UserInputMessageContext: &UserInputMessageContext{ToolResults: []KiroToolResult{{ToolUseID: "b"}}},
+		}},
+	}
+
+	got := normalizeHistoryAlternation(history)
+	if len(got) != 1 {
+		t.Fatalf("expected single merged user entry, got %d", len(got))
+	}
+	ctx := got[0].UserInputMessage.UserInputMessageContext
+	if ctx == nil || len(ctx.ToolResults) != 2 {
+		t.Fatalf("expected merged tool results, got %#v", ctx)
+	}
+}
+
+func TestOpenAIToKiroProducesStrictlyAlternatingHistory(t *testing.T) {
+	// 模拟 Codex agent 场景：文本说明 + 并行 tool_call 拆成多条 assistant，
+	// 中间夹杂多条 tool 结果，最终历史必须严格交替。
+	req := &OpenAIRequest{
+		Model: "claude-sonnet-4.5",
+		Messages: []OpenAIMessage{
+			{Role: "system", Content: "sys"},
+			{Role: "user", Content: "do work"},
+			{Role: "assistant", Content: "let me check"},
+			{Role: "assistant", Content: "", ToolCalls: []ToolCall{{ID: "c1", Type: "function", Function: struct {
+				Name      string `json:"name"`
+				Arguments string `json:"arguments"`
+			}{Name: "shell", Arguments: "{}"}}}},
+			{Role: "tool", ToolCallID: "c1", Content: "out1"},
+			{Role: "user", Content: "continue"},
+			{Role: "assistant", Content: "almost done"},
+			{Role: "user", Content: "now"},
+		},
+	}
+
+	payload := OpenAIToKiro(req, false)
+	hist := payload.ConversationState.History
+
+	for i := 1; i < len(hist); i++ {
+		prevUser := hist[i-1].UserInputMessage != nil
+		curUser := hist[i].UserInputMessage != nil
+		if prevUser == curUser {
+			t.Fatalf("history not strictly alternating at index %d", i)
+		}
+	}
+}
+
 func TestConvertOpenAIToolsSanitizesSchemaAndDescription(t *testing.T) {
 	var tool OpenAITool
 	tool.Type = "function"


### PR DESCRIPTION
## 复现版本

`1.1.1`（最新发布版）

## 问题

在长 agent 会话场景中（codex-tui 多轮调用 + 并行 tool_call），通过 `/v1/responses` 转发到 AmazonQ/CodeWhisperer/Kiro IDE 时**偶发**返回：

```
HTTP 400 from AmazonQ: {"message":"Improperly formed request.","reason":null}
```

客户端表现为 `stream disconnected before completion`。短对话不会触发，会话越长越容易复现。

## 根因

打开 Debug 抓 `[KiroAPI] Request payload` 后定位：失败请求的当前消息**没有**问题，但 `conversationState.history` 不符合上游约束。

AmazonQ/CodeWhisperer 要求 `history` 严格按 `user → assistant → user → …` 交替；当前转换器在处理 agent 会话时会把：

- 一轮 assistant 输出里的「文本说明 + 多个并行 `tool_use`」拆成多条独立 assistant 消息
- 多条 tool 结果 + 排队的 user 消息直接逐条追加为多条 user

于是产生大量连续同角色的历史条目，被上游判定为请求格式不合法。

一次真实失败请求的统计：

| 项 | 数值 |
|---|---:|
| history 总条数 | 433 |
| 连续同角色违反数 | 209（其中 user-user 63、assistant-assistant 146） |
| 违反占比 | 约 48% |

## 修改

`proxy/translator.go`:

- 新增 `normalizeHistoryAlternation`：把连续同角色的历史条目合并成一条；assistant 合并 `content` 与 `toolUses`，user 合并 `content`、`images` 与 `toolResults`，内容用换行拼接，**不丢失任何信息**。
- `ClaudeToKiro` 与 `OpenAIToKiro` 在组装完 history 后均调用该归一化函数。

`proxy/translator_test.go`:

- 补 3 个单元测试：连续同角色合并、user toolResults 合并、OpenAI 端到端严格交替校验。

## 验证

```bash
go build ./...
go test ./proxy/
```

均通过。

把复现日志里那条真实的 433 条历史 payload 喂给归一化函数：

| 指标 | 修复前 | 修复后 |
|---|---:|---:|
| history 条数 | 433 | 224 |
| 连续同角色违反数 | 209 | 0 |
| 头部 24 条角色序列 | 含连续 U/A | `UAUAUA…` |

本地 Docker 部署后，长 agent 会话不再触发 `Improperly formed request`。

## 影响范围

仅影响转换层 history 装配阶段；非 agent 短对话本身就严格交替，归一化对它们是恒等操作，不会改变行为。
