### PR TITLE
Add RTK request compression

### DIFF
--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -750,6 +750,7 @@ func (h *Handler) handleCountTokens(w http.ResponseWriter, r *http.Request) {
 		h.sendClaudeError(w, 400, "invalid_request_error", "Failed to read request body")
 		return
 	}
+	body = maybeCompressRequestBody(body)
 
 	var req ClaudeRequest
 	if err := json.Unmarshal(body, &req); err != nil {
@@ -792,6 +793,7 @@ func (h *Handler) handleClaudeMessagesInternal(w http.ResponseWriter, r *http.Re
 		h.sendClaudeError(w, 400, "invalid_request_error", "Failed to read request body")
 		return
 	}
+	body = maybeCompressRequestBody(body)
 
 	var req ClaudeRequest
 	if err := json.Unmarshal(body, &req); err != nil {
@@ -1483,6 +1485,7 @@ func (h *Handler) handleOpenAIChat(w http.ResponseWriter, r *http.Request) {
 		h.sendOpenAIError(w, 400, "invalid_request_error", "Failed to read request body")
 		return
 	}
+	body = maybeCompressRequestBody(body)
 
 	var req OpenAIRequest
 	if err := json.Unmarshal(body, &req); err != nil {

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -23,6 +23,7 @@ func (h *Handler) handleOpenAIResponses(w http.ResponseWriter, r *http.Request) 
 		h.sendOpenAIError(w, 400, "invalid_request_error", "Failed to read request body")
 		return
 	}
+	body = maybeCompressRequestBody(body)
 
 	var req ResponsesRequest
 	if err := json.Unmarshal(body, &req); err != nil {

--- a/proxy/rtk_integration.go
+++ b/proxy/rtk_integration.go
@@ -1,0 +1,50 @@
+package proxy
+
+import (
+	"os"
+	"strconv"
+	"strings"
+
+	"kiro-go/logger"
+	"kiro-go/rtk"
+)
+
+func maybeCompressRequestBody(raw []byte) []byte {
+	cfg := rtkConfigFromEnv()
+	if !cfg.Enabled {
+		return raw
+	}
+	updated, stats, changed, err := rtk.TransformJSON(raw, cfg)
+	if err != nil {
+		logger.Warnf("[RTK] request transform skipped: %v", err)
+		return raw
+	}
+	if !changed {
+		return raw
+	}
+	if line := rtk.FormatLog(stats); line != "" {
+		logger.Infof("%s", line)
+	}
+	return updated
+}
+
+func rtkConfigFromEnv() rtk.Config {
+	cfg := rtk.DefaultConfig()
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("KIRO_GO_RTK"))) {
+	case "0", "false", "off", "no", "disabled":
+		cfg.Enabled = false
+	case "1", "true", "on", "yes", "enabled":
+		cfg.Enabled = true
+	}
+	if v := strings.TrimSpace(os.Getenv("KIRO_GO_RTK_MIN_BYTES")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.MinBytes = n
+		}
+	}
+	if v := strings.TrimSpace(os.Getenv("KIRO_GO_RTK_MAX_BYTES")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.MaxBytes = n
+		}
+	}
+	return cfg
+}

--- a/proxy/rtk_integration_test.go
+++ b/proxy/rtk_integration_test.go
@@ -1,0 +1,527 @@
+package proxy
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRTKCompressesClaudeToolResultBeforeUpstreamKiroRequest(t *testing.T) {
+	t.Setenv("KIRO_GO_RTK_MIN_BYTES", "1")
+
+	h, cleanup := setupResponsesTestHandler(t)
+	defer cleanup()
+
+	rawToolOutput := rtkIntegrationGrepOutput(40)
+	requestBody := `{
+		"model":"claude-sonnet-4.5",
+		"max_tokens":256,
+		"messages":[
+			{"role":"user","content":"run the search"},
+			{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"exec_command","input":{"cmd":"rg needle"}}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":` + quoteJSONString(rawToolOutput) + `}]}
+		]
+	}`
+
+	baselineKiroRequest := captureClaudeMessagesKiroRequest(t, h, requestBody, false)
+	baselineText := capturedKiroToolResultText(t, baselineKiroRequest)
+	if baselineText != rawToolOutput {
+		t.Fatalf("expected disabled RTK to preserve raw tool result, got %q", baselineText)
+	}
+
+	compressedKiroRequest := captureClaudeMessagesKiroRequest(t, h, requestBody, true)
+	compressedText := capturedKiroToolResultText(t, compressedKiroRequest)
+	if !strings.Contains(compressedText, "40 matches in 1 files") {
+		t.Fatalf("expected compressed grep summary in upstream Kiro request, got %q", compressedText)
+	}
+	if strings.Contains(compressedText, "needle occurrence 39") {
+		t.Fatalf("expected raw grep tail to be removed from upstream Kiro request, got %q", compressedText)
+	}
+
+	if dir := os.Getenv("KIRO_GO_RTK_ARTIFACT_DIR"); dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir artifact dir: %v", err)
+		}
+		writeTestArtifact(t, filepath.Join(dir, "claude-request-before.json"), []byte(requestBody))
+		writeTestArtifact(t, filepath.Join(dir, "kiro-upstream-before.json"), baselineKiroRequest)
+		writeTestArtifact(t, filepath.Join(dir, "kiro-upstream-after.json"), compressedKiroRequest)
+		writeTestArtifact(t, filepath.Join(dir, "kiro-upstream-before.normalized.json"), normalizedKiroRequestArtifact(t, baselineKiroRequest))
+		writeTestArtifact(t, filepath.Join(dir, "kiro-upstream-after.normalized.json"), normalizedKiroRequestArtifact(t, compressedKiroRequest))
+		writeTestArtifact(t, filepath.Join(dir, "tool-result-before.txt"), []byte(baselineText))
+		writeTestArtifact(t, filepath.Join(dir, "tool-result-after.txt"), []byte(compressedText))
+	}
+}
+
+func TestRTKCompressesMultiTurnClaudeCodeSessionBeforeUpstreamKiroRequest(t *testing.T) {
+	t.Setenv("KIRO_GO_RTK_MIN_BYTES", "1")
+
+	h, cleanup := setupResponsesTestHandler(t)
+	defer cleanup()
+
+	searchOutput := rtkIntegrationGrepOutputFrom("proxy/handler.go", 200, 32, "search-history")
+	buildOutput := rtkIntegrationBuildOutput(36)
+	currentOutput := rtkIntegrationGrepOutputFrom("rtk/rtk.go", 500, 38, "current-search")
+	requestBody := string(multiTurnClaudeCodeRequest(t, searchOutput, buildOutput, currentOutput))
+
+	baselineKiroRequest := captureClaudeMessagesKiroRequest(t, h, requestBody, false)
+	baselinePayload := decodeCapturedKiroPayload(t, baselineKiroRequest)
+	baselineCurrentText := capturedKiroToolResultText(t, baselineKiroRequest)
+	if baselineCurrentText != currentOutput {
+		t.Fatalf("expected disabled RTK to preserve current raw tool result, got %q", baselineCurrentText)
+	}
+	assertActiveToolTurnPreserved(t, baselinePayload, "toolu_current_search")
+
+	compressedKiroRequest := captureClaudeMessagesKiroRequest(t, h, requestBody, true)
+	compressedPayload := decodeCapturedKiroPayload(t, compressedKiroRequest)
+	compressedCurrentText := capturedKiroToolResultText(t, compressedKiroRequest)
+	if !strings.Contains(compressedCurrentText, "38 matches in 1 files") {
+		t.Fatalf("expected compressed current grep summary, got %q", compressedCurrentText)
+	}
+	if strings.Contains(compressedCurrentText, "current-search occurrence 37") {
+		t.Fatalf("expected current grep tail removed, got %q", compressedCurrentText)
+	}
+	assertActiveToolTurnPreserved(t, compressedPayload, "toolu_current_search")
+
+	baselineHistory := kiroHistoryText(t, baselinePayload)
+	if !strings.Contains(baselineHistory, "search-history occurrence 31") {
+		t.Fatalf("expected disabled RTK history to retain raw earlier search tail, got %q", baselineHistory)
+	}
+	if !strings.Contains(baselineHistory, "package_35") {
+		t.Fatalf("expected disabled RTK history to retain raw build tail, got %q", baselineHistory)
+	}
+
+	compressedHistory := kiroHistoryText(t, compressedPayload)
+	if !strings.Contains(compressedHistory, "32 matches in 1 files") {
+		t.Fatalf("expected earlier search summary in history, got %q", compressedHistory)
+	}
+	if strings.Contains(compressedHistory, "search-history occurrence 31") {
+		t.Fatalf("expected earlier search tail removed from history, got %q", compressedHistory)
+	}
+	if !strings.Contains(compressedHistory, "Compiled 36 packages") {
+		t.Fatalf("expected build summary in history, got %q", compressedHistory)
+	}
+	if strings.Contains(compressedHistory, "package_35") {
+		t.Fatalf("expected raw build tail removed from history, got %q", compressedHistory)
+	}
+
+	if dir := os.Getenv("KIRO_GO_RTK_ARTIFACT_DIR"); dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir artifact dir: %v", err)
+		}
+		writeTestArtifact(t, filepath.Join(dir, "multi-turn-claude-request-before.json"), []byte(requestBody))
+		writeTestArtifact(t, filepath.Join(dir, "multi-turn-kiro-upstream-before.json"), baselineKiroRequest)
+		writeTestArtifact(t, filepath.Join(dir, "multi-turn-kiro-upstream-after.json"), compressedKiroRequest)
+		writeTestArtifact(t, filepath.Join(dir, "multi-turn-kiro-upstream-before.normalized.json"), normalizedKiroRequestArtifact(t, baselineKiroRequest))
+		writeTestArtifact(t, filepath.Join(dir, "multi-turn-kiro-upstream-after.normalized.json"), normalizedKiroRequestArtifact(t, compressedKiroRequest))
+		writeTestArtifact(t, filepath.Join(dir, "multi-turn-current-tool-result-before.txt"), []byte(baselineCurrentText))
+		writeTestArtifact(t, filepath.Join(dir, "multi-turn-current-tool-result-after.txt"), []byte(compressedCurrentText))
+		writeTestArtifact(t, filepath.Join(dir, "multi-turn-history-before.txt"), []byte(baselineHistory))
+		writeTestArtifact(t, filepath.Join(dir, "multi-turn-history-after.txt"), []byte(compressedHistory))
+	}
+}
+
+func TestRTKCompressesMultiTurnOpenAIChatSessionBeforeUpstreamKiroRequest(t *testing.T) {
+	t.Setenv("KIRO_GO_RTK_MIN_BYTES", "1")
+
+	h, cleanup := setupResponsesTestHandler(t)
+	defer cleanup()
+
+	searchOutput := rtkIntegrationGrepOutputFrom("proxy/responses_handler.go", 300, 30, "codex-history")
+	buildOutput := rtkIntegrationBuildOutput(34)
+	currentOutput := rtkIntegrationGrepOutputFrom("rtk/rtk.go", 700, 36, "codex-current")
+	requestBody := string(multiTurnOpenAIChatRequest(t, searchOutput, buildOutput, currentOutput))
+
+	baselineKiroRequest := captureOpenAIChatKiroRequest(t, h, requestBody, false)
+	baselinePayload := decodeCapturedKiroPayload(t, baselineKiroRequest)
+	baselineCurrentText := capturedKiroToolResultText(t, baselineKiroRequest)
+	if baselineCurrentText != currentOutput {
+		t.Fatalf("expected disabled RTK to preserve current raw tool result, got %q", baselineCurrentText)
+	}
+	assertActiveToolTurnPreserved(t, baselinePayload, "call_current_search")
+
+	compressedKiroRequest := captureOpenAIChatKiroRequest(t, h, requestBody, true)
+	compressedPayload := decodeCapturedKiroPayload(t, compressedKiroRequest)
+	compressedCurrentText := capturedKiroToolResultText(t, compressedKiroRequest)
+	if !strings.Contains(compressedCurrentText, "36 matches in 1 files") {
+		t.Fatalf("expected compressed current grep summary, got %q", compressedCurrentText)
+	}
+	if strings.Contains(compressedCurrentText, "codex-current occurrence 35") {
+		t.Fatalf("expected current grep tail removed, got %q", compressedCurrentText)
+	}
+	assertActiveToolTurnPreserved(t, compressedPayload, "call_current_search")
+
+	baselineHistory := kiroHistoryText(t, baselinePayload)
+	if !strings.Contains(baselineHistory, "codex-history occurrence 29") {
+		t.Fatalf("expected disabled RTK history to retain raw earlier search tail, got %q", baselineHistory)
+	}
+	if !strings.Contains(baselineHistory, "package_33") {
+		t.Fatalf("expected disabled RTK history to retain raw build tail, got %q", baselineHistory)
+	}
+
+	compressedHistory := kiroHistoryText(t, compressedPayload)
+	if !strings.Contains(compressedHistory, "30 matches in 1 files") {
+		t.Fatalf("expected earlier search summary in history, got %q", compressedHistory)
+	}
+	if strings.Contains(compressedHistory, "codex-history occurrence 29") {
+		t.Fatalf("expected earlier search tail removed from history, got %q", compressedHistory)
+	}
+	if !strings.Contains(compressedHistory, "Compiled 34 packages") {
+		t.Fatalf("expected build summary in history, got %q", compressedHistory)
+	}
+	if strings.Contains(compressedHistory, "package_33") {
+		t.Fatalf("expected raw build tail removed from history, got %q", compressedHistory)
+	}
+
+	if dir := os.Getenv("KIRO_GO_RTK_ARTIFACT_DIR"); dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir artifact dir: %v", err)
+		}
+		writeTestArtifact(t, filepath.Join(dir, "codex-multi-turn-openai-request-before.json"), []byte(requestBody))
+		writeTestArtifact(t, filepath.Join(dir, "codex-multi-turn-kiro-upstream-before.json"), baselineKiroRequest)
+		writeTestArtifact(t, filepath.Join(dir, "codex-multi-turn-kiro-upstream-after.json"), compressedKiroRequest)
+		writeTestArtifact(t, filepath.Join(dir, "codex-multi-turn-kiro-upstream-before.normalized.json"), normalizedKiroRequestArtifact(t, baselineKiroRequest))
+		writeTestArtifact(t, filepath.Join(dir, "codex-multi-turn-kiro-upstream-after.normalized.json"), normalizedKiroRequestArtifact(t, compressedKiroRequest))
+		writeTestArtifact(t, filepath.Join(dir, "codex-multi-turn-current-tool-result-before.txt"), []byte(baselineCurrentText))
+		writeTestArtifact(t, filepath.Join(dir, "codex-multi-turn-current-tool-result-after.txt"), []byte(compressedCurrentText))
+		writeTestArtifact(t, filepath.Join(dir, "codex-multi-turn-history-before.txt"), []byte(baselineHistory))
+		writeTestArtifact(t, filepath.Join(dir, "codex-multi-turn-history-after.txt"), []byte(compressedHistory))
+	}
+}
+
+func captureClaudeMessagesKiroRequest(t *testing.T, h *Handler, requestBody string, rtkEnabled bool) []byte {
+	t.Helper()
+	if rtkEnabled {
+		t.Setenv("KIRO_GO_RTK", "true")
+	} else {
+		t.Setenv("KIRO_GO_RTK", "false")
+	}
+
+	var captured []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read upstream request: %v", err)
+		}
+		captured = append([]byte(nil), body...)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(awsEventStreamFrame(t, "assistantResponseEvent", map[string]interface{}{
+			"content": "request accepted",
+		}))
+	}))
+	defer server.Close()
+	defer swapKiroEndpointsForTest(t, server)()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(requestBody))
+	rec := httptest.NewRecorder()
+	h.handleClaudeMessages(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if len(captured) == 0 {
+		t.Fatalf("expected upstream Kiro request to be captured")
+	}
+	return captured
+}
+
+func captureOpenAIChatKiroRequest(t *testing.T, h *Handler, requestBody string, rtkEnabled bool) []byte {
+	t.Helper()
+	if rtkEnabled {
+		t.Setenv("KIRO_GO_RTK", "true")
+	} else {
+		t.Setenv("KIRO_GO_RTK", "false")
+	}
+
+	var captured []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read upstream request: %v", err)
+		}
+		captured = append([]byte(nil), body...)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(awsEventStreamFrame(t, "assistantResponseEvent", map[string]interface{}{
+			"content": "request accepted",
+		}))
+	}))
+	defer server.Close()
+	defer swapKiroEndpointsForTest(t, server)()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(requestBody))
+	rec := httptest.NewRecorder()
+	h.handleOpenAIChat(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if len(captured) == 0 {
+		t.Fatalf("expected upstream Kiro request to be captured")
+	}
+	return captured
+}
+
+func decodeCapturedKiroPayload(t *testing.T, raw []byte) *KiroPayload {
+	t.Helper()
+	var payload KiroPayload
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("decode upstream Kiro payload: %v\n%s", err, string(raw))
+	}
+	return &payload
+}
+
+func capturedKiroToolResultText(t *testing.T, raw []byte) string {
+	t.Helper()
+	var payload struct {
+		ConversationState struct {
+			CurrentMessage struct {
+				UserInputMessage struct {
+					UserInputMessageContext *struct {
+						ToolResults []struct {
+							Content []struct {
+								Text string `json:"text"`
+							} `json:"content"`
+						} `json:"toolResults"`
+					} `json:"userInputMessageContext"`
+				} `json:"userInputMessage"`
+			} `json:"currentMessage"`
+		} `json:"conversationState"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("decode upstream request: %v\n%s", err, string(raw))
+	}
+	ctx := payload.ConversationState.CurrentMessage.UserInputMessage.UserInputMessageContext
+	if ctx == nil || len(ctx.ToolResults) == 0 || len(ctx.ToolResults[0].Content) == 0 {
+		t.Fatalf("upstream request missing current tool result: %s", string(raw))
+	}
+	return ctx.ToolResults[0].Content[0].Text
+}
+
+func normalizedKiroRequestArtifact(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	var payload map[string]interface{}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("decode upstream request for normalized artifact: %v", err)
+	}
+	if conversationState, ok := payload["conversationState"].(map[string]interface{}); ok {
+		conversationState["agentContinuationId"] = "<generated>"
+	}
+	out, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		t.Fatalf("encode normalized upstream request artifact: %v", err)
+	}
+	return append(out, '\n')
+}
+
+func rtkIntegrationGrepOutput(n int) string {
+	return rtkIntegrationGrepOutputFrom("proxy/handler.go", 200, n, "needle")
+}
+
+func rtkIntegrationGrepOutputFrom(file string, startLine, n int, label string) string {
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		b.WriteString(file)
+		b.WriteString(":")
+		b.WriteString(strconvItoa(startLine + i))
+		b.WriteString(": ")
+		b.WriteString(label)
+		b.WriteString(" occurrence ")
+		b.WriteString(strconvItoa(i))
+		b.WriteString(" with verbose context that should be summarized before Kiro receives it\n")
+	}
+	return b.String()
+}
+
+func rtkIntegrationBuildOutput(n int) string {
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		b.WriteString("   Compiling package_")
+		b.WriteString(strconvItoa(i))
+		b.WriteString(" v0.1.0 (/tmp/kiro-go/package)\n")
+	}
+	b.WriteString("warning: generated fixture includes a representative warning\n")
+	b.WriteString("    Finished test [unoptimized + debuginfo] target(s) in 12.34s\n")
+	return b.String()
+}
+
+func multiTurnClaudeCodeRequest(t *testing.T, searchOutput, buildOutput, currentOutput string) []byte {
+	t.Helper()
+	payload := map[string]interface{}{
+		"model":      "claude-sonnet-4.5",
+		"max_tokens": 512,
+		"system":     "You are Claude Code running in a local repository. Use tools to inspect files and test changes.",
+		"messages": []interface{}{
+			map[string]interface{}{"role": "user", "content": "Please inspect RTK and verify the branch."},
+			map[string]interface{}{
+				"role": "assistant",
+				"content": []interface{}{
+					map[string]interface{}{"type": "text", "text": "I will inspect the integration points."},
+					map[string]interface{}{
+						"type":  "tool_use",
+						"id":    "toolu_search_history",
+						"name":  "exec_command",
+						"input": map[string]interface{}{"cmd": "rg RTK proxy rtk"},
+					},
+				},
+			},
+			map[string]interface{}{
+				"role": "user",
+				"content": []interface{}{
+					map[string]interface{}{"type": "tool_result", "tool_use_id": "toolu_search_history", "content": searchOutput},
+				},
+			},
+			map[string]interface{}{
+				"role": "assistant",
+				"content": []interface{}{
+					map[string]interface{}{"type": "text", "text": "I found the integration and will run focused tests."},
+					map[string]interface{}{
+						"type":  "tool_use",
+						"id":    "toolu_build_history",
+						"name":  "exec_command",
+						"input": map[string]interface{}{"cmd": "go test ./rtk ./proxy"},
+					},
+				},
+			},
+			map[string]interface{}{
+				"role": "user",
+				"content": []interface{}{
+					map[string]interface{}{"type": "tool_result", "tool_use_id": "toolu_build_history", "content": buildOutput},
+				},
+			},
+			map[string]interface{}{
+				"role": "assistant",
+				"content": []interface{}{
+					map[string]interface{}{"type": "text", "text": "The focused test output is available. I will inspect one final current search result."},
+					map[string]interface{}{
+						"type":  "tool_use",
+						"id":    "toolu_current_search",
+						"name":  "exec_command",
+						"input": map[string]interface{}{"cmd": "rg current-search rtk"},
+					},
+				},
+			},
+			map[string]interface{}{
+				"role": "user",
+				"content": []interface{}{
+					map[string]interface{}{"type": "tool_result", "tool_use_id": "toolu_current_search", "content": currentOutput},
+				},
+			},
+		},
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("encode multi-turn Claude request: %v", err)
+	}
+	return raw
+}
+
+func multiTurnOpenAIChatRequest(t *testing.T, searchOutput, buildOutput, currentOutput string) []byte {
+	t.Helper()
+	payload := map[string]interface{}{
+		"model":      "gpt-5-codex",
+		"max_tokens": 512,
+		"messages": []interface{}{
+			map[string]interface{}{"role": "system", "content": "You are Codex running in a local repository. Use tools to inspect files and test changes."},
+			map[string]interface{}{"role": "user", "content": "Please inspect RTK and verify the branch."},
+			openAIToolCallMessage("call_search_history", "I will inspect the integration points.", "rg RTK proxy rtk"),
+			map[string]interface{}{"role": "tool", "tool_call_id": "call_search_history", "content": searchOutput},
+			openAIToolCallMessage("call_build_history", "I found the integration and will run focused tests.", "go test ./rtk ./proxy"),
+			map[string]interface{}{"role": "tool", "tool_call_id": "call_build_history", "content": buildOutput},
+			openAIToolCallMessage("call_current_search", "The focused test output is available. I will inspect one final current search result.", "rg codex-current rtk"),
+			map[string]interface{}{"role": "tool", "tool_call_id": "call_current_search", "content": currentOutput},
+		},
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("encode multi-turn OpenAI chat request: %v", err)
+	}
+	return raw
+}
+
+func openAIToolCallMessage(id, text, cmd string) map[string]interface{} {
+	args, _ := json.Marshal(map[string]string{"cmd": cmd})
+	return map[string]interface{}{
+		"role":    "assistant",
+		"content": text,
+		"tool_calls": []interface{}{
+			map[string]interface{}{
+				"id":   id,
+				"type": "function",
+				"function": map[string]interface{}{
+					"name":      "exec_command",
+					"arguments": string(args),
+				},
+			},
+		},
+	}
+}
+
+func assertActiveToolTurnPreserved(t *testing.T, payload *KiroPayload, wantToolID string) {
+	t.Helper()
+	history := payload.ConversationState.History
+	if len(history) == 0 {
+		t.Fatalf("expected Kiro history to contain prior turns")
+	}
+	last := history[len(history)-1].AssistantResponseMessage
+	if last == nil || len(last.ToolUses) != 1 {
+		t.Fatalf("expected final assistant tool use to stay structured, got %+v", history[len(history)-1])
+	}
+	if last.ToolUses[0].ToolUseID != wantToolID {
+		t.Fatalf("expected active tool use %s, got %+v", wantToolID, last.ToolUses[0])
+	}
+	ctx := payload.ConversationState.CurrentMessage.UserInputMessage.UserInputMessageContext
+	if ctx == nil || len(ctx.ToolResults) != 1 {
+		t.Fatalf("expected current message to carry one structured tool result, got %+v", ctx)
+	}
+	if ctx.ToolResults[0].ToolUseID != wantToolID {
+		t.Fatalf("expected current tool result to match active tool use %s, got %+v", wantToolID, ctx.ToolResults[0])
+	}
+}
+
+func kiroHistoryText(t *testing.T, payload *KiroPayload) string {
+	t.Helper()
+	var parts []string
+	for _, msg := range payload.ConversationState.History {
+		if msg.UserInputMessage != nil {
+			parts = append(parts, msg.UserInputMessage.Content)
+		}
+		if msg.AssistantResponseMessage != nil {
+			parts = append(parts, msg.AssistantResponseMessage.Content)
+			for _, toolUse := range msg.AssistantResponseMessage.ToolUses {
+				parts = append(parts, toolUse.ToolUseID)
+				parts = append(parts, toolUse.Name)
+			}
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+func quoteJSONString(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+func writeTestArtifact(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write artifact %s: %v", path, err)
+	}
+}
+
+func strconvItoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}

--- a/rtk/rtk.go
+++ b/rtk/rtk.go
@@ -1,0 +1,1094 @@
+package rtk
+
+import (
+	"encoding/json"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const (
+	DefaultMinBytes = 500
+	DefaultMaxBytes = 10 * 1024 * 1024
+	detectWindow    = 1024
+)
+
+type Config struct {
+	Enabled  bool
+	MinBytes int
+	MaxBytes int
+}
+
+type Stats struct {
+	BytesBefore int
+	BytesAfter  int
+	Hits        []Hit
+}
+
+type Hit struct {
+	Shape  string
+	Filter string
+	Saved  int
+}
+
+func DefaultConfig() Config {
+	return Config{Enabled: true, MinBytes: DefaultMinBytes, MaxBytes: DefaultMaxBytes}
+}
+
+func (cfg Config) normalized() Config {
+	if cfg.MinBytes <= 0 {
+		cfg.MinBytes = DefaultMinBytes
+	}
+	if cfg.MaxBytes <= 0 {
+		cfg.MaxBytes = DefaultMaxBytes
+	}
+	if cfg.MinBytes > cfg.MaxBytes {
+		cfg.MinBytes = DefaultMinBytes
+		cfg.MaxBytes = DefaultMaxBytes
+	}
+	return cfg
+}
+
+func TransformJSON(raw []byte, cfg Config) ([]byte, Stats, bool, error) {
+	cfg = cfg.normalized()
+	if !cfg.Enabled {
+		return raw, Stats{}, false, nil
+	}
+	var payload any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil, Stats{}, false, err
+	}
+	stats, changed := TransformValue(payload, cfg)
+	if !changed {
+		return raw, stats, false, nil
+	}
+	updated, err := json.Marshal(payload)
+	if err != nil {
+		return nil, stats, false, err
+	}
+	return updated, stats, true, nil
+}
+
+func TransformValue(payload any, cfg Config) (Stats, bool) {
+	cfg = cfg.normalized()
+	if !cfg.Enabled {
+		return Stats{}, false
+	}
+	var stats Stats
+	cmds := toolCommands(payload)
+	changed := compressValue(payload, cfg, &stats, "", cmds)
+	return stats, changed
+}
+
+func FormatLog(stats Stats) string {
+	if len(stats.Hits) == 0 {
+		return ""
+	}
+	filters := map[string]bool{}
+	saved := 0
+	for _, hit := range stats.Hits {
+		filters[hit.Filter] = true
+		saved += hit.Saved
+	}
+	names := make([]string, 0, len(filters))
+	for name := range filters {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	pct := "0.0"
+	if stats.BytesBefore > 0 {
+		pct = strconv.FormatFloat(float64(saved)*100/float64(stats.BytesBefore), 'f', 1, 64)
+	}
+	return "[RTK] saved " + stringInt(saved) + "B / " + stringInt(stats.BytesBefore) + "B (" + pct + "%) via [" + strings.Join(names, ",") + "] hits=" + stringInt(len(stats.Hits))
+}
+
+func compressValue(v any, cfg Config, stats *Stats, shape string, cmds map[string]string) bool {
+	switch val := v.(type) {
+	case map[string]any:
+		changed := false
+		if typeName, _ := val["type"].(string); typeName == "function_call_output" {
+			cmd := lookupCommand(cmds, val, "call_id")
+			if next, ok := compressContent(val["output"], cfg, stats, "openai-responses", cmd, cmds); ok {
+				val["output"] = next
+				changed = true
+			}
+		}
+		if role, _ := val["role"].(string); role == "tool" {
+			cmd := lookupCommand(cmds, val, "tool_call_id")
+			if next, ok := compressContent(val["content"], cfg, stats, "openai-tool", cmd, cmds); ok {
+				val["content"] = next
+				changed = true
+			}
+		}
+		if typeName, _ := val["type"].(string); typeName == "tool_result" && val["is_error"] != true {
+			cmd := lookupCommand(cmds, val, "tool_use_id")
+			if next, ok := compressContent(val["content"], cfg, stats, "tool-result", cmd, cmds); ok {
+				val["content"] = next
+				changed = true
+			}
+		}
+		if _, ok := val["toolUseId"].(string); ok {
+			status, _ := val["status"].(string)
+			if !strings.EqualFold(strings.TrimSpace(status), "error") {
+				if next, ok := compressKiroResultContent(val["content"], cfg, stats, "kiro-tool-result", "", cmds); ok {
+					val["content"] = next
+					changed = true
+				}
+			}
+		}
+		for _, child := range val {
+			changed = compressValue(child, cfg, stats, shape, cmds) || changed
+		}
+		return changed
+	case []any:
+		changed := false
+		for _, child := range val {
+			changed = compressValue(child, cfg, stats, shape, cmds) || changed
+		}
+		return changed
+	default:
+		return false
+	}
+}
+
+func lookupCommand(cmds map[string]string, m map[string]any, key string) string {
+	if cmds == nil {
+		return ""
+	}
+	id, _ := m[key].(string)
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return ""
+	}
+	return cmds[id]
+}
+
+func compressContent(v any, cfg Config, stats *Stats, shape, command string, cmds map[string]string) (any, bool) {
+	switch val := v.(type) {
+	case string:
+		out, ok := compressText(val, cfg, stats, shape, command)
+		return out, ok
+	case []any:
+		changed := false
+		for i, item := range val {
+			switch part := item.(type) {
+			case string:
+				if out, ok := compressText(part, cfg, stats, shape, command); ok {
+					val[i] = out
+					changed = true
+				}
+			case map[string]any:
+				if text, ok := part["text"].(string); ok {
+					if out, compressed := compressText(text, cfg, stats, shape, command); compressed {
+						part["text"] = out
+						changed = true
+					}
+				}
+				changed = compressValue(part, cfg, stats, shape, cmds) || changed
+			}
+		}
+		return val, changed
+	default:
+		return v, false
+	}
+}
+
+func compressKiroResultContent(v any, cfg Config, stats *Stats, shape, command string, cmds map[string]string) (any, bool) {
+	arr, ok := v.([]any)
+	if !ok {
+		return v, false
+	}
+	changed := false
+	for _, item := range arr {
+		part, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if text, ok := part["text"].(string); ok {
+			if out, compressed := compressText(text, cfg, stats, shape, command); compressed {
+				part["text"] = out
+				changed = true
+			}
+		}
+		changed = compressValue(part, cfg, stats, shape, cmds) || changed
+	}
+	return arr, changed
+}
+
+func compressText(text string, cfg Config, stats *Stats, shape, command string) (string, bool) {
+	bytesIn := len([]byte(text))
+	if bytesIn < cfg.MinBytes || bytesIn > cfg.MaxBytes {
+		return text, false
+	}
+	out, filter := autoFilterCommand(text, command)
+	if out == "" || filter == "" {
+		return text, false
+	}
+	bytesOut := len([]byte(out))
+	if bytesOut <= 0 || bytesOut >= bytesIn {
+		return text, false
+	}
+	stats.BytesBefore += bytesIn
+	stats.BytesAfter += bytesOut
+	stats.Hits = append(stats.Hits, Hit{Shape: shape, Filter: filter, Saved: bytesIn - bytesOut})
+	return out, true
+}
+
+func autoFilterCommand(text, command string) (string, string) {
+	head := text
+	if len(head) > detectWindow {
+		head = head[:detectWindow]
+	}
+	gitAllowed := true
+	if strings.TrimSpace(command) != "" {
+		if name := filterForCommand(command); name != "" {
+			if out, ok := applyNamedFilter(name, text); ok && len([]byte(out)) < len([]byte(text)) {
+				return out, name
+			}
+		}
+		gitAllowed = commandIsGit(command)
+	}
+	switch {
+	case gitAllowed && (strings.Contains(head, "diff --git ") || strings.Contains(head, "\n@@ ")):
+		return compactGitDiff(text), "git-diff"
+	case gitAllowed && (strings.Contains(head, "On branch ") || strings.Contains(head, "Untracked files:") || looksLikePorcelain(head)):
+		return compactGitStatus(text), "git-status"
+	case looksLikeBuildOutput(head):
+		return compactBuildOutput(text), "build-output"
+	case looksLikeGrep(head):
+		return compactGrep(text), "grep"
+	case looksLikePathList(head):
+		return compactFind(text), "find"
+	case strings.Contains(head, "\u251c\u2500\u2500") || strings.Contains(head, "\u2514\u2500\u2500") || strings.Contains(head, "\u2502  "):
+		return compactTree(text), "tree"
+	case looksLikeLS(head):
+		return compactLS(text), "ls"
+	case searchListHeaderRE.MatchString(head):
+		return compactSearchList(text), "search-list"
+	case isLineNumbered(strings.Split(head, "\n")):
+		return readNumbered(text), "read-numbered"
+	case len(strings.Split(text, "\n")) >= 250:
+		return smartTruncate(text), "smart-truncate"
+	case len(nonEmptyLines(text)) >= 5:
+		return dedupLog(text), "dedup-log"
+	default:
+		return "", ""
+	}
+}
+
+func applyNamedFilter(name, text string) (string, bool) {
+	switch name {
+	case "git-diff":
+		return compactGitDiff(text), true
+	case "git-status":
+		return compactGitStatus(text), true
+	case "build-output":
+		return compactBuildOutput(text), true
+	case "grep":
+		return compactGrep(text), true
+	case "find":
+		return compactFind(text), true
+	case "ls":
+		return compactLS(text), true
+	case "tree":
+		return compactTree(text), true
+	case "search-list":
+		return compactSearchList(text), true
+	case "read-numbered":
+		return readNumbered(text), true
+	case "smart-truncate":
+		return smartTruncate(text), true
+	case "dedup-log":
+		return dedupLog(text), true
+	default:
+		return "", false
+	}
+}
+
+func compactGitDiff(diff string) string {
+	const maxLines = 500
+	const maxHunkLines = 100
+	var result []string
+	currentFile := ""
+	added, removed := 0, 0
+	inHunk := false
+	hunkShown, hunkSkipped := 0, 0
+	truncated := false
+	flushSkipped := func() {
+		if hunkSkipped > 0 {
+			result = append(result, "  ... ("+stringInt(hunkSkipped)+" lines truncated)")
+			truncated = true
+			hunkSkipped = 0
+		}
+	}
+	flushFile := func() {
+		flushSkipped()
+		if currentFile != "" {
+			result = append(result, "summary: "+currentFile+" +"+stringInt(added)+" -"+stringInt(removed))
+		}
+		added, removed = 0, 0
+	}
+	for _, line := range strings.Split(diff, "\n") {
+		if strings.HasPrefix(line, "diff --git ") {
+			flushFile()
+			currentFile = strings.TrimSpace(line)
+			result = append(result, line)
+			inHunk = false
+			continue
+		}
+		if strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---") || strings.HasPrefix(line, "index ") || strings.HasPrefix(line, "new file") || strings.HasPrefix(line, "deleted file") {
+			result = append(result, line)
+			continue
+		}
+		if strings.HasPrefix(line, "@@") {
+			flushSkipped()
+			result = append(result, line)
+			inHunk = true
+			hunkShown = 0
+			continue
+		}
+		if strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "+++") {
+			added++
+		}
+		if strings.HasPrefix(line, "-") && !strings.HasPrefix(line, "---") {
+			removed++
+		}
+		if inHunk {
+			if hunkShown < maxHunkLines || strings.HasPrefix(line, "+") || strings.HasPrefix(line, "-") {
+				result = append(result, line)
+				hunkShown++
+			} else {
+				hunkSkipped++
+			}
+			continue
+		}
+		result = append(result, line)
+		if len(result) >= maxLines {
+			truncated = true
+			break
+		}
+	}
+	flushFile()
+	if len(result) > maxLines {
+		result = result[:maxLines]
+		truncated = true
+	}
+	if truncated {
+		result = append(result, "[diff truncated]")
+	}
+	return strings.TrimRight(strings.Join(result, "\n"), "\n")
+}
+
+func compactGrep(text string) string {
+	const perFileMax = 10
+	byFile := map[string][]grepMatch{}
+	for _, line := range nonEmptyLines(text) {
+		first := strings.Index(line, ":")
+		if first < 0 {
+			continue
+		}
+		second := strings.Index(line[first+1:], ":")
+		if second < 0 {
+			continue
+		}
+		second += first + 1
+		file := line[:first]
+		lineNum := line[first+1 : second]
+		if _, err := strconv.Atoi(lineNum); err != nil {
+			continue
+		}
+		byFile[file] = append(byFile[file], grepMatch{lineNum: lineNum, content: line[second+1:]})
+	}
+	if len(byFile) == 0 {
+		return text
+	}
+	files := make([]string, 0, len(byFile))
+	total := 0
+	for f, matches := range byFile {
+		files = append(files, f)
+		total += len(matches)
+	}
+	sort.Strings(files)
+	out := []string{stringInt(total) + " matches in " + stringInt(len(files)) + " files:", ""}
+	for _, file := range files {
+		matches := byFile[file]
+		out = append(out, "[file] "+file+" ("+stringInt(len(matches))+"):")
+		limit := perFileMax
+		if len(matches) < limit {
+			limit = len(matches)
+		}
+		for _, item := range matches[:limit] {
+			out = append(out, "  "+leftPad(item.lineNum, 4)+": "+strings.TrimSpace(item.content))
+		}
+		if len(matches) > limit {
+			out = append(out, "  +"+stringInt(len(matches)-limit))
+		}
+		out = append(out, "")
+	}
+	return strings.TrimRight(strings.Join(out, "\n"), "\n")
+}
+
+type grepMatch struct {
+	lineNum string
+	content string
+}
+
+func compactFind(text string) string {
+	return compactPathBasenames(nonEmptyLines(text), 10, 20)
+}
+
+func compactPathBasenames(paths []string, perDirMax, maxDirs int) string {
+	groups := map[string][]string{}
+	for _, p := range paths {
+		dir := "."
+		name := p
+		if idx := strings.LastIndex(p, "/"); idx >= 0 {
+			dir = p[:idx]
+			if dir == "" {
+				dir = "/"
+			}
+			name = p[idx+1:]
+		}
+		groups[dir] = append(groups[dir], name)
+	}
+	dirs := make([]string, 0, len(groups))
+	for dir := range groups {
+		dirs = append(dirs, dir)
+	}
+	sort.Strings(dirs)
+	out := []string{stringInt(len(paths)) + " files in " + stringInt(len(dirs)) + " dirs:", ""}
+	for i, dir := range dirs {
+		if i >= maxDirs {
+			out = append(out, "+"+stringInt(len(dirs)-i)+" more dirs")
+			break
+		}
+		names := groups[dir]
+		out = append(out, dir+"/ ("+stringInt(len(names))+"):")
+		limit := perDirMax
+		if len(names) < limit {
+			limit = len(names)
+		}
+		for _, name := range names[:limit] {
+			out = append(out, "  "+name)
+		}
+		if len(names) > limit {
+			out = append(out, "  +"+stringInt(len(names)-limit))
+		}
+		out = append(out, "")
+	}
+	return strings.TrimRight(strings.Join(out, "\n"), "\n")
+}
+
+func compactGitStatus(text string) string {
+	const maxFiles = 10
+	const maxUntracked = 10
+	branch := ""
+	var stagedFiles, modifiedFiles, untrackedFiles []string
+	staged, modified, untracked, conflicts := 0, 0, 0, 0
+	for _, raw := range strings.Split(text, "\n") {
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+		if strings.HasPrefix(raw, "On branch ") {
+			branch = strings.Fields(strings.TrimPrefix(raw, "On branch "))[0]
+			continue
+		}
+		if strings.HasPrefix(raw, "##") {
+			branch = strings.TrimSpace(strings.TrimPrefix(raw, "##"))
+			continue
+		}
+		if len(raw) >= 4 && strings.Contains(" MADRCU?!", raw[:1]) && strings.Contains(" MADRCU?!", raw[1:2]) && raw[2] == ' ' {
+			x, y := raw[0], raw[1]
+			file := raw[3:]
+			if x != ' ' && x != '?' {
+				staged++
+				if len(stagedFiles) < maxFiles {
+					stagedFiles = append(stagedFiles, file)
+				}
+			}
+			if y != ' ' && y != '?' {
+				modified++
+				if len(modifiedFiles) < maxFiles {
+					modifiedFiles = append(modifiedFiles, file)
+				}
+			}
+			if x == '?' || y == '?' {
+				untracked++
+				if len(untrackedFiles) < maxUntracked {
+					untrackedFiles = append(untrackedFiles, file)
+				}
+			}
+			if x == 'U' || y == 'U' {
+				conflicts++
+			}
+			continue
+		}
+		t := strings.TrimSpace(raw)
+		if strings.HasPrefix(t, "modified:") {
+			modified++
+			if len(modifiedFiles) < maxFiles {
+				modifiedFiles = append(modifiedFiles, strings.TrimSpace(strings.TrimPrefix(t, "modified:")))
+			}
+			continue
+		}
+		if strings.HasPrefix(t, "new file:") {
+			staged++
+			if len(stagedFiles) < maxFiles {
+				stagedFiles = append(stagedFiles, strings.TrimSpace(strings.TrimPrefix(t, "new file:")))
+			}
+			continue
+		}
+		if !strings.Contains(t, " ") && strings.Contains(t, "/") {
+			untracked++
+			if len(untrackedFiles) < maxUntracked {
+				untrackedFiles = append(untrackedFiles, t)
+			}
+		}
+	}
+	var out []string
+	if branch != "" {
+		out = append(out, "branch: "+branch)
+	}
+	out = append(out, "staged="+stringInt(staged)+" modified="+stringInt(modified)+" untracked="+stringInt(untracked)+" conflicts="+stringInt(conflicts))
+	appendList := func(label string, files []string, total int) {
+		if total == 0 {
+			return
+		}
+		out = append(out, label+":")
+		for _, f := range files {
+			out = append(out, "  "+f)
+		}
+		if total > len(files) {
+			out = append(out, "  +"+stringInt(total-len(files)))
+		}
+	}
+	appendList("staged files", stagedFiles, staged)
+	appendList("modified files", modifiedFiles, modified)
+	appendList("untracked files", untrackedFiles, untracked)
+	return strings.Join(out, "\n")
+}
+
+func compactBuildOutput(input string) string {
+	lines := strings.Split(input, "\n")
+	var errors, warnings, deprecations []string
+	summary := ""
+	compilingCount, downloadingCount := 0, 0
+	inCargoError := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if inCargoError {
+			if trimmed == "" {
+				inCargoError = false
+				continue
+			}
+			if cargoErrContRE.MatchString(line) {
+				errors = append(errors, line)
+				continue
+			}
+			inCargoError = false
+		}
+		if trimmed == "" {
+			continue
+		}
+		switch {
+		case npmErrorRE.MatchString(trimmed), yarnErrorRE.MatchString(trimmed), strings.HasPrefix(trimmed, "ERROR:"), errorLineRE.MatchString(trimmed), strings.HasPrefix(trimmed, "error -->"), buildFailedRE.MatchString(trimmed):
+			errors = append(errors, line)
+			inCargoError = true
+		case npmWarnDeprecatedRE.MatchString(trimmed):
+			deprecations = append(deprecations, line)
+		case npmWarnRE.MatchString(trimmed), yarnWarnRE.MatchString(trimmed), warningLineRE.MatchString(trimmed), strings.HasPrefix(trimmed, "warning -->"), bracketWarningRE.MatchString(trimmed):
+			warnings = append(warnings, line)
+			inCargoError = strings.HasPrefix(trimmed, "warning -->")
+		case compilingRE.MatchString(trimmed):
+			compilingCount++
+		case downloadingRE.MatchString(trimmed):
+			downloadingCount++
+		case buildSummaryRE.MatchString(trimmed):
+			if summary == "" {
+				summary = line
+			} else {
+				summary += "\n" + line
+			}
+		}
+	}
+	var out []string
+	keepDep := 3
+	if len(deprecations) < keepDep {
+		keepDep = len(deprecations)
+	}
+	out = append(out, deprecations[:keepDep]...)
+	if len(deprecations) > keepDep {
+		out = append(out, "... +"+stringInt(len(deprecations)-keepDep)+" more deprecated packages")
+	}
+	if compilingCount > 0 {
+		out = append(out, "Compiled "+stringInt(compilingCount)+" packages")
+	}
+	if downloadingCount > 0 {
+		out = append(out, "Downloaded "+stringInt(downloadingCount)+" packages")
+	}
+	out = append(out, errors...)
+	keepWarnings := 5
+	if len(warnings) < keepWarnings {
+		keepWarnings = len(warnings)
+	}
+	out = append(out, warnings[:keepWarnings]...)
+	if len(warnings) > keepWarnings {
+		out = append(out, "... +"+stringInt(len(warnings)-keepWarnings)+" more warnings")
+	}
+	if summary != "" {
+		out = append(out, strings.Split(summary, "\n")...)
+	}
+	if len(out) == 0 {
+		return input
+	}
+	return strings.TrimRight(strings.Join(out, "\n"), "\n")
+}
+
+func dedupLog(text string) string {
+	const maxLine = 2000
+	lines := strings.Split(text, "\n")
+	seen := map[string]int{}
+	var out []string
+	omitted := 0
+	for _, line := range lines {
+		key := line
+		if len(key) > maxLine {
+			key = key[:maxLine]
+		}
+		seen[key]++
+		if seen[key] <= 3 {
+			out = append(out, line)
+		} else {
+			omitted++
+		}
+	}
+	if omitted > 0 {
+		out = append(out, "... "+stringInt(omitted)+" duplicate lines omitted")
+	}
+	return strings.TrimRight(strings.Join(out, "\n"), "\n")
+}
+
+func smartTruncate(text string) string {
+	lines := strings.Split(text, "\n")
+	const head = 120
+	const tail = 60
+	if len(lines) <= head+tail {
+		return text
+	}
+	out := append([]string{}, lines[:head]...)
+	out = append(out, "... "+stringInt(len(lines)-head-tail)+" lines omitted ...")
+	out = append(out, lines[len(lines)-tail:]...)
+	return strings.TrimRight(strings.Join(out, "\n"), "\n")
+}
+
+func readNumbered(text string) string {
+	lines := strings.Split(text, "\n")
+	return smartTruncate(strings.Join(lines, "\n"))
+}
+
+func compactTree(text string) string {
+	lines := strings.Split(text, "\n")
+	var out []string
+	for _, line := range lines {
+		if strings.Contains(line, "director") && strings.Contains(line, "file") {
+			continue
+		}
+		if strings.TrimSpace(line) == "" && len(out) == 0 {
+			continue
+		}
+		out = append(out, line)
+	}
+	for len(out) > 0 && strings.TrimSpace(out[len(out)-1]) == "" {
+		out = out[:len(out)-1]
+	}
+	const maxLines = 200
+	if len(out) > maxLines {
+		return strings.Join(out[:maxLines], "\n") + "\n... +" + stringInt(len(out)-maxLines) + " more lines"
+	}
+	return strings.Join(out, "\n")
+}
+
+type lsEntry struct {
+	fileType byte
+	size     int64
+	name     string
+}
+
+func compactLS(text string) string {
+	var entries []lsEntry
+	for _, line := range strings.Split(text, "\n") {
+		if entry, ok := parseLSLine(line); ok {
+			entries = append(entries, entry)
+		}
+	}
+	if len(entries) == 0 {
+		return text
+	}
+	dirs, files, totalSize := 0, 0, int64(0)
+	exts := map[string]int{}
+	for _, entry := range entries {
+		if entry.fileType == 'd' {
+			dirs++
+			continue
+		}
+		files++
+		totalSize += entry.size
+		if idx := strings.LastIndex(entry.name, "."); idx >= 0 && idx < len(entry.name)-1 {
+			exts[strings.ToLower(entry.name[idx:])]++
+		}
+	}
+	out := []string{"ls: " + stringInt(files) + " files, " + stringInt(dirs) + " dirs, " + humanSize(totalSize)}
+	type kv struct {
+		k string
+		v int
+	}
+	var pairs []kv
+	for k, v := range exts {
+		pairs = append(pairs, kv{k: k, v: v})
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		if pairs[i].v == pairs[j].v {
+			return pairs[i].k < pairs[j].k
+		}
+		return pairs[i].v > pairs[j].v
+	})
+	for i, p := range pairs {
+		if i >= 5 {
+			break
+		}
+		out = append(out, p.k+": "+stringInt(p.v))
+	}
+	return strings.Join(out, "\n")
+}
+
+func parseLSLine(line string) (lsEntry, bool) {
+	if len(line) < 10 || !lsPermRE.MatchString(line[:10]) {
+		return lsEntry{}, false
+	}
+	fields := strings.Fields(line)
+	if len(fields) < 9 {
+		return lsEntry{}, false
+	}
+	size, err := strconv.ParseInt(fields[4], 10, 64)
+	if err != nil {
+		return lsEntry{}, false
+	}
+	return lsEntry{fileType: line[0], size: size, name: strings.Join(fields[8:], " ")}, true
+}
+
+func compactSearchList(text string) string {
+	lines := strings.Split(text, "\n")
+	if len(lines) == 0 || !searchListHeaderRE.MatchString(lines[0]) {
+		return text
+	}
+	var paths []string
+	for _, raw := range lines[1:] {
+		t := strings.TrimSpace(raw)
+		if strings.HasPrefix(t, "- ") {
+			paths = append(paths, strings.TrimSpace(strings.TrimPrefix(t, "- ")))
+		}
+	}
+	if len(paths) == 0 {
+		return text
+	}
+	return lines[0] + "\n" + compactPathBasenames(paths, 10, 20)
+}
+
+var (
+	grepLineRE          = regexp.MustCompile(`^.+:\d+:.+`)
+	porcelainRE         = regexp.MustCompile(`^[ MADRCU?!][ MADRCU?!] \S`)
+	lsPermRE            = regexp.MustCompile(`^[-dlbcps][rwx-]{9}$`)
+	readNumberedLineRE  = regexp.MustCompile(`^\s*\d+\|`)
+	searchListHeaderRE  = regexp.MustCompile(`^Result of search in '.+' \(total \d+ files\):`)
+	cargoErrContRE      = regexp.MustCompile(`^\s*(-->|\||\d+\s*\||=)`)
+	buildOutputRE       = regexp.MustCompile(`(?i)^(npm (warn|error|ERR!)|yarn (warn|error)|\s*Compiling\s+\S+|\s*Downloading\s+\S+|added \d+ package|\[ERROR\]|BUILD (SUCCESS|FAILED)|\s*Finished\s+|Successfully (installed|built)|ERROR:)`)
+	npmErrorRE          = regexp.MustCompile(`(?i)^npm (ERR!|error)`)
+	yarnErrorRE         = regexp.MustCompile(`(?i)^yarn error`)
+	npmWarnDeprecatedRE = regexp.MustCompile(`(?i)^npm warn deprecated`)
+	npmWarnRE           = regexp.MustCompile(`(?i)^npm warn`)
+	yarnWarnRE          = regexp.MustCompile(`(?i)^yarn warn`)
+	errorLineRE         = regexp.MustCompile(`(?i)^error(\[|:)`)
+	warningLineRE       = regexp.MustCompile(`(?i)^warning(\[|:)`)
+	bracketWarningRE    = regexp.MustCompile(`(?i)^\[WARNING\]`)
+	buildFailedRE       = regexp.MustCompile(`(?i)^\[ERROR\]|^BUILD FAILED`)
+	compilingRE         = regexp.MustCompile(`(?i)^\s*Compiling\s+\S+`)
+	downloadingRE       = regexp.MustCompile(`(?i)^\s*Downloading\s+\S+|^Fetching\s+`)
+	buildSummaryRE      = regexp.MustCompile(`(?i)^(added|removed|changed|audited|installed)\s+\d+\s+package|^\s*Finished\s+|^BUILD SUCCESS|^\d+\s+(vulnerabilities|packages?|warnings?|errors?)|^Successfully (installed|built)|^To address .* issues|^Run ` + "`" + `npm (audit|fund)` + "`" + `|packages are looking for funding`)
+	envAssignRE         = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*=`)
+)
+
+func looksLikeGrep(head string) bool {
+	lines := nonEmptyLines(head)
+	limit := 5
+	if len(lines) < limit {
+		limit = len(lines)
+	}
+	for _, line := range lines[:limit] {
+		if grepLineRE.MatchString(line) {
+			return true
+		}
+	}
+	return false
+}
+
+func looksLikePathList(head string) bool {
+	lines := nonEmptyLines(head)
+	if len(lines) < 3 {
+		return false
+	}
+	for _, line := range lines {
+		t := strings.TrimSpace(line)
+		if strings.Contains(t, ":") {
+			return false
+		}
+		if !(strings.HasPrefix(t, ".") || strings.HasPrefix(t, "/") || strings.Contains(t, "/")) {
+			return false
+		}
+	}
+	return true
+}
+
+func looksLikePorcelain(head string) bool {
+	lines := nonEmptyLines(head)
+	if len(lines) < 3 {
+		return false
+	}
+	hits := 0
+	for _, line := range lines {
+		if porcelainRE.MatchString(line) {
+			hits++
+		}
+	}
+	return hits*10 >= len(lines)*6
+}
+
+func looksLikeBuildOutput(head string) bool {
+	for _, line := range strings.Split(head, "\n") {
+		if buildOutputRE.MatchString(strings.TrimSpace(line)) {
+			return true
+		}
+	}
+	return false
+}
+
+func looksLikeLS(head string) bool {
+	if regexp.MustCompile(`(?m)^total \d+$`).MatchString(head) {
+		return true
+	}
+	count := 0
+	for _, line := range strings.Split(head, "\n") {
+		if len(line) >= 10 && lsPermRE.MatchString(line[:10]) {
+			count++
+		}
+	}
+	return count >= 3
+}
+
+func isLineNumbered(lines []string) bool {
+	hits, nonEmpty := 0, 0
+	limit := 100
+	if len(lines) < limit {
+		limit = len(lines)
+	}
+	for _, line := range lines[:limit] {
+		if line == "" {
+			continue
+		}
+		nonEmpty++
+		if readNumberedLineRE.MatchString(line) {
+			hits++
+		}
+	}
+	return nonEmpty >= 5 && hits*10 >= nonEmpty*7
+}
+
+func nonEmptyLines(text string) []string {
+	var out []string
+	for _, line := range strings.Split(text, "\n") {
+		if strings.TrimSpace(line) != "" {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+func humanSize(bytes int64) string {
+	switch {
+	case bytes >= 1_048_576:
+		return strconv.FormatFloat(float64(bytes)/1_048_576, 'f', 1, 64) + "M"
+	case bytes >= 1024:
+		return strconv.FormatFloat(float64(bytes)/1024, 'f', 1, 64) + "K"
+	default:
+		return stringInt(int(bytes)) + "B"
+	}
+}
+
+func leftPad(value string, width int) string {
+	if len(value) >= width {
+		return value
+	}
+	return strings.Repeat(" ", width-len(value)) + value
+}
+
+func stringInt(n int) string {
+	return strconv.Itoa(n)
+}
+
+func toolCommands(payload any) map[string]string {
+	cmds := map[string]string{}
+	collectToolCommands(payload, cmds)
+	if len(cmds) == 0 {
+		return nil
+	}
+	return cmds
+}
+
+func collectToolCommands(v any, cmds map[string]string) {
+	switch val := v.(type) {
+	case map[string]any:
+		switch typeName, _ := val["type"].(string); typeName {
+		case "function_call":
+			id, _ := val["call_id"].(string)
+			if strings.TrimSpace(id) == "" {
+				id, _ = val["id"].(string)
+			}
+			if cmd := commandFromToolCall(val); id != "" && cmd != "" {
+				cmds[id] = cmd
+			}
+		case "tool_use":
+			id, _ := val["id"].(string)
+			if cmd := commandFromToolCall(val); id != "" && cmd != "" {
+				cmds[id] = cmd
+			}
+		}
+		if calls, ok := val["tool_calls"].([]any); ok {
+			for _, call := range calls {
+				if m, ok := call.(map[string]any); ok {
+					id, _ := m["id"].(string)
+					if cmd := commandFromToolCall(m); id != "" && cmd != "" {
+						cmds[id] = cmd
+					}
+				}
+			}
+		}
+		for _, child := range val {
+			collectToolCommands(child, cmds)
+		}
+	case []any:
+		for _, child := range val {
+			collectToolCommands(child, cmds)
+		}
+	}
+}
+
+func commandFromToolCall(m map[string]any) string {
+	name, _ := m["name"].(string)
+	input := m["input"]
+	if fn, ok := m["function"].(map[string]any); ok {
+		if name == "" {
+			name, _ = fn["name"].(string)
+		}
+		input = fn["arguments"]
+	}
+	if !isShellToolName(name) {
+		return ""
+	}
+	switch v := input.(type) {
+	case map[string]any:
+		for _, key := range []string{"cmd", "command", "script"} {
+			if s, ok := v[key].(string); ok && strings.TrimSpace(s) != "" {
+				return strings.TrimSpace(s)
+			}
+		}
+	case string:
+		var parsed map[string]any
+		if json.Unmarshal([]byte(v), &parsed) == nil {
+			return commandFromToolCall(map[string]any{"name": name, "input": parsed})
+		}
+	}
+	return ""
+}
+
+func isShellToolName(name string) bool {
+	n := strings.ToLower(strings.TrimSpace(name))
+	return n == "shell" || n == "bash" || n == "terminal" || n == "exec" ||
+		n == "exec_command" || strings.Contains(n, "shell") || strings.Contains(n, "terminal")
+}
+
+func filterForCommand(command string) string {
+	words := shellWords(command)
+	for len(words) > 0 && envAssignRE.MatchString(words[0]) {
+		words = words[1:]
+	}
+	if len(words) == 0 {
+		return ""
+	}
+	cmd := strings.TrimSuffix(words[0], ",")
+	base := cmd
+	if idx := strings.LastIndex(base, "/"); idx >= 0 {
+		base = base[idx+1:]
+	}
+	switch base {
+	case "git":
+		if len(words) > 1 {
+			switch words[1] {
+			case "diff", "show":
+				return "git-diff"
+			case "status":
+				return "git-status"
+			}
+		}
+	case "rg", "grep", "ag":
+		return "grep"
+	case "find", "fd":
+		return "find"
+	case "ls", "ll":
+		return "ls"
+	case "tree":
+		return "tree"
+	case "npm", "yarn", "pnpm", "cargo", "go", "mvn", "gradle", "make", "pip", "uv":
+		return "build-output"
+	case "sed", "awk", "nl", "cat":
+		return "read-numbered"
+	}
+	return ""
+}
+
+func commandIsGit(command string) bool {
+	words := shellWords(command)
+	for len(words) > 0 && envAssignRE.MatchString(words[0]) {
+		words = words[1:]
+	}
+	return len(words) > 0 && strings.TrimSuffix(words[0], ",") == "git"
+}
+
+func shellWords(command string) []string {
+	var words []string
+	var b strings.Builder
+	inSingle, inDouble, escaped := false, false, false
+	for _, r := range command {
+		switch {
+		case escaped:
+			b.WriteRune(r)
+			escaped = false
+		case r == '\\' && !inSingle:
+			escaped = true
+		case r == '\'' && !inDouble:
+			inSingle = !inSingle
+		case r == '"' && !inSingle:
+			inDouble = !inDouble
+		case (r == ' ' || r == '\t' || r == '\n') && !inSingle && !inDouble:
+			if b.Len() > 0 {
+				words = append(words, b.String())
+				b.Reset()
+			}
+		default:
+			b.WriteRune(r)
+		}
+	}
+	if b.Len() > 0 {
+		words = append(words, b.String())
+	}
+	return words
+}

--- a/rtk/rtk_test.go
+++ b/rtk/rtk_test.go
@@ -1,0 +1,152 @@
+package rtk
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestTransformJSONCompressesClaudeToolResult(t *testing.T) {
+	toolOutput := repeatedGrepOutput(35)
+	raw := `{
+		"model":"claude-sonnet-4.5",
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"exec_command","input":{"cmd":"rg needle"}}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":` + quoteJSON(toolOutput) + `}]}
+		]
+	}`
+
+	updated, stats, changed, err := TransformJSON([]byte(raw), Config{Enabled: true, MinBytes: 1, MaxBytes: DefaultMaxBytes})
+	if err != nil {
+		t.Fatalf("TransformJSON error: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected request to be compressed")
+	}
+	if len(stats.Hits) != 1 || stats.Hits[0].Filter != "grep" || stats.Hits[0].Shape != "tool-result" {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(updated, &payload); err != nil {
+		t.Fatalf("decode updated: %v", err)
+	}
+	content := payload["messages"].([]any)[1].(map[string]any)["content"].([]any)[0].(map[string]any)["content"].(string)
+	if !strings.Contains(content, "35 matches in 1 files") {
+		t.Fatalf("expected grep summary, got %q", content)
+	}
+	if strings.Contains(content, "needle occurrence 34") {
+		t.Fatalf("expected long raw tail to be removed, got %q", content)
+	}
+}
+
+func TestTransformJSONCompressesOpenAIResponsesBuildOutput(t *testing.T) {
+	raw := `{
+		"model":"claude-sonnet-4.5",
+		"input":[
+			{"type":"function_call","call_id":"call_1","name":"exec_command","input":{"cmd":"cargo build"}},
+			{"type":"function_call_output","call_id":"call_1","output":` + quoteJSON(repeatedBuildOutput(40)) + `}
+		]
+	}`
+
+	updated, stats, changed, err := TransformJSON([]byte(raw), Config{Enabled: true, MinBytes: 1, MaxBytes: DefaultMaxBytes})
+	if err != nil {
+		t.Fatalf("TransformJSON error: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected request to be compressed")
+	}
+	if len(stats.Hits) != 1 || stats.Hits[0].Filter != "build-output" || stats.Hits[0].Shape != "openai-responses" {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+	if !strings.Contains(string(updated), "Compiled 40 packages") {
+		t.Fatalf("expected build summary, got %s", string(updated))
+	}
+}
+
+func TestTransformJSONCompressesNativeKiroToolResult(t *testing.T) {
+	raw := `{
+		"conversationState":{
+			"currentMessage":{
+				"userInputMessage":{
+					"userInputMessageContext":{
+						"toolResults":[{"toolUseId":"toolu_1","status":"success","content":[{"text":` + quoteJSON(repeatedGrepOutput(30)) + `}]}]
+					}
+				}
+			},
+			"history":[]
+		}
+	}`
+
+	updated, stats, changed, err := TransformJSON([]byte(raw), Config{Enabled: true, MinBytes: 1, MaxBytes: DefaultMaxBytes})
+	if err != nil {
+		t.Fatalf("TransformJSON error: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected native Kiro payload to be compressed")
+	}
+	if len(stats.Hits) != 1 || stats.Hits[0].Shape != "kiro-tool-result" {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+	if !strings.Contains(string(updated), "30 matches in 1 files") {
+		t.Fatalf("expected native Kiro grep summary, got %s", string(updated))
+	}
+}
+
+func TestTransformJSONSkipsErroredNativeKiroToolResult(t *testing.T) {
+	output := repeatedGrepOutput(30)
+	raw := `{
+		"conversationState":{
+			"currentMessage":{
+				"userInputMessage":{
+					"userInputMessageContext":{
+						"toolResults":[{"toolUseId":"toolu_1","status":"error","content":[{"text":` + quoteJSON(output) + `}]}]
+					}
+				}
+			}
+		}
+	}`
+
+	updated, stats, changed, err := TransformJSON([]byte(raw), Config{Enabled: true, MinBytes: 1, MaxBytes: DefaultMaxBytes})
+	if err != nil {
+		t.Fatalf("TransformJSON error: %v", err)
+	}
+	if changed {
+		t.Fatalf("expected errored tool result to remain unchanged")
+	}
+	if len(stats.Hits) != 0 {
+		t.Fatalf("unexpected hits: %+v", stats.Hits)
+	}
+	if !strings.Contains(string(updated), "needle occurrence 29") {
+		t.Fatalf("expected raw error output to remain, got %s", string(updated))
+	}
+}
+
+func repeatedGrepOutput(n int) string {
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		b.WriteString("proxy/handler.go:")
+		b.WriteString(stringInt(100 + i))
+		b.WriteString(": needle occurrence ")
+		b.WriteString(stringInt(i))
+		b.WriteString(" with a verbose line that should not be repeated in full after compression\n")
+	}
+	return b.String()
+}
+
+func repeatedBuildOutput(n int) string {
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		b.WriteString("   Compiling crate_")
+		b.WriteString(stringInt(i))
+		b.WriteString(" v0.1.0 (/tmp/crate)\n")
+	}
+	b.WriteString("warning: unused import: fmt\n")
+	b.WriteString("    Finished dev [unoptimized + debuginfo] target(s) in 12.34s\n")
+	return b.String()
+}
+
+func quoteJSON(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}


### PR DESCRIPTION
## Summary
- add a standalone RTK request-compression package for tool-result payloads
- enable RTK by default for Claude messages, Claude count_tokens, OpenAI chat completions, and OpenAI responses before request validation/translation
- keep the integration isolated from persisted config/admin UI; optional env overrides are KIRO_GO_RTK, KIRO_GO_RTK_MIN_BYTES, and KIRO_GO_RTK_MAX_BYTES

## Verification
- go test ./rtk -v
- go test ./proxy -run TestRTKCompressesClaudeToolResultBeforeUpstreamKiroRequest -v
- go test ./proxy -run 'TestRTKCompresses(ClaudeToolResult|MultiTurnClaudeCodeSession|MultiTurnOpenAIChatSession)BeforeUpstreamKiroRequest' -v -count=1
- KIRO_GO_RTK_ARTIFACT_DIR=/tmp/kiro-go-rtk-live go test ./proxy -run 'TestRTKCompresses(ClaudeToolResult|MultiTurnClaudeCodeSession|MultiTurnOpenAIChatSession)BeforeUpstreamKiroRequest' -v -count=1
- go test ./rtk ./proxy -run 'TestRTK|TestTransformJSON' -count=1
- go test ./... currently fails on upstream-main tests TestClaudeToolResultMixedTextAndImage and TestOpenAIToolResultImageCarriedWhenFollowedByUser; reproduced unchanged in a clean upstream/main worktree at a2e3971

## Live Capture
The integration tests capture same-shape upstream Kiro request JSON with RTK disabled and enabled.

Captured cases:
- single-turn Claude tool result: 4550B to 1049B, 76.9% saved, filter=grep
- multi-turn Claude-Code-style session: 3 tool-result hits, 10351B to 2397B across compressed tool outputs, 76.8% saved, filters=build-output,grep
- multi-turn Codex/OpenAI-chat-style session: 3 tool-result hits, 10001B to 2387B across compressed tool outputs, 76.1% saved, filters=build-output,grep

Artifacts written under KIRO_GO_RTK_ARTIFACT_DIR include raw and normalized before/after Kiro request JSON plus current-tool-result and history text extracts for the single-turn, Claude multi-turn, and Codex multi-turn cases.
