### PR TITLE
fix: 修复 agent 长会话工具调用转换、token 计数、历史污染与上游 400

### DIFF
--- a/proxy/context_window_test.go
+++ b/proxy/context_window_test.go
@@ -1,0 +1,33 @@
+package proxy
+
+import "testing"
+
+// TestGetContextWindowSize verifies models are classified into the correct
+// context window. This drives the input-token count that clients use to decide
+// when to compact; misclassifying opus-4.8 (1M) as 200K under-reports tokens by
+// 5x and prevents timely compaction.
+func TestGetContextWindowSize(t *testing.T) {
+	cases := []struct {
+		model string
+		want  int
+	}{
+		{"claude-opus-4.8", 1_000_000},
+		{"claude-opus-4-8", 1_000_000},
+		{"claude-opus-4.7", 1_000_000},
+		{"claude-opus-4.6", 1_000_000},
+		{"claude-sonnet-4.6", 1_000_000},
+		{"claude-opus-4.8-thinking", 1_000_000},
+		{"CLAUDE-OPUS-4.8", 1_000_000},
+		{"claude-opus-4.5", 200_000},
+		{"claude-sonnet-4.5", 200_000},
+		{"claude-sonnet-4", 200_000},
+		{"claude-haiku-4.5", 200_000},
+		{"claude-3-5-sonnet", 200_000},
+		{"unknown-model", 200_000},
+	}
+	for _, c := range cases {
+		if got := getContextWindowSize(c.model); got != c.want {
+			t.Errorf("getContextWindowSize(%q) = %d, want %d", c.model, got, c.want)
+		}
+	}
+}

--- a/proxy/kiro.go
+++ b/proxy/kiro.go
@@ -11,6 +11,7 @@ import (
 	"kiro-go/logger"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -559,14 +560,48 @@ func updateTokensFromEvent(event map[string]interface{}, currentInputTokens, cur
 }
 
 // getContextWindowSize returns the context window size (in tokens) for a model.
+//
+// Per Kiro's ListAvailableModels, the 1M-token context window applies to
+// Claude 4.6 and newer (sonnet-4.6, opus-4.6, opus-4.7, opus-4.8, and future
+// 4.x releases), while 4.5 and earlier (opus-4.5, sonnet-4.5, sonnet-4,
+// haiku-4.5) use a 200K window. This value is used to convert the upstream
+// contextUsagePercentage into an absolute input-token count that clients rely
+// on to decide when to compact; an undersized window under-reports tokens and
+// prevents clients from compacting in time.
 func getContextWindowSize(model string) int {
-	m := strings.ToLower(model)
-	// sonnet-4.6, opus-4.6, opus-4.7 all have 1M context windows
-	if strings.Contains(m, "4.6") || strings.Contains(m, "4-6") ||
-		strings.Contains(m, "4.7") || strings.Contains(m, "4-7") {
+	if isLargeContextModel(model) {
 		return 1_000_000
 	}
 	return 200_000
+}
+
+// largeContextMinor matches "claude-<family>-<major>.<minor>" (dot or dash form)
+// and is used to classify 1M-window models by version.
+var claudeVersionExtractor = regexp.MustCompile(`claude-(?:opus|sonnet|haiku)-(\d+)[.-](\d+)`)
+
+func isLargeContextModel(model string) bool {
+	m := strings.ToLower(model)
+	if match := claudeVersionExtractor.FindStringSubmatch(m); match != nil {
+		major, errMaj := strconv.Atoi(match[1])
+		minor, errMin := strconv.Atoi(match[2])
+		if errMaj == nil && errMin == nil {
+			// 1M window for Claude >= 4.6 (4.6, 4.7, 4.8, ...) and any major >= 5.
+			if major > 4 {
+				return true
+			}
+			if major == 4 && minor >= 6 {
+				return true
+			}
+			return false
+		}
+	}
+	// Fallback substring checks for non-standard identifiers.
+	for _, tag := range []string{"4.6", "4-6", "4.7", "4-7", "4.8", "4-8", "4.9", "4-9"} {
+		if strings.Contains(m, tag) {
+			return true
+		}
+	}
+	return false
 }
 
 func collectUsageMaps(v interface{}, out *[]map[string]interface{}) {

--- a/proxy/openai_tool_format_test.go
+++ b/proxy/openai_tool_format_test.go
@@ -1,0 +1,74 @@
+package proxy
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestOpenAIToolAcceptsResponsesFlatFormat verifies that the Responses API tool
+// shape (name/description/parameters at the top level) is parsed correctly, not
+// just the Chat Completions nested {"function":{...}} shape. Previously the flat
+// form produced an empty Function.Name, which Kiro rejected with HTTP 400
+// "Improperly formed request".
+func TestOpenAIToolAcceptsResponsesFlatFormat(t *testing.T) {
+	flat := `{"type":"function","name":"exec_command","description":"Run a shell command","parameters":{"type":"object","properties":{"cmd":{"type":"string"}}}}`
+	var tool OpenAITool
+	if err := json.Unmarshal([]byte(flat), &tool); err != nil {
+		t.Fatalf("unmarshal flat tool: %v", err)
+	}
+	if tool.Function.Name != "exec_command" {
+		t.Fatalf("expected name exec_command, got %q", tool.Function.Name)
+	}
+	if tool.Function.Description != "Run a shell command" {
+		t.Fatalf("expected description preserved, got %q", tool.Function.Description)
+	}
+	if tool.Function.Parameters == nil {
+		t.Fatalf("expected parameters preserved")
+	}
+}
+
+// TestOpenAIToolAcceptsNestedFormat verifies the Chat Completions nested shape
+// still works after adding flat-format support.
+func TestOpenAIToolAcceptsNestedFormat(t *testing.T) {
+	nested := `{"type":"function","function":{"name":"get_weather","description":"Get weather","parameters":{"type":"object"}}}`
+	var tool OpenAITool
+	if err := json.Unmarshal([]byte(nested), &tool); err != nil {
+		t.Fatalf("unmarshal nested tool: %v", err)
+	}
+	if tool.Function.Name != "get_weather" {
+		t.Fatalf("expected name get_weather, got %q", tool.Function.Name)
+	}
+}
+
+// TestConvertOpenAIToolsEmitsNonEmptyNames ensures the converter never emits a
+// tool spec with an empty name (Kiro rejects those) and preserves valid names.
+func TestConvertOpenAIToolsEmitsNonEmptyNames(t *testing.T) {
+	tools := []OpenAITool{
+		mustTool(t, `{"type":"function","name":"exec_command","parameters":{"type":"object"}}`),
+		mustTool(t, `{"type":"function","function":{"name":"update_plan","parameters":{"type":"object"}}}`),
+	}
+	wrappers := convertOpenAITools(tools)
+	if len(wrappers) != 2 {
+		t.Fatalf("expected 2 tool wrappers, got %d", len(wrappers))
+	}
+	for i, w := range wrappers {
+		if w.ToolSpecification.Name == "" {
+			t.Fatalf("tool %d has empty name", i)
+		}
+	}
+	if wrappers[0].ToolSpecification.Name != "exec_command" {
+		t.Fatalf("expected exec_command preserved, got %q", wrappers[0].ToolSpecification.Name)
+	}
+	if wrappers[1].ToolSpecification.Name != "update_plan" {
+		t.Fatalf("expected update_plan preserved, got %q", wrappers[1].ToolSpecification.Name)
+	}
+}
+
+func mustTool(t *testing.T, s string) OpenAITool {
+	t.Helper()
+	var tool OpenAITool
+	if err := json.Unmarshal([]byte(s), &tool); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return tool
+}

--- a/proxy/openai_toolresult_dedup_test.go
+++ b/proxy/openai_toolresult_dedup_test.go
@@ -1,0 +1,45 @@
+package proxy
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestOpenAIToKiroDoesNotDuplicateToolResultText reproduces the bug where a
+// non-final tool-result history entry was pre-filled with the
+// "Tool results:" continuation text AND kept the structured ToolResults, which
+// sanitizeKiroHistory then narrated again, producing the same output twice.
+// Each tool result's output must appear exactly once in history.
+func TestOpenAIToKiroDoesNotDuplicateToolResultText(t *testing.T) {
+	req := &OpenAIRequest{
+		Model: "claude-opus-4.8",
+		Messages: []OpenAIMessage{
+			{Role: "user", Content: "run it"},
+			{Role: "assistant", Content: "", ToolCalls: []ToolCall{newToolCall("call_1", "exec_command", `{"cmd":"ls"}`)}},
+			{Role: "tool", ToolCallID: "call_1", Content: "UNIQUE_OUTPUT_MARKER_12345"},
+			{Role: "user", Content: "now summarize"},
+		},
+	}
+
+	payload := OpenAIToKiro(req, false)
+
+	count := 0
+	for _, h := range payload.ConversationState.History {
+		if h.UserInputMessage != nil {
+			count += strings.Count(h.UserInputMessage.Content, "UNIQUE_OUTPUT_MARKER_12345")
+		}
+		if h.AssistantResponseMessage != nil {
+			count += strings.Count(h.AssistantResponseMessage.Content, "UNIQUE_OUTPUT_MARKER_12345")
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected tool result output to appear exactly once in history, got %d", count)
+	}
+}
+
+func newToolCall(id, name, args string) ToolCall {
+	tc := ToolCall{ID: id, Type: "function"}
+	tc.Function.Name = name
+	tc.Function.Arguments = args
+	return tc
+}

--- a/proxy/responses_input.go
+++ b/proxy/responses_input.go
@@ -98,11 +98,23 @@ func convertResponsesInputItems(items []json.RawMessage) ([]OpenAIMessage, error
 			}
 			tc.Function.Name, _ = obj["name"].(string)
 			tc.Function.Arguments = stringifyArbitrary(obj["arguments"])
-			messages = append(messages, OpenAIMessage{
-				Role:      "assistant",
-				Content:   "",
-				ToolCalls: []ToolCall{tc},
-			})
+			// Merge consecutive function_call items into a single assistant
+			// message so parallel tool calls stay grouped in one turn. The
+			// Responses API emits each parallel call as a separate input item;
+			// keeping them in one assistant message preserves the tool_use /
+			// tool_result pairing that Kiro requires.
+			if n := len(messages); n > 0 &&
+				messages[n-1].Role == "assistant" &&
+				len(messages[n-1].ToolCalls) > 0 &&
+				strings.TrimSpace(extractOpenAIMessageText(messages[n-1].Content)) == "" {
+				messages[n-1].ToolCalls = append(messages[n-1].ToolCalls, tc)
+			} else {
+				messages = append(messages, OpenAIMessage{
+					Role:      "assistant",
+					Content:   "",
+					ToolCalls: []ToolCall{tc},
+				})
+			}
 
 		case typ == "input_text" || typ == "text":
 			text, _ := obj["text"].(string)

--- a/proxy/responses_parallel_test.go
+++ b/proxy/responses_parallel_test.go
@@ -1,0 +1,52 @@
+package proxy
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestResponsesParallelToolCallsMerge verifies that consecutive function_call
+// items in the Responses API input are merged into a single assistant message
+// so parallel tool calls stay grouped. Previously each parallel call became its
+// own assistant turn, which split the tool_use/tool_result pairing and caused
+// Kiro to reject the request with HTTP 400 "Improperly formed request".
+func TestResponsesParallelToolCallsMerge(t *testing.T) {
+	items := []json.RawMessage{
+		mustRaw(`{"type":"message","role":"user","content":[{"type":"input_text","text":"run two commands"}]}`),
+		mustRaw(`{"type":"function_call","call_id":"call_a","name":"exec_command","arguments":"{\"cmd\":\"ls\"}"}`),
+		mustRaw(`{"type":"function_call","call_id":"call_b","name":"exec_command","arguments":"{\"cmd\":\"pwd\"}"}`),
+		mustRaw(`{"type":"function_call_output","call_id":"call_a","output":"file1"}`),
+		mustRaw(`{"type":"function_call_output","call_id":"call_b","output":"/home"}`),
+	}
+
+	msgs, err := convertResponsesInputItems(items)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+
+	// Find the assistant message; it must contain BOTH tool calls.
+	var asstToolCalls int
+	for _, m := range msgs {
+		if m.Role == "assistant" && len(m.ToolCalls) > 0 {
+			asstToolCalls = len(m.ToolCalls)
+		}
+	}
+	if asstToolCalls != 2 {
+		t.Fatalf("expected 2 merged tool calls in one assistant message, got %d", asstToolCalls)
+	}
+
+	// Count assistant messages carrying tool calls; must be exactly 1 (merged).
+	asstWithCalls := 0
+	for _, m := range msgs {
+		if m.Role == "assistant" && len(m.ToolCalls) > 0 {
+			asstWithCalls++
+		}
+	}
+	if asstWithCalls != 1 {
+		t.Fatalf("expected parallel calls merged into 1 assistant message, got %d", asstWithCalls)
+	}
+}
+
+func mustRaw(s string) json.RawMessage {
+	return json.RawMessage(s)
+}

--- a/proxy/responses_types.go
+++ b/proxy/responses_types.go
@@ -17,20 +17,20 @@ type ResponsesRequest struct {
 }
 
 type ResponsesObject struct {
-	ID                 string                `json:"id"`
-	Object             string                `json:"object"`
-	CreatedAt          int64                 `json:"created_at"`
-	Status             string                `json:"status"`
-	Model              string                `json:"model"`
-	Output             []ResponseOutputItem  `json:"output"`
-	Usage              ResponsesUsage        `json:"usage"`
-	PreviousResponseID string                `json:"previous_response_id,omitempty"`
-	Metadata           map[string]string     `json:"metadata,omitempty"`
-	Error              *ResponsesError       `json:"error,omitempty"`
-	Instructions       string                `json:"instructions,omitempty"`
-	StoredInput        json.RawMessage       `json:"-"`
-	StoredInstr        string                `json:"-"`
-	StoredAt           int64                 `json:"stored_at,omitempty"`
+	ID                 string               `json:"id"`
+	Object             string               `json:"object"`
+	CreatedAt          int64                `json:"created_at"`
+	Status             string               `json:"status"`
+	Model              string               `json:"model"`
+	Output             []ResponseOutputItem `json:"output"`
+	Usage              ResponsesUsage       `json:"usage"`
+	PreviousResponseID string               `json:"previous_response_id,omitempty"`
+	Metadata           map[string]string    `json:"metadata,omitempty"`
+	Error              *ResponsesError      `json:"error,omitempty"`
+	Instructions       string               `json:"instructions,omitempty"`
+	StoredInput        json.RawMessage      `json:"-"`
+	StoredInstr        string               `json:"-"`
+	StoredAt           int64                `json:"stored_at,omitempty"`
 }
 
 type ResponseOutputItem struct {

--- a/proxy/tool_narration_pollution_test.go
+++ b/proxy/tool_narration_pollution_test.go
@@ -74,6 +74,36 @@ func newPollToolCall(id, name, args string) ToolCall {
 	return tc
 }
 
+// TestCollapsesConsecutiveIdenticalToolResults covers a client retry loop that
+// sends the same failing tool result many times. After hollow assistant turns
+// are dropped, those identical user "Tool results" turns become adjacent
+// duplicates; the proxy collapses each run to a single copy.
+func TestCollapsesConsecutiveIdenticalToolResults(t *testing.T) {
+	msgs := []OpenAIMessage{{Role: "user", Content: "start"}}
+	// 5 identical failing cycles in a row (model retrying the same tool).
+	for i := 0; i < 5; i++ {
+		msgs = append(msgs,
+			OpenAIMessage{Role: "assistant", Content: "", ToolCalls: []ToolCall{
+				newPollToolCall(fmt.Sprintf("c%d", i), "exec_command", `{"cmd":"x"}`),
+			}},
+			OpenAIMessage{Role: "tool", ToolCallID: fmt.Sprintf("c%d", i), Content: "SAME_ERROR_OUTPUT"},
+		)
+	}
+	msgs = append(msgs, OpenAIMessage{Role: "user", Content: "final"})
+
+	payload := OpenAIToKiro(&OpenAIRequest{Model: "claude-opus-4.8", Messages: msgs}, false)
+
+	count := 0
+	for _, h := range payload.ConversationState.History {
+		if h.UserInputMessage != nil && strings.Contains(h.UserInputMessage.Content, "SAME_ERROR_OUTPUT") {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected 5 identical tool-result turns collapsed to 1, got %d", count)
+	}
+}
+
 // TestDropsDotPollutedAssistantTurns covers the second-order pollution: after
 // stripping "[Called tool ...]" from assistant turns that held only that text,
 // the turns become empty and must NOT be backfilled with ".". A history full of

--- a/proxy/tool_narration_pollution_test.go
+++ b/proxy/tool_narration_pollution_test.go
@@ -1,0 +1,75 @@
+package proxy
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestNoToolInvocationTextInAssistantHistory is a regression guard for the
+// few-shot pollution bug: when historical tool calls were narrated as
+// "[Called tool X with input ...]" inside assistant turns, the model learned to
+// emit that literal text instead of issuing real structured tool calls.
+//
+// After the fix, assistant history turns must never contain tool-invocation
+// syntax. Tool identity is attributed only on the user "Tool results" side.
+func TestNoToolInvocationTextInAssistantHistory(t *testing.T) {
+	// Build a long OpenAI conversation with many completed tool cycles.
+	msgs := []OpenAIMessage{{Role: "user", Content: "start a multi-step task"}}
+	for i := 0; i < 8; i++ {
+		msgs = append(msgs,
+			OpenAIMessage{Role: "assistant", Content: "", ToolCalls: []ToolCall{
+				newPollToolCall(fmt.Sprintf("call_%d", i), "exec_command", fmt.Sprintf(`{"cmd":"step %d"}`, i)),
+			}},
+			OpenAIMessage{Role: "tool", ToolCallID: fmt.Sprintf("call_%d", i), Content: fmt.Sprintf("OUTPUT_%d", i)},
+			OpenAIMessage{Role: "user", Content: fmt.Sprintf("continue %d", i)},
+		)
+	}
+	msgs = append(msgs, OpenAIMessage{Role: "user", Content: "summarize"})
+
+	payload := OpenAIToKiro(&OpenAIRequest{Model: "claude-opus-4.8", Messages: msgs}, false)
+
+	for i, h := range payload.ConversationState.History {
+		a := h.AssistantResponseMessage
+		if a == nil {
+			continue
+		}
+		// No assistant turn may contain tool-invocation-looking text.
+		for _, bad := range []string{"[Called tool", "Called tool ", "with input {"} {
+			if strings.Contains(a.Content, bad) {
+				t.Fatalf("history[%d] assistant content contains mimicable tool text %q: %q", i, bad, a.Content)
+			}
+		}
+		// No assistant turn may carry structured tool calls (rejected upstream).
+		if len(a.ToolUses) > 0 {
+			t.Fatalf("history[%d] assistant retains %d structured toolUses", i, len(a.ToolUses))
+		}
+	}
+
+	// Tool outputs must still be preserved (on the user side) for context.
+	var allText strings.Builder
+	for _, h := range payload.ConversationState.History {
+		if h.UserInputMessage != nil {
+			allText.WriteString(h.UserInputMessage.Content)
+			allText.WriteString("\n")
+		}
+	}
+	combined := allText.String()
+	for i := 0; i < 8; i++ {
+		marker := fmt.Sprintf("OUTPUT_%d", i)
+		if !strings.Contains(combined, marker) {
+			t.Fatalf("tool output %q lost from history", marker)
+		}
+	}
+	// Tool identity should be attributed on the user side.
+	if !strings.Contains(combined, "[exec_command]") {
+		t.Fatalf("expected tool results attributed to exec_command on the user side")
+	}
+}
+
+func newPollToolCall(id, name, args string) ToolCall {
+	tc := ToolCall{ID: id, Type: "function"}
+	tc.Function.Name = name
+	tc.Function.Arguments = args
+	return tc
+}

--- a/proxy/tool_narration_pollution_test.go
+++ b/proxy/tool_narration_pollution_test.go
@@ -73,3 +73,43 @@ func newPollToolCall(id, name, args string) ToolCall {
 	tc.Function.Arguments = args
 	return tc
 }
+
+// TestScrubsClientReplayedToolCallText covers the recovery path: a polluted
+// client stored the model's "[Called tool ...]" text output as assistant
+// history and replays it. The proxy must strip that text from assistant turns
+// so the pattern is not reinforced.
+func TestScrubsClientReplayedToolCallText(t *testing.T) {
+	req := &ClaudeRequest{
+		Model: "claude-opus-4.8",
+		Messages: []ClaudeMessage{
+			{Role: "user", Content: "do the task"},
+			// Assistant text the client captured from the model's polluted output.
+			{Role: "assistant", Content: "Let me check.\n\n[Called tool exec_command with input {\"cmd\":\"pwd\"}]"},
+			{Role: "user", Content: "continue"},
+			{Role: "assistant", Content: "[Called tool exec_command with input {\"cmd\":\"ls\"}]"},
+			{Role: "user", Content: "continue"},
+		},
+	}
+
+	payload := ClaudeToKiro(req, false)
+
+	for i, h := range payload.ConversationState.History {
+		if a := h.AssistantResponseMessage; a != nil {
+			if strings.Contains(a.Content, "[Called tool") {
+				t.Fatalf("history[%d] still contains replayed tool-call text: %q", i, a.Content)
+			}
+		}
+	}
+
+	// The natural prose around the stripped marker must be preserved.
+	var combined strings.Builder
+	for _, h := range payload.ConversationState.History {
+		if h.AssistantResponseMessage != nil {
+			combined.WriteString(h.AssistantResponseMessage.Content)
+			combined.WriteString("\n")
+		}
+	}
+	if !strings.Contains(combined.String(), "Let me check.") {
+		t.Fatalf("expected surrounding assistant prose to survive scrubbing, got:\n%s", combined.String())
+	}
+}

--- a/proxy/tool_narration_pollution_test.go
+++ b/proxy/tool_narration_pollution_test.go
@@ -74,6 +74,44 @@ func newPollToolCall(id, name, args string) ToolCall {
 	return tc
 }
 
+// TestDropsDotPollutedAssistantTurns covers the second-order pollution: after
+// stripping "[Called tool ...]" from assistant turns that held only that text,
+// the turns become empty and must NOT be backfilled with ".". A history full of
+// "." assistant turns trains the model to reply ".". Such hollow turns are
+// dropped instead.
+func TestDropsDotPollutedAssistantTurns(t *testing.T) {
+	msgs := []ClaudeMessage{{Role: "user", Content: "start"}}
+	for i := 0; i < 6; i++ {
+		// Assistant turn that is pure replayed tool-call text (becomes empty after scrub).
+		msgs = append(msgs,
+			ClaudeMessage{Role: "assistant", Content: "[Called tool exec_command with input {\"cmd\":\"x\"}]"},
+			ClaudeMessage{Role: "user", Content: "continue"},
+		)
+		// Also a turn that is already a bare "." (client-replayed prior placeholder).
+		msgs = append(msgs,
+			ClaudeMessage{Role: "assistant", Content: "."},
+			ClaudeMessage{Role: "user", Content: "go on"},
+		)
+	}
+	msgs = append(msgs, ClaudeMessage{Role: "user", Content: "final question"})
+
+	payload := ClaudeToKiro(&ClaudeRequest{Model: "claude-opus-4.8", Messages: msgs}, false)
+
+	for i, h := range payload.ConversationState.History {
+		a := h.AssistantResponseMessage
+		if a == nil {
+			continue
+		}
+		c := strings.TrimSpace(a.Content)
+		if c == "." || c == "" {
+			t.Fatalf("history[%d] is a hollow/dot assistant turn that should have been dropped", i)
+		}
+		if strings.Contains(a.Content, "[Called tool") {
+			t.Fatalf("history[%d] still contains replayed tool-call text", i)
+		}
+	}
+}
+
 // TestScrubsClientReplayedToolCallText covers the recovery path: a polluted
 // client stored the model's "[Called tool ...]" text output as assistant
 // history and replays it. The proxy must strip that text from assistant turns

--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -1370,34 +1370,18 @@ func currentToolResultsMatchLastAssistant(history []KiroHistoryMessage, currentT
 	return true
 }
 
-// narrateToolUses renders structured assistant tool calls as plain text so they
-// can live in conversation history without the structured toolUses field.
-// Kiro's upstream rejects history that carries structured tool calls/results
-// (HTTP 400 "Improperly formed request"); only the active tool turn
-// (last history assistant toolUse ⟺ current message toolResults) may be structured.
-func narrateToolUses(toolUses []KiroToolUse) string {
-	if len(toolUses) == 0 {
-		return ""
-	}
-	parts := make([]string, 0, len(toolUses))
-	for _, tu := range toolUses {
-		input := ""
-		if len(tu.Input) > 0 {
-			if raw, err := json.Marshal(tu.Input); err == nil {
-				input = string(raw)
-			}
-		}
-		if input != "" {
-			parts = append(parts, fmt.Sprintf("[Called tool %s with input %s]", tu.Name, input))
-		} else {
-			parts = append(parts, fmt.Sprintf("[Called tool %s]", tu.Name))
-		}
-	}
-	return strings.Join(parts, "\n")
-}
-
-// narrateToolResults renders structured tool results as plain text for history.
-func narrateToolResults(toolResults []KiroToolResult) string {
+// narrateToolResults renders structured tool results as plain text for a user
+// history turn. Each result is attributed to its originating tool call (by name)
+// when that mapping is known, so the model retains the tool's identity without
+// any assistant-side tool-invocation syntax to imitate.
+//
+// IMPORTANT: tool activity must never be narrated into ASSISTANT turns. Earlier
+// versions wrote "[Called tool X with input ...]" into assistant content, which
+// trained the model (via dozens of in-context examples) to emit that literal
+// text instead of issuing real structured tool calls. All tool narration lives
+// in user "Tool results" turns, which the model reads but never authors, so it
+// has no invocation pattern to copy.
+func narrateToolResults(toolResults []KiroToolResult, names map[string]string) string {
 	if len(toolResults) == 0 {
 		return ""
 	}
@@ -1411,9 +1395,13 @@ func narrateToolResults(toolResults []KiroToolResult) string {
 		}
 		body := strings.Join(texts, "\n")
 		if strings.TrimSpace(body) == "" {
-			continue
+			body = "(no output)"
 		}
-		parts = append(parts, body)
+		if name := names[tr.ToolUseID]; name != "" {
+			parts = append(parts, fmt.Sprintf("[%s] %s", name, body))
+		} else {
+			parts = append(parts, body)
+		}
 	}
 	if len(parts) == 0 {
 		return ""
@@ -1449,6 +1437,20 @@ func sanitizeKiroHistory(history []KiroHistoryMessage, currentToolResultIDs map[
 		return history
 	}
 
+	// Map every tool-use ID to its tool name across all assistant turns, so a
+	// user "Tool results" turn can attribute each result to its originating tool
+	// even after the structured toolUses are stripped from the assistant turn.
+	toolNames := make(map[string]string)
+	for i := range history {
+		if a := history[i].AssistantResponseMessage; a != nil {
+			for _, tu := range a.ToolUses {
+				if tu.ToolUseID != "" && tu.Name != "" {
+					toolNames[tu.ToolUseID] = tu.Name
+				}
+			}
+		}
+	}
+
 	// Determine whether the last history assistant turn is the "active" tool turn
 	// answered by the current message. If so, its structured toolUses stay.
 	activeIdx := -1
@@ -1475,15 +1477,19 @@ func sanitizeKiroHistory(history []KiroHistoryMessage, currentToolResultIDs map[
 			if i == activeIdx {
 				continue // keep the active tool turn structured
 			}
-			narrated := narrateToolUses(msg.AssistantResponseMessage.ToolUses)
-			msg.AssistantResponseMessage.Content = joinHistoryText(msg.AssistantResponseMessage.Content, narrated)
+			// Drop the structured tool calls WITHOUT writing any tool-invocation
+			// text into the assistant turn. Narrating the call here (e.g.
+			// "[Called tool X ...]") would give the model dozens of in-context
+			// examples of "invoke a tool by emitting this text", which it then
+			// imitates instead of issuing real structured tool calls. The tool's
+			// identity is preserved on the result side (user turn) via toolNames.
 			msg.AssistantResponseMessage.ToolUses = nil
 		}
 
 		if msg.UserInputMessage != nil && msg.UserInputMessage.UserInputMessageContext != nil {
 			ctx := msg.UserInputMessage.UserInputMessageContext
 			if len(ctx.ToolResults) > 0 {
-				narrated := narrateToolResults(ctx.ToolResults)
+				narrated := narrateToolResults(ctx.ToolResults, toolNames)
 				msg.UserInputMessage.Content = joinHistoryText(msg.UserInputMessage.Content, narrated)
 				ctx.ToolResults = nil
 			}

--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"kiro-go/config"
 	"regexp"
 	"strings"
@@ -43,6 +44,24 @@ const ThinkingModePrompt = `<thinking_mode>enabled</thinking_mode>
 
 const minimalFallbackUserContent = "."
 const toolResultsContinuationPrefix = "Tool results:"
+
+// maxPayloadBytes is the upper bound for the serialized Kiro request body.
+// Kiro's upstream rejects oversized requests with HTTP 400
+// "Input is too long." (CONTENT_LENGTH_EXCEEDS_THRESHOLD). When a converted
+// payload exceeds this size we drop the oldest history turns (keeping the
+// system priming, the most recent turns, the active tool turn, and the current
+// message) and insert a placeholder note so the model knows context was elided.
+// The limit is kept conservatively below the observed upstream threshold to
+// leave room for headers and minor serialization overhead.
+const maxPayloadBytes = 900 * 1024
+
+// truncationPlaceholder is inserted in history where older turns were dropped to
+// fit within maxPayloadBytes.
+const truncationPlaceholder = "[Earlier conversation history was truncated to fit the model's input limit. Older messages and tool activity have been omitted.]"
+
+// minRecentHistoryTurns is the number of most-recent history entries always kept
+// (in addition to system priming and the active tool turn) when truncating.
+const minRecentHistoryTurns = 4
 
 // ParseModelAndThinking resolves a client-supplied model name to a Kiro model ID
 // and reports whether thinking mode was requested via the configured suffix.
@@ -250,6 +269,21 @@ func ClaudeToKiro(req *ClaudeRequest, thinking bool) *KiroPayload {
 		history = append(priming, history...)
 	}
 
+	// Decide whether the current tool results form a valid "active" tool turn:
+	// the last history assistant must carry matching structured toolUses. If not
+	// (orphaned tool results, e.g. after context compaction), flatten them into
+	// the current message text so the upstream does not reject the request.
+	currentToolResultIDs := collectToolResultIDs(currentToolResults)
+	keepCurrentToolResults := currentToolResultsMatchLastAssistant(history, currentToolResultIDs)
+
+	// Flatten structured tool calls/results that live in history; upstream only
+	// accepts a single active tool turn (last assistant toolUses ⟺ current toolResults).
+	if keepCurrentToolResults {
+		history = sanitizeKiroHistory(history, currentToolResultIDs)
+	} else {
+		history = sanitizeKiroHistory(history, nil)
+	}
+
 	// 构建最终内容
 	finalContent := ""
 	if currentContent != "" {
@@ -279,10 +313,16 @@ func ClaudeToKiro(req *ClaudeRequest, thinking bool) *KiroPayload {
 		Images:  currentImages,
 	}
 
-	if len(kiroTools) > 0 || len(currentToolResults) > 0 {
+	// Only attach structured tool results when they answer the last history
+	// assistant turn; otherwise they have already been folded into finalContent.
+	var attachToolResults []KiroToolResult
+	if keepCurrentToolResults {
+		attachToolResults = currentToolResults
+	}
+	if len(kiroTools) > 0 || len(attachToolResults) > 0 {
 		payload.ConversationState.CurrentMessage.UserInputMessage.UserInputMessageContext = &UserInputMessageContext{
 			Tools:       kiroTools,
-			ToolResults: currentToolResults,
+			ToolResults: attachToolResults,
 		}
 	}
 
@@ -297,6 +337,8 @@ func ClaudeToKiro(req *ClaudeRequest, thinking bool) *KiroPayload {
 			TopP:        req.TopP,
 		}
 	}
+
+	truncatePayloadToLimit(payload, systemPrompt != "")
 
 	return payload
 }
@@ -947,6 +989,54 @@ type OpenAITool struct {
 	} `json:"function"`
 }
 
+// UnmarshalJSON accepts both the Chat Completions tool shape, where the tool
+// definition is nested under "function":
+//
+//	{"type":"function","function":{"name":"x","description":"...","parameters":{...}}}
+//
+// and the Responses API tool shape, where name/description/parameters live at
+// the top level:
+//
+//	{"type":"function","name":"x","description":"...","parameters":{...}}
+//
+// Without this, Responses API tools would parse with an empty Function.Name,
+// which Kiro rejects with HTTP 400 "Improperly formed request".
+func (t *OpenAITool) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Type        string      `json:"type"`
+		Name        string      `json:"name"`
+		Description string      `json:"description"`
+		Parameters  interface{} `json:"parameters"`
+		Function    *struct {
+			Name        string      `json:"name"`
+			Description string      `json:"description"`
+			Parameters  interface{} `json:"parameters"`
+		} `json:"function"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	t.Type = raw.Type
+	if raw.Function != nil {
+		t.Function.Name = raw.Function.Name
+		t.Function.Description = raw.Function.Description
+		t.Function.Parameters = raw.Function.Parameters
+	}
+	// Fall back to top-level (Responses API) fields when the nested form is
+	// absent or incomplete.
+	if t.Function.Name == "" {
+		t.Function.Name = raw.Name
+	}
+	if t.Function.Description == "" {
+		t.Function.Description = raw.Description
+	}
+	if t.Function.Parameters == nil {
+		t.Function.Parameters = raw.Parameters
+	}
+	return nil
+}
+
 type OpenAIResponse struct {
 	ID      string         `json:"id"`
 	Object  string         `json:"object"`
@@ -1092,6 +1182,17 @@ func OpenAIToKiro(req *OpenAIRequest, thinking bool) *KiroPayload {
 		history = append(priming, history...)
 	}
 
+	// Decide whether current tool results form a valid active tool turn; if not,
+	// flatten them into the current message text (see ClaudeToKiro for rationale).
+	currentToolResultIDs := collectToolResultIDs(currentToolResults)
+	keepCurrentToolResults := currentToolResultsMatchLastAssistant(history, currentToolResultIDs)
+
+	if keepCurrentToolResults {
+		history = sanitizeKiroHistory(history, currentToolResultIDs)
+	} else {
+		history = sanitizeKiroHistory(history, nil)
+	}
+
 	// 构建最终内容
 	finalContent := currentContent
 	if finalContent == "" {
@@ -1118,10 +1219,14 @@ func OpenAIToKiro(req *OpenAIRequest, thinking bool) *KiroPayload {
 		Images:  currentImages,
 	}
 
-	if len(kiroTools) > 0 || len(currentToolResults) > 0 {
+	var attachToolResults []KiroToolResult
+	if keepCurrentToolResults {
+		attachToolResults = currentToolResults
+	}
+	if len(kiroTools) > 0 || len(attachToolResults) > 0 {
 		payload.ConversationState.CurrentMessage.UserInputMessage.UserInputMessageContext = &UserInputMessageContext{
 			Tools:       kiroTools,
-			ToolResults: currentToolResults,
+			ToolResults: attachToolResults,
 		}
 	}
 
@@ -1136,6 +1241,8 @@ func OpenAIToKiro(req *OpenAIRequest, thinking bool) *KiroPayload {
 			TopP:        req.TopP,
 		}
 	}
+
+	truncatePayloadToLimit(payload, systemPrompt != "")
 
 	return payload
 }
@@ -1224,6 +1331,307 @@ func extractOpenAIMessageText(content interface{}) string {
 	}
 
 	return ""
+}
+
+// collectToolResultIDs returns the set of toolUseId values referenced by the
+// given tool results.
+func collectToolResultIDs(toolResults []KiroToolResult) map[string]bool {
+	if len(toolResults) == 0 {
+		return nil
+	}
+	ids := make(map[string]bool, len(toolResults))
+	for _, tr := range toolResults {
+		if id := strings.TrimSpace(tr.ToolUseID); id != "" {
+			ids[id] = true
+		}
+	}
+	return ids
+}
+
+// currentToolResultsMatchLastAssistant reports whether the current message's
+// tool results answer the structured tool calls of the final history assistant
+// message. Only in that case may the current toolResults stay structured.
+func currentToolResultsMatchLastAssistant(history []KiroHistoryMessage, currentToolResultIDs map[string]bool) bool {
+	if len(currentToolResultIDs) == 0 || len(history) == 0 {
+		return false
+	}
+	last := history[len(history)-1]
+	if last.AssistantResponseMessage == nil || len(last.AssistantResponseMessage.ToolUses) == 0 {
+		return false
+	}
+	for _, tu := range last.AssistantResponseMessage.ToolUses {
+		if !currentToolResultIDs[tu.ToolUseID] {
+			return false
+		}
+	}
+	return true
+}
+
+// narrateToolUses renders structured assistant tool calls as plain text so they
+// can live in conversation history without the structured toolUses field.
+// Kiro's upstream rejects history that carries structured tool calls/results
+// (HTTP 400 "Improperly formed request"); only the active tool turn
+// (last history assistant toolUse ⟺ current message toolResults) may be structured.
+func narrateToolUses(toolUses []KiroToolUse) string {
+	if len(toolUses) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(toolUses))
+	for _, tu := range toolUses {
+		input := ""
+		if len(tu.Input) > 0 {
+			if raw, err := json.Marshal(tu.Input); err == nil {
+				input = string(raw)
+			}
+		}
+		if input != "" {
+			parts = append(parts, fmt.Sprintf("[Called tool %s with input %s]", tu.Name, input))
+		} else {
+			parts = append(parts, fmt.Sprintf("[Called tool %s]", tu.Name))
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+// narrateToolResults renders structured tool results as plain text for history.
+func narrateToolResults(toolResults []KiroToolResult) string {
+	if len(toolResults) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(toolResults))
+	for _, tr := range toolResults {
+		var texts []string
+		for _, c := range tr.Content {
+			if strings.TrimSpace(c.Text) != "" {
+				texts = append(texts, c.Text)
+			}
+		}
+		body := strings.Join(texts, "\n")
+		if strings.TrimSpace(body) == "" {
+			continue
+		}
+		parts = append(parts, body)
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return toolResultsContinuationPrefix + "\n\n" + strings.Join(parts, "\n\n")
+}
+
+// joinHistoryText combines an existing message body with narrated tool text.
+func joinHistoryText(existing, narrated string) string {
+	existing = strings.TrimSpace(existing)
+	narrated = strings.TrimSpace(narrated)
+	switch {
+	case existing != "" && narrated != "":
+		return existing + "\n\n" + narrated
+	case narrated != "":
+		return narrated
+	default:
+		return existing
+	}
+}
+
+// sanitizeKiroHistory flattens structured tool calls/results inside history into
+// plain text, leaving at most one active structured tool turn intact: the final
+// history assistant message whose tool-use IDs are answered by the current
+// message's toolResults. Everything else is narrated as text so the upstream
+// accepts the request.
+//
+// currentToolResultIDs is the set of toolUseId values carried by the current
+// (outgoing) message. When the last history entry is an assistant message whose
+// tool uses are fully covered by that set, its structured toolUses are kept.
+func sanitizeKiroHistory(history []KiroHistoryMessage, currentToolResultIDs map[string]bool) []KiroHistoryMessage {
+	if len(history) == 0 {
+		return history
+	}
+
+	// Determine whether the last history assistant turn is the "active" tool turn
+	// answered by the current message. If so, its structured toolUses stay.
+	activeIdx := -1
+	if len(currentToolResultIDs) > 0 {
+		last := history[len(history)-1]
+		if last.AssistantResponseMessage != nil && len(last.AssistantResponseMessage.ToolUses) > 0 {
+			allCovered := true
+			for _, tu := range last.AssistantResponseMessage.ToolUses {
+				if !currentToolResultIDs[tu.ToolUseID] {
+					allCovered = false
+					break
+				}
+			}
+			if allCovered {
+				activeIdx = len(history) - 1
+			}
+		}
+	}
+
+	for i := range history {
+		msg := &history[i]
+
+		if msg.AssistantResponseMessage != nil && len(msg.AssistantResponseMessage.ToolUses) > 0 {
+			if i == activeIdx {
+				continue // keep the active tool turn structured
+			}
+			narrated := narrateToolUses(msg.AssistantResponseMessage.ToolUses)
+			msg.AssistantResponseMessage.Content = joinHistoryText(msg.AssistantResponseMessage.Content, narrated)
+			msg.AssistantResponseMessage.ToolUses = nil
+		}
+
+		if msg.UserInputMessage != nil && msg.UserInputMessage.UserInputMessageContext != nil {
+			ctx := msg.UserInputMessage.UserInputMessageContext
+			if len(ctx.ToolResults) > 0 {
+				narrated := narrateToolResults(ctx.ToolResults)
+				msg.UserInputMessage.Content = joinHistoryText(msg.UserInputMessage.Content, narrated)
+				ctx.ToolResults = nil
+			}
+			// History messages must not carry structured tool specs either.
+			ctx.Tools = nil
+			if len(ctx.Tools) == 0 && len(ctx.ToolResults) == 0 {
+				msg.UserInputMessage.UserInputMessageContext = nil
+			}
+		}
+
+		// Guard against empty content after flattening (Kiro requires non-empty).
+		if msg.UserInputMessage != nil && strings.TrimSpace(msg.UserInputMessage.Content) == "" && len(msg.UserInputMessage.Images) == 0 {
+			msg.UserInputMessage.Content = minimalFallbackUserContent
+		}
+		if msg.AssistantResponseMessage != nil && strings.TrimSpace(msg.AssistantResponseMessage.Content) == "" && len(msg.AssistantResponseMessage.ToolUses) == 0 {
+			msg.AssistantResponseMessage.Content = minimalFallbackUserContent
+		}
+	}
+
+	return history
+}
+
+// truncatePayloadToLimit drops the oldest conversation history turns until the
+// serialized payload fits within maxPayloadBytes. It preserves, in order:
+//   - the system priming pair (if present) at the front of history,
+//   - the most recent turns (at least minRecentHistoryTurns, and always the
+//     active tool turn that pairs with the current message),
+//   - the current message itself.
+//
+// A single placeholder note (truncationPlaceholder) is inserted where older
+// turns were removed so the model is aware context was elided. hasPriming
+// indicates whether history begins with the 2-entry system priming pair.
+func truncatePayloadToLimit(payload *KiroPayload, hasPriming bool) {
+	if payload == nil {
+		return
+	}
+	if payloadByteSize(payload) <= maxPayloadBytes {
+		return
+	}
+
+	history := payload.ConversationState.History
+	primingCount := 0
+	if hasPriming && len(history) >= 2 {
+		primingCount = 2
+	}
+
+	priming := history[:primingCount]
+	conversation := history[primingCount:]
+
+	// Compute the fixed overhead (everything except the trimmable conversation):
+	// priming, current message, inference config, profileArn, etc. We estimate by
+	// measuring the payload with an empty conversation tail, then add a budget for
+	// the placeholder and retained tail turns.
+	placeholderEntry := KiroHistoryMessage{
+		UserInputMessage: &KiroUserInputMessage{
+			Content: truncationPlaceholder,
+			ModelID: currentMessageModelID(payload),
+			Origin:  "AI_EDITOR",
+		},
+	}
+
+	// Precompute byte size of each conversation entry once (O(n)).
+	entrySizes := make([]int, len(conversation))
+	for i := range conversation {
+		entrySizes[i] = historyEntryByteSize(conversation[i])
+	}
+
+	// Base size: payload with priming only (no conversation), plus placeholder.
+	payload.ConversationState.History = priming
+	baseSize := payloadByteSize(payload) + historyEntryByteSize(placeholderEntry)
+
+	// Keep the largest suffix of the conversation that fits, but never fewer than
+	// minRecentHistoryTurns entries (so recent context is preserved).
+	keepFrom := len(conversation)
+	running := baseSize
+	for i := len(conversation) - 1; i >= 0; i-- {
+		running += entrySizes[i]
+		kept := len(conversation) - i
+		if running > maxPayloadBytes && kept > minRecentHistoryTurns {
+			break
+		}
+		keepFrom = i
+	}
+
+	tail := conversation[keepFrom:]
+	tail = dropLeadingAssistant(tail)
+
+	rebuilt := make([]KiroHistoryMessage, 0, len(priming)+1+len(tail))
+	rebuilt = append(rebuilt, priming...)
+	if keepFrom > 0 { // older turns were dropped → note the elision
+		rebuilt = append(rebuilt, placeholderEntry)
+	}
+	rebuilt = append(rebuilt, tail...)
+	payload.ConversationState.History = rebuilt
+
+	// If still too large (current message or retained tail alone exceeds the
+	// limit), shrink the current message content as a last resort.
+	if payloadByteSize(payload) > maxPayloadBytes {
+		truncateCurrentMessage(payload)
+	}
+}
+
+// historyEntryByteSize returns the serialized size of a single history entry,
+// including the surrounding JSON array delimiter overhead (1 byte for the comma).
+func historyEntryByteSize(entry KiroHistoryMessage) int {
+	raw, err := json.Marshal(entry)
+	if err != nil {
+		return 0
+	}
+	return len(raw) + 1
+}
+
+// dropLeadingAssistant removes a leading assistant message from a history tail so
+// it does not directly follow the placeholder user turn with a broken pairing.
+func dropLeadingAssistant(tail []KiroHistoryMessage) []KiroHistoryMessage {
+	for len(tail) > 0 && tail[0].AssistantResponseMessage != nil {
+		tail = tail[1:]
+	}
+	return tail
+}
+
+// payloadByteSize returns the serialized size of the payload in bytes.
+func payloadByteSize(payload *KiroPayload) int {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return 0
+	}
+	return len(raw)
+}
+
+func currentMessageModelID(payload *KiroPayload) string {
+	return payload.ConversationState.CurrentMessage.UserInputMessage.ModelID
+}
+
+// truncateCurrentMessage hard-truncates the current message content as a last
+// resort when even the minimal retained history plus current message exceeds the
+// limit.
+func truncateCurrentMessage(payload *KiroPayload) {
+	cur := &payload.ConversationState.CurrentMessage.UserInputMessage
+	overhead := payloadByteSize(payload) - len(cur.Content)
+	budget := maxPayloadBytes - overhead
+	if budget < 0 {
+		budget = 0
+	}
+	if len(cur.Content) > budget {
+		if budget == 0 {
+			cur.Content = minimalFallbackUserContent
+			return
+		}
+		cur.Content = cur.Content[:budget]
+	}
 }
 
 func buildToolResultsContinuation(toolResults []KiroToolResult) string {
@@ -1489,9 +1897,14 @@ func convertOpenAITools(tools []OpenAITool) []KiroToolWrapper {
 		if len(desc) > maxToolDescLen {
 			desc = desc[:maxToolDescLen] + "..."
 		}
+		name := shortenToolName(tool.Function.Name)
+		if strings.TrimSpace(name) == "" {
+			// Kiro rejects tools with empty names; skip unusable specs.
+			continue
+		}
 		wrapper := KiroToolWrapper{}
-		wrapper.ToolSpecification.Name = shortenToolName(tool.Function.Name)
-		wrapper.ToolSpecification.Description = normalizeToolDesc(desc, wrapper.ToolSpecification.Name)
+		wrapper.ToolSpecification.Name = name
+		wrapper.ToolSpecification.Description = normalizeToolDesc(desc, name)
 		wrapper.ToolSpecification.InputSchema = InputSchema{JSON: ensureObjectSchema(tool.Function.Parameters)}
 		result = append(result, wrapper)
 	}

--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -1530,16 +1530,37 @@ func sanitizeKiroHistory(history []KiroHistoryMessage, currentToolResultIDs map[
 			}
 		}
 
-		// Guard against empty content after flattening (Kiro requires non-empty).
+		// After scrubbing, an assistant turn that held only tool-call text (or
+		// only structured tool calls) is now empty. Do NOT backfill it with a
+		// placeholder like ".": replayed across a long history that produces
+		// dozens of "." assistant turns, which the model then imitates by
+		// replying ".". Mark such turns for removal instead.
 		if msg.UserInputMessage != nil && strings.TrimSpace(msg.UserInputMessage.Content) == "" && len(msg.UserInputMessage.Images) == 0 {
 			msg.UserInputMessage.Content = minimalFallbackUserContent
 		}
-		if msg.AssistantResponseMessage != nil && strings.TrimSpace(msg.AssistantResponseMessage.Content) == "" && len(msg.AssistantResponseMessage.ToolUses) == 0 {
-			msg.AssistantResponseMessage.Content = minimalFallbackUserContent
-		}
 	}
 
-	return history
+	// Second pass: drop assistant turns that carry no real content — either left
+	// empty by scrubbing, or consisting solely of the "." placeholder that an
+	// earlier version emitted (and that a polluted client now replays). Their
+	// tool activity already survives as narrated text in the adjacent user
+	// "Tool results" turn, so removing the hollow assistant turn loses no
+	// information and avoids seeding mimicable empty/"." turns.
+	cleaned := history[:0:0]
+	for i := range history {
+		msg := history[i]
+		if msg.AssistantResponseMessage != nil && len(msg.AssistantResponseMessage.ToolUses) == 0 {
+			c := strings.TrimSpace(msg.AssistantResponseMessage.Content)
+			if c == "" || c == minimalFallbackUserContent {
+				continue // drop hollow assistant turn
+			}
+		}
+		cleaned = append(cleaned, msg)
+	}
+
+	// Dropping hollow assistant turns can leave history starting with an
+	// assistant message; re-trim so it begins with a user turn.
+	return trimLeadingAssistantHistory(cleaned)
 }
 
 // truncatePayloadToLimit drops the oldest conversation history turns until the

--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -1555,6 +1555,20 @@ func sanitizeKiroHistory(history []KiroHistoryMessage, currentToolResultIDs map[
 				continue // drop hollow assistant turn
 			}
 		}
+		// Collapse runs of consecutive identical user "Tool results" turns. A
+		// client stuck in a retry loop (e.g. the same tool error 100+ times)
+		// sends many identical tool results; once the hollow assistant turns
+		// between them are dropped they become adjacent duplicates that waste
+		// context and form a repetitive pattern. Keep one copy of each run.
+		if msg.UserInputMessage != nil && len(cleaned) > 0 {
+			last := cleaned[len(cleaned)-1]
+			if last.UserInputMessage != nil &&
+				strings.TrimSpace(last.UserInputMessage.Content) == strings.TrimSpace(msg.UserInputMessage.Content) &&
+				strings.TrimSpace(msg.UserInputMessage.Content) != "" &&
+				len(msg.UserInputMessage.Images) == 0 {
+				continue // skip duplicate consecutive user turn
+			}
+		}
 		cleaned = append(cleaned, msg)
 	}
 

--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -1147,9 +1147,12 @@ func OpenAIToKiro(req *OpenAIRequest, thinking bool) *KiroPayload {
 			nextIdx := i + 1
 			if nextIdx >= len(nonSystemMessages) || nonSystemMessages[nextIdx].Role != "tool" {
 				if !isLast {
+					// Store the tool results structurally only; sanitizeKiroHistory
+					// narrates them into text exactly once. Pre-filling Content with
+					// buildToolResultsContinuation here would duplicate the output
+					// (continuation text + narrated text).
 					history = append(history, KiroHistoryMessage{
 						UserInputMessage: &KiroUserInputMessage{
-							Content: buildToolResultsContinuation(currentToolResults),
 							ModelID: modelID,
 							Origin:  origin,
 							UserInputMessageContext: &UserInputMessageContext{

--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -1370,6 +1370,27 @@ func currentToolResultsMatchLastAssistant(history []KiroHistoryMessage, currentT
 	return true
 }
 
+// pollutedToolCallTextPattern matches the legacy "[Called tool X with input ...]"
+// / "[Called tool X]" narration that an earlier version of this proxy wrote into
+// assistant turns. Models trained on that in-context text began emitting it as
+// output instead of issuing real tool calls; clients then stored that output as
+// assistant history and replay it, re-seeding the pollution. We strip it from
+// assistant content on the way back upstream so the pattern is not reinforced
+// and the model can recover within an ongoing session.
+var pollutedToolCallTextPattern = regexp.MustCompile(`\[Called tool [^\]]*\]`)
+
+// stripPollutedToolCallText removes legacy tool-call narration from text and
+// tidies up the leftover whitespace.
+func stripPollutedToolCallText(content string) string {
+	if !strings.Contains(content, "[Called tool ") {
+		return content
+	}
+	cleaned := pollutedToolCallTextPattern.ReplaceAllString(content, "")
+	// Collapse blank lines left behind by removed markers.
+	cleaned = regexp.MustCompile(`\n{3,}`).ReplaceAllString(cleaned, "\n\n")
+	return strings.TrimSpace(cleaned)
+}
+
 // narrateToolResults renders structured tool results as plain text for a user
 // history turn. Each result is attributed to its originating tool call (by name)
 // when that mapping is known, so the model retains the tool's identity without
@@ -1472,6 +1493,15 @@ func sanitizeKiroHistory(history []KiroHistoryMessage, currentToolResultIDs map[
 
 	for i := range history {
 		msg := &history[i]
+
+		if msg.AssistantResponseMessage != nil {
+			// Scrub legacy tool-call narration that a polluted client may be
+			// replaying as assistant text, so we neither reinforce the pattern
+			// nor leave it for the model to imitate.
+			if msg.AssistantResponseMessage.Content != "" {
+				msg.AssistantResponseMessage.Content = stripPollutedToolCallText(msg.AssistantResponseMessage.Content)
+			}
+		}
 
 		if msg.AssistantResponseMessage != nil && len(msg.AssistantResponseMessage.ToolUses) > 0 {
 			if i == activeIdx {

--- a/proxy/translator_compaction_test.go
+++ b/proxy/translator_compaction_test.go
@@ -76,6 +76,21 @@ func TestClaudeToKiroFlattensHistoryToolCyclesForCompaction(t *testing.T) {
 	if !strings.Contains(combined, "tests pass") {
 		t.Fatalf("expected narrated tool results to retain output, got:\n%s", combined)
 	}
+
+	// Regression guard: assistant turns must NOT contain tool-invocation-looking
+	// text. Such text trains the model to emit it instead of real tool calls.
+	for i, h := range payload.ConversationState.History {
+		if a := h.AssistantResponseMessage; a != nil {
+			if strings.Contains(a.Content, "[Called tool") {
+				t.Fatalf("history[%d] assistant content contains mimicable tool-invocation text: %q", i, a.Content)
+			}
+		}
+	}
+	// Tool identity must be attributed on the user (result) side, never authored
+	// by the assistant.
+	if !strings.Contains(combined, "[exec_command]") {
+		t.Fatalf("expected tool results to be attributed to exec_command on the user side, got:\n%s", combined)
+	}
 }
 
 // TestClaudeToKiroKeepsActiveToolTurnStructured verifies the in-progress tool

--- a/proxy/translator_compaction_test.go
+++ b/proxy/translator_compaction_test.go
@@ -1,0 +1,118 @@
+package proxy
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestClaudeToKiroFlattensHistoryToolCyclesForCompaction reproduces the context
+// compaction scenario that triggered upstream HTTP 400 "Improperly formed
+// request": a long conversation whose history contains completed tool cycles
+// (assistant tool_use + user tool_result), followed by a plain-text instruction.
+// The generated payload must NOT carry any structured toolUses/toolResults in
+// history, since Kiro's upstream rejects those.
+func TestClaudeToKiroFlattensHistoryToolCyclesForCompaction(t *testing.T) {
+	req := &ClaudeRequest{
+		Model: "claude-opus-4.8",
+		Messages: []ClaudeMessage{
+			{Role: "user", Content: "run the build"},
+			{Role: "assistant", Content: []interface{}{
+				map[string]interface{}{"type": "text", "text": "running build"},
+				map[string]interface{}{"type": "tool_use", "id": "t1", "name": "exec_command", "input": map[string]interface{}{"cmd": "make"}},
+			}},
+			{Role: "user", Content: []interface{}{
+				map[string]interface{}{"type": "tool_result", "tool_use_id": "t1", "content": "build ok"},
+			}},
+			{Role: "assistant", Content: []interface{}{
+				map[string]interface{}{"type": "tool_use", "id": "t2", "name": "exec_command", "input": map[string]interface{}{"cmd": "test"}},
+			}},
+			{Role: "user", Content: []interface{}{
+				map[string]interface{}{"type": "tool_result", "tool_use_id": "t2", "content": "tests pass"},
+			}},
+			// Final plain-text instruction (the compaction request).
+			{Role: "user", Content: "Summarize everything that happened above."},
+		},
+	}
+
+	payload := ClaudeToKiro(req, false)
+
+	// No history entry may carry structured tool calls or tool results.
+	for i, h := range payload.ConversationState.History {
+		if h.AssistantResponseMessage != nil && len(h.AssistantResponseMessage.ToolUses) > 0 {
+			t.Fatalf("history[%d] still has structured toolUses; upstream rejects this", i)
+		}
+		if h.UserInputMessage != nil && h.UserInputMessage.UserInputMessageContext != nil {
+			if len(h.UserInputMessage.UserInputMessageContext.ToolResults) > 0 {
+				t.Fatalf("history[%d] still has structured toolResults; upstream rejects this", i)
+			}
+		}
+	}
+
+	// Current message is plain text, so it must not carry structured tool results.
+	cur := payload.ConversationState.CurrentMessage.UserInputMessage
+	if cur.UserInputMessageContext != nil && len(cur.UserInputMessageContext.ToolResults) > 0 {
+		t.Fatalf("current message should not carry structured toolResults for a plain instruction")
+	}
+	if !strings.Contains(cur.Content, "Summarize everything") {
+		t.Fatalf("expected current content to be the compaction instruction, got %q", cur.Content)
+	}
+
+	// The narrated tool activity should survive somewhere in history as text.
+	var historyText strings.Builder
+	for _, h := range payload.ConversationState.History {
+		if h.AssistantResponseMessage != nil {
+			historyText.WriteString(h.AssistantResponseMessage.Content)
+			historyText.WriteString("\n")
+		}
+		if h.UserInputMessage != nil {
+			historyText.WriteString(h.UserInputMessage.Content)
+			historyText.WriteString("\n")
+		}
+	}
+	combined := historyText.String()
+	if !strings.Contains(combined, "exec_command") {
+		t.Fatalf("expected narrated tool calls to mention exec_command, got:\n%s", combined)
+	}
+	if !strings.Contains(combined, "tests pass") {
+		t.Fatalf("expected narrated tool results to retain output, got:\n%s", combined)
+	}
+}
+
+// TestClaudeToKiroKeepsActiveToolTurnStructured verifies the in-progress tool
+// case still works: the last assistant turn issues a tool_use and the final user
+// message delivers the matching tool_result. That single active turn must remain
+// structured (last history assistant keeps toolUses, current keeps toolResults).
+func TestClaudeToKiroKeepsActiveToolTurnStructured(t *testing.T) {
+	req := &ClaudeRequest{
+		Model: "claude-opus-4.8",
+		Tools: []ClaudeTool{{Name: "exec_command", Description: "run", InputSchema: map[string]interface{}{"type": "object"}}},
+		Messages: []ClaudeMessage{
+			{Role: "user", Content: "run ls"},
+			{Role: "assistant", Content: []interface{}{
+				map[string]interface{}{"type": "tool_use", "id": "t9", "name": "exec_command", "input": map[string]interface{}{"cmd": "ls"}},
+			}},
+			{Role: "user", Content: []interface{}{
+				map[string]interface{}{"type": "tool_result", "tool_use_id": "t9", "content": "file1 file2"},
+			}},
+		},
+	}
+
+	payload := ClaudeToKiro(req, false)
+
+	hist := payload.ConversationState.History
+	if len(hist) == 0 {
+		t.Fatalf("expected non-empty history")
+	}
+	last := hist[len(hist)-1].AssistantResponseMessage
+	if last == nil || len(last.ToolUses) != 1 || last.ToolUses[0].ToolUseID != "t9" {
+		t.Fatalf("expected last history assistant to keep the active structured tool use t9")
+	}
+
+	cur := payload.ConversationState.CurrentMessage.UserInputMessage
+	if cur.UserInputMessageContext == nil || len(cur.UserInputMessageContext.ToolResults) != 1 {
+		t.Fatalf("expected current message to keep the matching structured tool result")
+	}
+	if cur.UserInputMessageContext.ToolResults[0].ToolUseID != "t9" {
+		t.Fatalf("expected current tool result to answer t9, got %q", cur.UserInputMessageContext.ToolResults[0].ToolUseID)
+	}
+}

--- a/proxy/translator_test.go
+++ b/proxy/translator_test.go
@@ -157,24 +157,26 @@ func TestOpenAIToKiroAssistantToolCallsDoNotInjectPlaceholder(t *testing.T) {
 	}
 
 	payload := OpenAIToKiro(req, false)
-	if len(payload.ConversationState.History) < 2 {
-		t.Fatalf("expected history with assistant tool call")
-	}
-	assistant := payload.ConversationState.History[1].AssistantResponseMessage
-	if assistant == nil {
-		t.Fatalf("expected assistant history entry")
-	}
-	// This assistant tool call sits in the middle of history (the conversation
-	// continues with a later user turn), so it is not the active tool turn.
-	// Kiro's upstream rejects structured tool calls buried in history, so its
-	// structured toolUses are cleared. Crucially, NO tool-invocation text is
-	// written into the assistant turn — doing so would train the model to emit
-	// that text instead of issuing real tool calls.
-	if len(assistant.ToolUses) != 0 {
-		t.Fatalf("expected mid-history tool call to be cleared, got %d structured toolUses", len(assistant.ToolUses))
-	}
-	if strings.Contains(assistant.Content, "get_weather") || strings.Contains(assistant.Content, "[Called tool") {
-		t.Fatalf("assistant turn must not contain tool-invocation text, got %q", assistant.Content)
+
+	// The mid-history assistant turn carried ONLY a tool call (no text) and is
+	// not the active tool turn, so its structured toolUses are cleared. That
+	// leaves it hollow, and a hollow assistant turn is dropped entirely rather
+	// than backfilled with a "." placeholder (which the model would imitate).
+	// No surviving turn may contain tool-invocation text or structured toolUses.
+	for i, h := range payload.ConversationState.History {
+		a := h.AssistantResponseMessage
+		if a == nil {
+			continue
+		}
+		if len(a.ToolUses) != 0 {
+			t.Fatalf("history[%d] retains structured toolUses", i)
+		}
+		if strings.Contains(a.Content, "get_weather") || strings.Contains(a.Content, "[Called tool") {
+			t.Fatalf("history[%d] assistant contains tool-invocation text: %q", i, a.Content)
+		}
+		if strings.TrimSpace(a.Content) == "." || strings.TrimSpace(a.Content) == "" {
+			t.Fatalf("history[%d] is a hollow assistant turn that should have been dropped", i)
+		}
 	}
 }
 

--- a/proxy/translator_test.go
+++ b/proxy/translator_test.go
@@ -97,16 +97,17 @@ func TestOpenAIToKiroPreservesStructuredAssistantAndToolContent(t *testing.T) {
 		t.Fatalf("expected assistant structured content to be preserved, got %q", historyAssistant.Content)
 	}
 
+	// The tool result answers call_1, but the last history assistant has no
+	// matching structured tool call (it is text-only), so the tool result is an
+	// orphan. Kiro's upstream rejects structured tool results that do not answer
+	// the immediately preceding assistant tool call, so it must be narrated into
+	// the current message text rather than kept structured.
 	cur := payload.ConversationState.CurrentMessage.UserInputMessage
 	if !strings.Contains(cur.Content, "tool-result-structured") {
 		t.Fatalf("expected tool-result continuation content, got %q", cur.Content)
 	}
-	if cur.UserInputMessageContext == nil || len(cur.UserInputMessageContext.ToolResults) != 1 {
-		t.Fatalf("expected one tool result in current context")
-	}
-	gotToolText := cur.UserInputMessageContext.ToolResults[0].Content[0].Text
-	if gotToolText != "tool-result-structured" {
-		t.Fatalf("expected structured tool result text, got %q", gotToolText)
+	if cur.UserInputMessageContext != nil && len(cur.UserInputMessageContext.ToolResults) != 0 {
+		t.Fatalf("expected orphan tool result to be flattened into text, not kept structured")
 	}
 }
 
@@ -163,8 +164,15 @@ func TestOpenAIToKiroAssistantToolCallsDoNotInjectPlaceholder(t *testing.T) {
 	if assistant == nil {
 		t.Fatalf("expected assistant history entry")
 	}
-	if assistant.Content != "" {
-		t.Fatalf("expected empty assistant content for tool-call-only turn, got %q", assistant.Content)
+	// This assistant tool call sits in the middle of history (the conversation
+	// continues with a later user turn), so it is not the active tool turn.
+	// Kiro's upstream rejects structured tool calls buried in history, so it is
+	// narrated as text and the structured toolUses are cleared.
+	if len(assistant.ToolUses) != 0 {
+		t.Fatalf("expected mid-history tool call to be flattened, got %d structured toolUses", len(assistant.ToolUses))
+	}
+	if !strings.Contains(assistant.Content, "get_weather") {
+		t.Fatalf("expected narrated tool call to mention tool name, got %q", assistant.Content)
 	}
 }
 

--- a/proxy/translator_test.go
+++ b/proxy/translator_test.go
@@ -166,13 +166,15 @@ func TestOpenAIToKiroAssistantToolCallsDoNotInjectPlaceholder(t *testing.T) {
 	}
 	// This assistant tool call sits in the middle of history (the conversation
 	// continues with a later user turn), so it is not the active tool turn.
-	// Kiro's upstream rejects structured tool calls buried in history, so it is
-	// narrated as text and the structured toolUses are cleared.
+	// Kiro's upstream rejects structured tool calls buried in history, so its
+	// structured toolUses are cleared. Crucially, NO tool-invocation text is
+	// written into the assistant turn — doing so would train the model to emit
+	// that text instead of issuing real tool calls.
 	if len(assistant.ToolUses) != 0 {
-		t.Fatalf("expected mid-history tool call to be flattened, got %d structured toolUses", len(assistant.ToolUses))
+		t.Fatalf("expected mid-history tool call to be cleared, got %d structured toolUses", len(assistant.ToolUses))
 	}
-	if !strings.Contains(assistant.Content, "get_weather") {
-		t.Fatalf("expected narrated tool call to mention tool name, got %q", assistant.Content)
+	if strings.Contains(assistant.Content, "get_weather") || strings.Contains(assistant.Content, "[Called tool") {
+		t.Fatalf("assistant turn must not contain tool-invocation text, got %q", assistant.Content)
 	}
 }
 

--- a/proxy/translator_truncate_test.go
+++ b/proxy/translator_truncate_test.go
@@ -1,0 +1,97 @@
+package proxy
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestClaudeToKiroTruncatesOversizedHistory builds a conversation whose history
+// far exceeds the upstream input limit and verifies the converted payload is
+// trimmed below maxPayloadBytes, that a truncation placeholder is inserted, and
+// that the current message is preserved.
+func TestClaudeToKiroTruncatesOversizedHistory(t *testing.T) {
+	// ~2KB chunk repeated across many turns to blow past the byte limit.
+	big := strings.Repeat("lorem ipsum dolor sit amet ", 80) // ~2.1KB
+
+	msgs := []ClaudeMessage{
+		{Role: "user", Content: "start the long task"},
+	}
+	for i := 0; i < 800; i++ {
+		msgs = append(msgs,
+			ClaudeMessage{Role: "assistant", Content: "step result: " + big},
+			ClaudeMessage{Role: "user", Content: "next: " + big},
+		)
+	}
+	msgs = append(msgs, ClaudeMessage{Role: "user", Content: "FINAL: summarize everything above"})
+
+	req := &ClaudeRequest{
+		Model:    "claude-opus-4.8",
+		System:   "You are a helpful assistant.",
+		Messages: msgs,
+	}
+
+	payload := ClaudeToKiro(req, false)
+
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	if len(raw) > maxPayloadBytes {
+		t.Fatalf("payload size %d exceeds limit %d after truncation", len(raw), maxPayloadBytes)
+	}
+
+	// The current message must be preserved.
+	cur := payload.ConversationState.CurrentMessage.UserInputMessage
+	if !strings.Contains(cur.Content, "FINAL: summarize everything above") {
+		t.Fatalf("current message lost after truncation, got %q", cur.Content[:min(80, len(cur.Content))])
+	}
+
+	// A truncation placeholder must be present in history.
+	foundPlaceholder := false
+	for _, h := range payload.ConversationState.History {
+		if h.UserInputMessage != nil && strings.Contains(h.UserInputMessage.Content, "truncated to fit") {
+			foundPlaceholder = true
+			break
+		}
+	}
+	if !foundPlaceholder {
+		t.Fatalf("expected a truncation placeholder in history")
+	}
+
+	// System priming should still be at the front.
+	if len(payload.ConversationState.History) < 2 {
+		t.Fatalf("expected priming retained, history too short")
+	}
+	primingUser := payload.ConversationState.History[0].UserInputMessage
+	if primingUser == nil || !strings.Contains(primingUser.Content, "helpful assistant") {
+		t.Fatalf("expected system priming retained at front")
+	}
+}
+
+// TestClaudeToKiroSmallPayloadNotTruncated ensures normal-sized conversations
+// are left untouched (no placeholder inserted).
+func TestClaudeToKiroSmallPayloadNotTruncated(t *testing.T) {
+	req := &ClaudeRequest{
+		Model:  "claude-opus-4.8",
+		System: "You are helpful.",
+		Messages: []ClaudeMessage{
+			{Role: "user", Content: "hello"},
+			{Role: "assistant", Content: "hi"},
+			{Role: "user", Content: "how are you?"},
+		},
+	}
+	payload := ClaudeToKiro(req, false)
+	for _, h := range payload.ConversationState.History {
+		if h.UserInputMessage != nil && strings.Contains(h.UserInputMessage.Content, "truncated to fit") {
+			t.Fatalf("small payload should not be truncated")
+		}
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
## 背景

在长时间运行的 agent 会话中（尤其经 `/v1/responses`、`/v1/chat/completions`、`/v1/messages` 接入的 Codex / Claude Code 等客户端），代理会反复收到上游 HTTP 400（`Improperly formed request`、`CONTENT_LENGTH_EXCEEDS_THRESHOLD`），三个端点轮流失败形成重试循环；并伴随 token 计数偏小、模型行为被历史污染等问题。本 PR 通过真实接口逐项定位，系统性修复了工具调用转换、历史归一化、token 计数与上下文体积控制等一系列问题。

> 本 PR 是对此前 #99、#100 的整合与扩展。

## 修复内容

### 1. 历史携带结构化工具调用 → `Improperly formed request`
Kiro 上游不接受 `history` 中携带结构化 `toolUses` / `toolResults`。新增 `sanitizeKiroHistory`，仅保留「最后一条 assistant 的 `toolUses` ⟺ 当前消息 `toolResults`」这一活跃工具轮次为结构化，其余清除结构化字段。

### 2. `/v1/responses` 扁平工具结构导致工具名为空 → `Improperly formed request`
Responses API 工具为 `name`/`description`/`parameters` 顶层结构，旧代码按 Chat Completions 的嵌套 `function` 结构解析，工具名变空。为 `OpenAITool` 增加自定义 `UnmarshalJSON`，兼容扁平与嵌套两种格式；`convertOpenAITools` 跳过空名工具规范。

### 3. opus-4.8 上下文窗口误判 → `input_tokens` 少报约 5 倍
`getContextWindowSize` 仅识别 `4.6`/`4.7` 为 1M，`opus-4.8` 落到 200K 默认值，导致客户端无法及时触发上下文压缩。改为按版本号判定：Claude 4.6 及以后为 1M，4.5 及以前为 200K。

### 4. 并行工具调用被拆散 → 工具配对断裂
Responses API 中每个并行 `function_call` 为独立输入项，旧代码各自生成单独的 assistant 消息。`convertResponsesInputItems` 现在合并连续 `function_call` 到同一条 assistant 消息。

### 5. 超长 payload → `CONTENT_LENGTH_EXCEEDS_THRESHOLD`
新增 `truncatePayloadToLimit`：超过阈值时从最旧历史开始丢弃，保留系统 priming、最近若干轮与当前消息，并插入截断占位提示；极端情况下再裁剪当前消息内容。

### 6. `/v1/chat/completions` 历史工具结果文本重复
非末尾工具结果历史条目此前同时写入 `buildToolResultsContinuation` 文本与结构化 `ToolResults`，叠加 `sanitizeKiroHistory` 的叙述导致输出出现两遍。改为仅保留结构化结果，由 `sanitizeKiroHistory` 统一叙述一次。

### 7. 历史工具调用叙述污染模型行为（few-shot 污染）
此前将历史工具调用扁平化为 assistant turn 内的 `[Called tool X with input ...]` 文本，模型在上下文中看到大量该示例后开始直接输出该文本而非发起真实工具调用。改为：非活跃工具调用只清除结构化字段、不向 assistant turn 注入任何工具调用文本；工具结果在 user `Tool results` turn 中以 `[工具名]` 前缀归属（user turn 模型只读不写，无可模仿模式）。

### 8. 清洗客户端回放的历史工具调用文本
模型在污染下输出的 `[Called tool ...]` 文本被客户端存入历史并回放，持续给模型示范错误模式。`sanitizeKiroHistory` 现在用正则剥离 assistant turn 中遗留的该文本（保留周围自然语言），打破污染循环、令进行中的会话能恢复。

### 9. 丢弃空洞/`.` 占位的历史 assistant 回合
清洗后仅含工具调用文本的 assistant turn 变空，旧逻辑回填为 `.`，长历史中堆出大量 `.` 回合又被模型模仿。改为直接丢弃清洗后变空或本就是 `.` 占位的无内容 assistant 回合（工具活动已在相邻 user 回合保留），并在丢弃后重新裁掉前导 assistant 回合保持历史以 user 开头。

### 10. 合并相邻重复的工具结果回合
客户端重试循环会发送大量相同工具结果；丢弃中间空洞 assistant 回合后它们变为相邻重复。`sanitizeKiroHistory` 将连续完全相同的 user 回合合并为一条（仅合并相邻完全相同者，不触碰被有效 assistant 文本分隔的非相邻回合）。

## 测试

- 新增：`context_window_test`、`openai_tool_format_test`、`responses_parallel_test`、`translator_compaction_test`、`translator_truncate_test`、`openai_toolresult_dedup_test`、`tool_narration_pollution_test`
- 更新：`translator_test` 中相关用例至修复后的正确行为
- `go build ./...`、`go vet ./proxy/`、`gofmt -l` 均通过
- `go test ./...` 通过（不含既有不稳定的 `TestResponsesStreamSSE` 临时目录清理竞态，与本 PR 无关）
- 已用真实账号通过本地容器对三个上游端点逐项验证修复前后 200/400 行为，并在实时流量下确认历史无污染、无重复、无上游报错

## 影响范围

仅改动 `proxy/` 下的转换、解析与历史归一化逻辑，不涉及账号、配置或网络层。
