### PR TITLE
fix(responses): preserve images in function_call_output as vision input

### DIFF
--- a/proxy/responses_input.go
+++ b/proxy/responses_input.go
@@ -80,13 +80,23 @@ func convertResponsesInputItems(items []json.RawMessage) ([]OpenAIMessage, error
 			if callID == "" {
 				callID, _ = obj["tool_call_id"].(string)
 			}
-			out := stringifyArbitrary(obj["output"])
-			if out == "" {
-				out = stringifyArbitrary(obj["content"])
+			rawOut := obj["output"]
+			if rawOut == nil {
+				rawOut = obj["content"]
+			}
+			var toolContent interface{}
+			if parts := toolOutputParts(rawOut); parts != nil {
+				toolContent = parts
+			} else {
+				out := stringifyArbitrary(obj["output"])
+				if out == "" {
+					out = stringifyArbitrary(obj["content"])
+				}
+				toolContent = out
 			}
 			messages = append(messages, OpenAIMessage{
 				Role:       "tool",
-				Content:    out,
+				Content:    toolContent,
 				ToolCallID: callID,
 			})
 
@@ -229,3 +239,40 @@ func stringField(obj map[string]interface{}, keys ...string) string {
 	}
 	return ""
 }
+
+// toolOutputParts inspects a function_call_output payload and, when it carries
+// structured multimodal parts (notably images), returns them as a normalized
+// []interface{} so downstream conversion treats images as vision input instead
+// of stringifying the base64 data-URI into plain text. Returns nil when the
+// output has no image parts, so callers fall back to plain text handling.
+func toolOutputParts(raw interface{}) []interface{} {
+	arr, ok := raw.([]interface{})
+	if !ok {
+		return nil
+	}
+	hasImage := false
+	parts := make([]interface{}, 0, len(arr))
+	for _, p := range arr {
+		part, ok := p.(map[string]interface{})
+		if !ok {
+			return nil
+		}
+		ptype, _ := part["type"].(string)
+		switch ptype {
+		case "input_image", "image", "image_url":
+			hasImage = true
+			parts = append(parts, part)
+		case "input_text", "text", "output_text":
+			if t, ok := part["text"].(string); ok {
+				parts = append(parts, map[string]interface{}{"type": "input_text", "text": t})
+			}
+		default:
+			parts = append(parts, part)
+		}
+	}
+	if !hasImage {
+		return nil
+	}
+	return parts
+}
+

--- a/proxy/responses_tool_image_test.go
+++ b/proxy/responses_tool_image_test.go
@@ -1,0 +1,74 @@
+package proxy
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// tinyPNGDataURL is a 1x1 transparent PNG as a data URL, standing in for a
+// view_image tool result.
+const tinyPNGDataURL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+
+// TestResponsesToolOutputImagePreserved verifies that a function_call_output
+// whose output carries an input_image part is preserved as structured content
+// (so the image is forwarded as vision input) instead of being JSON-stringified
+// into plain text. The latter caused a 512x512 icon to burn ~12.8k tokens
+// instead of ~350 because the base64 data-URI was counted (and duplicated) as
+// text. See docs/opus-image-token-bug-20260611.md.
+func TestResponsesToolOutputImagePreserved(t *testing.T) {
+	output := `[{"type":"input_image","image_url":"` + tinyPNGDataURL + `"}]`
+	items := []json.RawMessage{
+		mustRaw(`{"type":"message","role":"user","content":[{"type":"input_text","text":"view it"}]}`),
+		mustRaw(`{"type":"function_call","call_id":"call_a","name":"view_image","arguments":"{\"path\":\"x.png\"}"}`),
+		mustRaw(`{"type":"function_call_output","call_id":"call_a","output":` + output + `}`),
+	}
+
+	msgs, err := convertResponsesInputItems(items)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+
+	var tool *OpenAIMessage
+	for i := range msgs {
+		if msgs[i].Role == "tool" {
+			tool = &msgs[i]
+			break
+		}
+	}
+	if tool == nil {
+		t.Fatal("no tool message produced")
+	}
+
+	// Content must be structured parts, not a flattened string blob.
+	if s, ok := tool.Content.(string); ok {
+		t.Fatalf("tool content was stringified (len=%d); image lost to text", len(s))
+	}
+
+	// Downstream extraction must recover a real image, no base64 left as text.
+	text, images := extractOpenAIUserContent(tool.Content)
+	if len(images) != 1 {
+		t.Fatalf("expected 1 extracted image, got %d", len(images))
+	}
+	if strings.Contains(text, "base64") || strings.Contains(text, "iVBOR") {
+		t.Fatalf("base64 payload leaked into text content: %q", text)
+	}
+}
+
+// TestResponsesToolOutputTextStillString verifies the common case (plain string
+// tool output) is unchanged: it stays a string, not wrapped in parts.
+func TestResponsesToolOutputTextStillString(t *testing.T) {
+	items := []json.RawMessage{
+		mustRaw(`{"type":"function_call_output","call_id":"c","output":"plain result"}`),
+	}
+	msgs, err := convertResponsesInputItems(items)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if len(msgs) != 1 || msgs[0].Role != "tool" {
+		t.Fatalf("unexpected messages: %+v", msgs)
+	}
+	if s, ok := msgs[0].Content.(string); !ok || s != "plain result" {
+		t.Fatalf("expected plain string content, got %#v", msgs[0].Content)
+	}
+}


### PR DESCRIPTION
## Problem

When a Codex agent uses `view_image` (or any tool that returns an image), the image is sent back to the model inside a `function_call_output` item whose `output` is a structured array like:

```json
[{"type":"input_image","image_url":"data:image/png;base64,iVBORw0KGgo..."}]
```

The `function_call_output` handler in `parseResponsesInput` called `stringifyArbitrary(output)`, which JSON-stringifies the whole array. The base64 data-URI ended up as plain text instead of a vision part, so the image was never tiled as vision input.

### Measured impact (claude-opus-4.8)

A tiny 512x512 PNG (6.7 KB) cost **~12,848 input tokens**, versus **~514** after the fix — roughly a 25x overcharge. The model also could not actually "see" the image: it produced a vague, wrong description (a "dark blue boxy container") because it only received the base64 text. After the fix it described the image correctly (a black ghost icon with white eyes).

This scales badly: a real screenshot (~200 KB base64) would burn hundreds of thousands of tokens and could overflow the context window from a single image.

## Fix

Add `toolOutputParts()` in `proxy/responses_input.go`. When a `function_call_output` payload carries image parts, preserve them as normalized structured content (`input_image` / `input_text`) so the existing downstream image path (`translator.go` `case "tool"` -> `extractOpenAIUserContent`) converts them into Kiro vision input. Text-only tool outputs keep the original plain-string behavior, so nothing else changes.

## Verification

- Reproduced end-to-end through a real Codex `exec` run; image bytes confirmed byte-identical (sha256) at the wire.
- Before: image turn = 32,286 input tokens (+12,848 for the image); After: 17,351 input tokens (+514 for the image).
- New tests in `proxy/responses_tool_image_test.go`:
  - `TestResponsesToolOutputImagePreserved` - image survives as structured content
  - `TestResponsesToolOutputTextStillString` - text outputs stay plain strings
- Full suite green: `go test ./...`
