### PR TITLE
fix: suppress unsupported BuilderId profile lookup

### DIFF
--- a/proxy/kiro.go
+++ b/proxy/kiro.go
@@ -325,12 +325,10 @@ func CallKiroAPI(account *config.Account, payload *KiroPayload, callback *KiroSt
 	if payload != nil && strings.TrimSpace(payload.ProfileArn) == "" {
 		if profileArn, err := ResolveProfileArn(account); err == nil {
 			payload.ProfileArn = profileArn
+		} else if isProfileArnResolutionSoftError(err) {
+			logger.Debugf("[ProfileArn] Skipped profile ARN resolution for %s: %v", accountEmailForLog(account), err)
 		} else {
-			accountEmail := "<nil>"
-			if account != nil {
-				accountEmail = account.Email
-			}
-			logger.Warnf("[ProfileArn] Failed to resolve profile ARN for %s: %v", accountEmail, err)
+			logger.Warnf("[ProfileArn] Failed to resolve profile ARN for %s: %v", accountEmailForLog(account), err)
 		}
 	}
 
@@ -404,6 +402,13 @@ func CallKiroAPI(account *config.Account, payload *KiroPayload, callback *KiroSt
 		return lastErr
 	}
 	return fmt.Errorf("all endpoints failed")
+}
+
+func accountEmailForLog(account *config.Account) string {
+	if account == nil {
+		return "<nil>"
+	}
+	return account.Email
 }
 
 // ==================== Event Stream Parsing ====================

--- a/proxy/kiro_api.go
+++ b/proxy/kiro_api.go
@@ -10,12 +10,16 @@ import (
 	"net/http"
 	neturl "net/url"
 	"strings"
+	"sync"
 	"time"
 )
 
 const (
-	kiroRestAPIBase = "https://codewhisperer.us-east-1.amazonaws.com"
+	kiroRestAPIBase               = "https://codewhisperer.us-east-1.amazonaws.com"
+	profileArnUnsupportedCooldown = 24 * time.Hour
 )
+
+var profileArnResolutionCooldowns sync.Map
 
 // kiroRegion returns the AWS region the account's Kiro profile lives in,
 // defaulting to us-east-1 when unset. AWS provisions Kiro / Q Developer
@@ -162,14 +166,22 @@ func ResolveProfileArn(account *config.Account) (string, error) {
 		return profileArn, nil
 	}
 
-	// Try ListAvailableProfiles first, retrying on transient failures.
-	profileArn, err := listAvailableProfilesWithRetry(account)
-	if err == nil && profileArn != "" {
-		if updateErr := config.UpdateAccountProfileArn(account.ID, profileArn); updateErr != nil {
-			logger.Warnf("[ProfileArn] Failed to cache profile ARN for %s: %v", account.Email, updateErr)
+	profileLookupSuppressed := isProfileArnResolutionSuppressed(account)
+	var profileUnsupportedErr error
+	var profileUnsupported bool
+
+	if !profileLookupSuppressed {
+		// Try ListAvailableProfiles first, retrying on transient failures.
+		profileArn, err := listAvailableProfilesWithRetry(account)
+		if err == nil && profileArn != "" {
+			if updateErr := config.UpdateAccountProfileArn(account.ID, profileArn); updateErr != nil {
+				logger.Warnf("[ProfileArn] Failed to cache profile ARN for %s: %v", account.Email, updateErr)
+			}
+			account.ProfileArn = profileArn
+			return profileArn, nil
 		}
-		account.ProfileArn = profileArn
-		return profileArn, nil
+		profileUnsupportedErr = err
+		profileUnsupported = isBuilderIDProfileUnsupportedError(account, err)
 	}
 
 	// Fallback: refresh token to get profileArn from auth response
@@ -183,8 +195,78 @@ func ResolveProfileArn(account *config.Account) (string, error) {
 			return refreshedArn, nil
 		}
 	}
+	if profileLookupSuppressed {
+		return "", fmt.Errorf("profile ARN resolution skipped: previous Builder ID profile lookup was unsupported")
+	}
+	if profileUnsupported {
+		suppressProfileArnResolution(account)
+		logger.Debugf("[ProfileArn] Builder ID profile lookup unsupported for %s: %v", accountEmailForLog(account), profileUnsupportedErr)
+		return "", fmt.Errorf("profile ARN unsupported for Builder ID account")
+	}
 
 	return "", fmt.Errorf("no available Kiro profile")
+}
+
+func isBuilderIDProfileUnsupportedError(account *config.Account, err error) bool {
+	if account == nil || err == nil {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(account.Provider), "BuilderId") {
+		return false
+	}
+	msg := err.Error()
+	return strings.HasPrefix(msg, "HTTP 403") && strings.Contains(msg, "AWS Builder ID is not supported for this operation")
+}
+
+func profileArnCooldownKey(account *config.Account) string {
+	if account == nil {
+		return ""
+	}
+	provider := strings.TrimSpace(account.Provider)
+	if id := strings.TrimSpace(account.ID); id != "" {
+		return provider + "\x00" + id
+	}
+	if userID := strings.TrimSpace(account.UserId); userID != "" {
+		return provider + "\x00" + userID
+	}
+	return provider + "\x00" + strings.TrimSpace(account.Email)
+}
+
+func suppressProfileArnResolution(account *config.Account) {
+	key := profileArnCooldownKey(account)
+	if key == "" {
+		return
+	}
+	profileArnResolutionCooldowns.Store(key, time.Now().Add(profileArnUnsupportedCooldown))
+}
+
+func isProfileArnResolutionSuppressed(account *config.Account) bool {
+	key := profileArnCooldownKey(account)
+	if key == "" {
+		return false
+	}
+	value, ok := profileArnResolutionCooldowns.Load(key)
+	if !ok {
+		return false
+	}
+	until, ok := value.(time.Time)
+	if !ok || time.Now().After(until) {
+		profileArnResolutionCooldowns.Delete(key)
+		return false
+	}
+	return true
+}
+
+func isProfileArnResolutionSkippedError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "profile ARN resolution skipped")
+}
+
+func isProfileArnResolutionUnsupportedError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "profile ARN unsupported for Builder ID account")
+}
+
+func isProfileArnResolutionSoftError(err error) bool {
+	return isProfileArnResolutionSkippedError(err) || isProfileArnResolutionUnsupportedError(err)
 }
 
 func ensureRestProfileArn(account *config.Account) error {
@@ -193,6 +275,10 @@ func ensureRestProfileArn(account *config.Account) error {
 	}
 	profileArn, err := ResolveProfileArn(account)
 	if err != nil {
+		if isProfileArnResolutionSoftError(err) {
+			logger.Debugf("[ProfileArn] Continuing REST request without profile ARN for %s: %v", accountEmailForLog(account), err)
+			return nil
+		}
 		return err
 	}
 	account.ProfileArn = profileArn

--- a/proxy/kiro_api_test.go
+++ b/proxy/kiro_api_test.go
@@ -2,10 +2,13 @@ package proxy
 
 import (
 	"io"
+	"kiro-go/auth"
 	"kiro-go/config"
 	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -87,6 +90,177 @@ func TestResolveProfileArnFetchesAndCachesProfile(t *testing.T) {
 	if accounts[0].UsageCurrent != 7 {
 		t.Fatalf("expected profile cache update to preserve usage fields, got usageCurrent=%v", accounts[0].UsageCurrent)
 	}
+}
+
+func TestResolveProfileArnSuppressesBuilderIDUnsupportedLookup(t *testing.T) {
+	clearProfileArnResolutionCooldowns()
+	t.Cleanup(clearProfileArnResolutionCooldowns)
+
+	var calls int32
+	kiroRestHttpStore.Store(&http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			atomic.AddInt32(&calls, 1)
+			if req.URL.Path != "/ListAvailableProfiles" {
+				t.Fatalf("expected ListAvailableProfiles path, got %s", req.URL.Path)
+			}
+			return &http.Response{
+				StatusCode: http.StatusForbidden,
+				Body:       io.NopCloser(strings.NewReader(`{"message":"AWS Builder ID is not supported for this operation.","reason":null}`)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	})
+	t.Cleanup(func() { InitKiroHttpClient("") })
+
+	account := &config.Account{
+		ID:          "builder-1",
+		Email:       "builder@example.com",
+		AccessToken: "access-token",
+		Provider:    "BuilderId",
+		Region:      "us-east-1",
+	}
+
+	_, err := ResolveProfileArn(account)
+	if err == nil || !isProfileArnResolutionUnsupportedError(err) {
+		t.Fatalf("expected Builder ID unsupported error, got %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("expected one profile lookup, got %d", got)
+	}
+
+	_, err = ResolveProfileArn(account)
+	if err == nil || !isProfileArnResolutionSkippedError(err) {
+		t.Fatalf("expected skipped profile ARN resolution error, got %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("expected no repeated profile lookup after suppression, got %d", got)
+	}
+}
+
+func TestResolveProfileArnKeepsRefreshFallbackForBuilderIDUnsupportedLookup(t *testing.T) {
+	clearProfileArnResolutionCooldowns()
+	t.Cleanup(clearProfileArnResolutionCooldowns)
+
+	kiroRestHttpStore.Store(&http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusForbidden,
+				Body:       io.NopCloser(strings.NewReader(`{"message":"AWS Builder ID is not supported for this operation.","reason":null}`)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	})
+	t.Cleanup(func() { InitKiroHttpClient("") })
+
+	authServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"accessToken":"new-access","refreshToken":"new-refresh","expiresIn":3600,"profileArn":"arn:aws:codewhisperer:profile/from-refresh"}`))
+	}))
+	t.Cleanup(authServer.Close)
+
+	oldTokenURL := auth.GetOIDCTokenURLForTest()
+	auth.SetOIDCTokenURLForTest(func(string) string { return authServer.URL })
+	t.Cleanup(func() { auth.SetOIDCTokenURLForTest(oldTokenURL) })
+	oldAuthClient := auth.SetGlobalAuthClientForTest(authServer.Client())
+	t.Cleanup(func() { auth.SetGlobalAuthClientForTest(oldAuthClient) })
+
+	account := &config.Account{
+		ID:           "builder-refresh-1",
+		Email:        "builder@example.com",
+		AccessToken:  "access-token",
+		RefreshToken: "refresh-token",
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		AuthMethod:   "idc",
+		Provider:     "BuilderId",
+		Region:       "us-east-1",
+	}
+
+	got, err := ResolveProfileArn(account)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "arn:aws:codewhisperer:profile/from-refresh" {
+		t.Fatalf("expected refresh fallback ARN, got %q", got)
+	}
+	if isProfileArnResolutionSuppressed(account) {
+		t.Fatalf("refresh fallback success should not suppress future profile resolution")
+	}
+}
+
+func TestRefreshAccountInfoDoesNotDisableBuilderIDWhenProfileLookupUnsupported(t *testing.T) {
+	clearProfileArnResolutionCooldowns()
+	t.Cleanup(clearProfileArnResolutionCooldowns)
+
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	if err := config.Init(configPath); err != nil {
+		t.Fatalf("init config: %v", err)
+	}
+	account := config.Account{
+		ID:          "builder-refresh-info-1",
+		Email:       "builder@example.com",
+		AccessToken: "access-token",
+		Provider:    "BuilderId",
+		Region:      "us-east-1",
+		Enabled:     true,
+	}
+	if err := config.AddAccount(account); err != nil {
+		t.Fatalf("add account: %v", err)
+	}
+
+	var profileCalls, usageCalls int32
+	kiroRestHttpStore.Store(&http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.Path {
+			case "/ListAvailableProfiles":
+				atomic.AddInt32(&profileCalls, 1)
+				return &http.Response{
+					StatusCode: http.StatusForbidden,
+					Body:       io.NopCloser(strings.NewReader(`{"message":"AWS Builder ID is not supported for this operation.","reason":null}`)),
+					Header:     make(http.Header),
+				}, nil
+			case "/getUsageLimits":
+				atomic.AddInt32(&usageCalls, 1)
+				if strings.Contains(req.URL.RawQuery, "profileArn=") {
+					t.Fatalf("expected Builder ID usage refresh to continue without profileArn, got query %q", req.URL.RawQuery)
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{}`)),
+					Header:     make(http.Header),
+				}, nil
+			default:
+				t.Fatalf("unexpected request path %s", req.URL.Path)
+				return nil, nil
+			}
+		}),
+	})
+	t.Cleanup(func() { InitKiroHttpClient("") })
+
+	requestAccount := account
+	if _, err := RefreshAccountInfo(&requestAccount); err != nil {
+		t.Fatalf("expected refresh to continue without profile ARN, got %v", err)
+	}
+	if got := atomic.LoadInt32(&profileCalls); got != 1 {
+		t.Fatalf("expected one profile lookup, got %d", got)
+	}
+	if got := atomic.LoadInt32(&usageCalls); got != 1 {
+		t.Fatalf("expected one usage request, got %d", got)
+	}
+	accounts := config.GetAccounts()
+	if len(accounts) != 1 {
+		t.Fatalf("expected one account, got %d", len(accounts))
+	}
+	if !accounts[0].Enabled || accounts[0].BanStatus != "" {
+		t.Fatalf("expected account to remain enabled, got enabled=%v banStatus=%q", accounts[0].Enabled, accounts[0].BanStatus)
+	}
+}
+
+func clearProfileArnResolutionCooldowns() {
+	profileArnResolutionCooldowns.Range(func(key, _ interface{}) bool {
+		profileArnResolutionCooldowns.Delete(key)
+		return true
+	})
 }
 
 type roundTripFunc func(*http.Request) (*http.Response, error)


### PR DESCRIPTION
## Summary
- cache a short-lived negative result when BuilderId profile lookup returns the unsupported AWS Builder ID 403
- suppress repeated ListAvailableProfiles calls during the cooldown while preserving refresh-token fallback
- downgrade repeated skipped profile resolution logs to debug to avoid warn spam during generation

## Why
BuilderId accounts can generate successfully without a profile ARN, but ListAvailableProfiles may return:

`HTTP 403: {"message":"AWS Builder ID is not supported for this operation.","reason":null}`

Without caching that unsupported result, every generation retries the same failing lookup and emits repeated warnings/overhead.

## Tests
- `go test ./proxy -run 'TestResolveProfileArn|TestSetPayloadProfileArn|TestInitKiroHttpClient' -count=1`
- `git diff --check`

## Notes
- Full `go test ./...` currently fails in unrelated translator tests: `TestClaudeToolResultMixedTextAndImage` and `TestOpenAIToolResultImageCarriedWhenFollowedByUser`.