### PR TITLE
Fix profile ARN resolution before account refresh calls

### DIFF
--- a/proxy/kiro_api.go
+++ b/proxy/kiro_api.go
@@ -19,6 +19,10 @@ const (
 
 // GetUsageLimits 获取账户使用量和订阅信息
 func GetUsageLimits(account *config.Account) (*UsageLimitsResponse, error) {
+	if err := ensureRestProfileArn(account); err != nil {
+		return nil, fmt.Errorf("resolve profileArn: %w", err)
+	}
+
 	url := fmt.Sprintf("%s/getUsageLimits?origin=AI_EDITOR&resourceType=AGENTIC_REQUEST&isEmailRequired=true", kiroRestAPIBase)
 	url = withProfileArnQuery(url, account)
 
@@ -80,6 +84,10 @@ func GetUserInfo(account *config.Account) (*UserInfoResponse, error) {
 
 // ListAvailableModels 获取可用模型列表
 func ListAvailableModels(account *config.Account) ([]ModelInfo, error) {
+	if err := ensureRestProfileArn(account); err != nil {
+		return nil, fmt.Errorf("resolve profileArn: %w", err)
+	}
+
 	url := fmt.Sprintf("%s/ListAvailableModels?origin=AI_EDITOR&maxResults=50", kiroRestAPIBase)
 	url = withProfileArnQuery(url, account)
 
@@ -144,6 +152,18 @@ func ResolveProfileArn(account *config.Account) (string, error) {
 	}
 
 	return "", fmt.Errorf("no available Kiro profile")
+}
+
+func ensureRestProfileArn(account *config.Account) error {
+	if account == nil || strings.TrimSpace(account.ProfileArn) != "" {
+		return nil
+	}
+	profileArn, err := ResolveProfileArn(account)
+	if err != nil {
+		return err
+	}
+	account.ProfileArn = profileArn
+	return nil
 }
 
 func listAvailableProfilesWithRetry(account *config.Account) (string, error) {


### PR DESCRIPTION
## What changed

This resolves the account profile ARN before calling REST endpoints that require it, including `getUsageLimits` and `ListAvailableModels`.

## Why

Some refreshed credentials return a valid access token but do not include `profileArn` in the refresh response. The streaming path already resolves the profile ARN before sending messages, but the REST refresh/model-list paths could call AWS without it and receive:

`HTTP 403: {"message":"User is not authorized to make this call.","reason":null}`

That can make a healthy account look unauthorized during admin refresh/model refresh.

## Validation

- Reproduced with a credential whose token refresh returns no `profileArn`.
- Confirmed `getUsageLimits` and `ListAvailableModels` return 403 without `profileArn`.
- Confirmed both return 200 after resolving and attaching `profileArn`.