### PR TITLE
fix: extract images from tool_result content blocks

### DIFF
--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -43,6 +43,7 @@ const ThinkingModePrompt = `<thinking_mode>enabled</thinking_mode>
 
 const minimalFallbackUserContent = "."
 const toolResultsContinuationPrefix = "Tool results:"
+const toolResultImagePlaceholder = "[Tool returned an image; the image is attached to this message.]"
 
 // ParseModelAndThinking resolves a client-supplied model name to a Kiro model ID
 // and reports whether thinking mode was requested via the configured suffix.
@@ -602,7 +603,13 @@ func extractClaudeUserContent(content interface{}) (string, []KiroImage, []KiroT
 				}
 			case "tool_result":
 				toolUseID, _ := block["tool_use_id"].(string)
-				resultContent := extractToolResultContent(block["content"])
+				resultContent, resultImages := extractToolResultContent(block["content"])
+				if len(resultImages) > 0 {
+					images = append(images, resultImages...)
+					if strings.TrimSpace(resultContent) == "" {
+						resultContent = toolResultImagePlaceholder
+					}
+				}
 				toolResults = append(toolResults, KiroToolResult{
 					ToolUseID: toolUseID,
 					Content:   []KiroResultContent{{Text: resultContent}},
@@ -653,22 +660,37 @@ func extractImageFromClaudeBlock(block map[string]interface{}) *KiroImage {
 	return nil
 }
 
-func extractToolResultContent(content interface{}) string {
+func extractToolResultContent(content interface{}) (string, []KiroImage) {
 	if s, ok := content.(string); ok {
-		return s
+		return s, nil
 	}
 	if blocks, ok := content.([]interface{}); ok {
 		var parts []string
+		var images []KiroImage
 		for _, b := range blocks {
-			if block, ok := b.(map[string]interface{}); ok {
-				if text, ok := block["text"].(string); ok {
-					parts = append(parts, text)
+			block, ok := b.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			blockType, _ := block["type"].(string)
+			switch blockType {
+			case "image", "image_url", "input_image":
+				if img := extractImageFromClaudeBlock(block); img != nil {
+					images = append(images, *img)
+					continue
 				}
 			}
+			if text, ok := block["text"].(string); ok {
+				parts = append(parts, text)
+				continue
+			}
+			if img := extractImageFromClaudeBlock(block); img != nil {
+				images = append(images, *img)
+			}
 		}
-		return strings.Join(parts, "")
+		return strings.Join(parts, ""), images
 	}
-	return ""
+	return "", nil
 }
 
 func extractClaudeAssistantContent(content interface{}) (string, []KiroToolUse) {
@@ -1046,7 +1068,17 @@ func OpenAIToKiro(req *OpenAIRequest, thinking bool) *KiroPayload {
 			})
 
 		case "tool":
-			content := extractOpenAIMessageText(msg.Content)
+			cleanText, toolImages := extractOpenAIUserContent(msg.Content)
+			var content string
+			if len(toolImages) > 0 {
+				currentImages = append(currentImages, toolImages...)
+				content = strings.TrimSpace(cleanText)
+				if content == "" {
+					content = toolResultImagePlaceholder
+				}
+			} else {
+				content = extractOpenAIMessageText(msg.Content)
+			}
 			currentToolResults = append(currentToolResults, KiroToolResult{
 				ToolUseID: msg.ToolCallID,
 				Content:   []KiroResultContent{{Text: content}},

--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -1094,12 +1094,14 @@ func OpenAIToKiro(req *OpenAIRequest, thinking bool) *KiroPayload {
 							Content: buildToolResultsContinuation(currentToolResults),
 							ModelID: modelID,
 							Origin:  origin,
+							Images:  currentImages,
 							UserInputMessageContext: &UserInputMessageContext{
 								ToolResults: currentToolResults,
 							},
 						},
 					})
 					currentToolResults = nil
+					currentImages = nil
 				}
 			}
 		}

--- a/proxy/translator_test.go
+++ b/proxy/translator_test.go
@@ -458,3 +458,124 @@ func TestParseModelAndThinkingDoesNotRewriteDatedSnapshotMinor(t *testing.T) {
 		t.Fatalf("dated snapshot must not be rewritten with a dot, got %q", got)
 	}
 }
+
+func TestClaudeToolResultImageAttachedToCurrentMessage(t *testing.T) {
+	const imgData = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+	req := &ClaudeRequest{
+		Model: "claude-opus-4.8",
+		Messages: []ClaudeMessage{
+			{Role: "user", Content: "read this image"},
+			{
+				Role: "assistant",
+				Content: []interface{}{
+					map[string]interface{}{"type": "tool_use", "id": "tool_1", "name": "read", "input": map[string]interface{}{"path": "a.png"}},
+				},
+			},
+			{
+				Role: "user",
+				Content: []interface{}{
+					map[string]interface{}{
+						"type":        "tool_result",
+						"tool_use_id": "tool_1",
+						"content": []interface{}{
+							map[string]interface{}{
+								"type": "image",
+								"source": map[string]interface{}{
+									"type":       "base64",
+									"media_type": "image/png",
+									"data":       imgData,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	payload := ClaudeToKiro(req, false)
+	cur := payload.ConversationState.CurrentMessage.UserInputMessage
+	if len(cur.Images) != 1 {
+		t.Fatalf("expected tool_result image attached to current message, got %d images", len(cur.Images))
+	}
+	if cur.Images[0].Format != "png" || cur.Images[0].Source.Bytes != imgData {
+		t.Fatalf("unexpected image payload: %+v", cur.Images[0])
+	}
+	if cur.UserInputMessageContext == nil || len(cur.UserInputMessageContext.ToolResults) != 1 {
+		t.Fatalf("expected one tool result preserved")
+	}
+	if strings.TrimSpace(cur.UserInputMessageContext.ToolResults[0].Content[0].Text) == "" {
+		t.Fatalf("expected non-empty placeholder text for image-only tool result")
+	}
+}
+
+func TestClaudeToolResultMixedTextAndImage(t *testing.T) {
+	const imgData = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+	req := &ClaudeRequest{
+		Model: "claude-opus-4.8",
+		Messages: []ClaudeMessage{
+			{
+				Role: "user",
+				Content: []interface{}{
+					map[string]interface{}{
+						"type":        "tool_result",
+						"tool_use_id": "tool_2",
+						"content": []interface{}{
+							map[string]interface{}{"type": "text", "text": "here is the screenshot"},
+							map[string]interface{}{
+								"type": "image",
+								"source": map[string]interface{}{
+									"type":       "base64",
+									"media_type": "image/png",
+									"data":       imgData,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	payload := ClaudeToKiro(req, false)
+	cur := payload.ConversationState.CurrentMessage.UserInputMessage
+	if len(cur.Images) != 1 {
+		t.Fatalf("expected one image extracted, got %d", len(cur.Images))
+	}
+	if cur.UserInputMessageContext == nil || len(cur.UserInputMessageContext.ToolResults) != 1 {
+		t.Fatalf("expected one tool result")
+	}
+	gotText := cur.UserInputMessageContext.ToolResults[0].Content[0].Text
+	if gotText != "here is the screenshot" {
+		t.Fatalf("expected original tool text preserved, got %q", gotText)
+	}
+}
+
+func TestOpenAIToolResultImageAttachedToCurrentMessage(t *testing.T) {
+	const dataURL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+	req := &OpenAIRequest{
+		Model: "claude-sonnet-4.5",
+		Messages: []OpenAIMessage{
+			{Role: "user", Content: "look at the file"},
+			{
+				Role:       "tool",
+				ToolCallID: "call_img",
+				Content: []interface{}{
+					map[string]interface{}{
+						"type":      "image_url",
+						"image_url": map[string]interface{}{"url": dataURL},
+					},
+				},
+			},
+		},
+	}
+
+	payload := OpenAIToKiro(req, false)
+	cur := payload.ConversationState.CurrentMessage.UserInputMessage
+	if len(cur.Images) != 1 {
+		t.Fatalf("expected tool image attached to current message, got %d", len(cur.Images))
+	}
+	if cur.Images[0].Format != "png" {
+		t.Fatalf("expected png format, got %q", cur.Images[0].Format)
+	}
+}

--- a/proxy/translator_test.go
+++ b/proxy/translator_test.go
@@ -579,3 +579,52 @@ func TestOpenAIToolResultImageAttachedToCurrentMessage(t *testing.T) {
 		t.Fatalf("expected png format, got %q", cur.Images[0].Format)
 	}
 }
+
+func TestOpenAIToolResultImageCarriedWhenFollowedByUser(t *testing.T) {
+	const dataURL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+	req := &OpenAIRequest{
+		Model: "claude-sonnet-4.5",
+		Messages: []OpenAIMessage{
+			{Role: "user", Content: "look at the file"},
+			{
+				Role: "assistant",
+				ToolCalls: []ToolCall{
+					{
+						ID:   "call_img",
+						Type: "function",
+						Function: struct {
+							Name      string `json:"name"`
+							Arguments string `json:"arguments"`
+						}{Name: "read", Arguments: `{"path":"a.png"}`},
+					},
+				},
+			},
+			{
+				Role:       "tool",
+				ToolCallID: "call_img",
+				Content: []interface{}{
+					map[string]interface{}{"type": "image_url", "image_url": map[string]interface{}{"url": dataURL}},
+				},
+			},
+			{Role: "user", Content: "what do you see?"},
+		},
+	}
+
+	payload := OpenAIToKiro(req, false)
+
+	var toolHistImages int
+	for _, h := range payload.ConversationState.History {
+		if h.UserInputMessage != nil && h.UserInputMessage.UserInputMessageContext != nil &&
+			len(h.UserInputMessage.UserInputMessageContext.ToolResults) > 0 {
+			toolHistImages += len(h.UserInputMessage.Images)
+		}
+	}
+	if toolHistImages != 1 {
+		t.Fatalf("expected tool image carried on the flushed tool-result history entry, got %d", toolHistImages)
+	}
+
+	cur := payload.ConversationState.CurrentMessage.UserInputMessage
+	if len(cur.Images) != 0 {
+		t.Fatalf("tool image should not leak into a later user message, got %d on current", len(cur.Images))
+	}
+}


### PR DESCRIPTION
## 背景

修复 #105：使用 `read` 工具读取图片时返回空,但剪贴板粘贴图片可正常读取。

## 根因

Claude Code 的 `read` 工具读取图片时,图片数据作为 `image` 子块嵌在 `tool_result` 块的 `content` 数组里。`extractToolResultContent`(`proxy/translator.go`)只提取 `text` 子块,直接丢弃了 `image` 子块,导致图片数据在转换为 Kiro payload 时丢失,模型收到空内容。

剪贴板粘贴能工作,是因为图片是顶层 `image` 块,走 `extractImageFromClaudeBlock` 进入了用户消息的 `Images` 字段。该问题与系统提示替换、环境噪音过滤等选项无关。

## 改动

`KiroToolResult.Content` 仅支持纯文本,无法承载图片,因此将 tool_result 中的图片提取出来,附加到用户消息的 `Images` 字段(与剪贴板路径走同一通道):

- `extractToolResultContent` 改为同时返回提取到的图片,识别 `image` / `image_url` / `input_image` 子块。
- Claude 路径的 `tool_result` 分支把提取的图片并入消息 `images`;若无文本则填占位文本,避免内容为空。
- OpenAI 侧 `tool` 角色消息同样处理(复用 `extractOpenAIUserContent`),顺带修掉了原先纯图片 tool 消息会把 base64 整块塞进文本的隐患。

## 测试

- 新增三个回归测试:Claude 纯图片、Claude 图文混合、OpenAI 图片 tool_result。
- `go build ./...` 与 `go test ./...` 全部通过。