### PR TITLE
feat: add session affinity and request logs panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@
 .idea/
 .vscode/
 .claude/
+.kiro/
+*.code-workspace
 .DS_Store
 Thumbs.db
 

--- a/proxy/auth.go
+++ b/proxy/auth.go
@@ -53,11 +53,17 @@ func extractProvidedKey(r *http.Request) string {
 // Returns (entry, nil) on success. entry is nil when the legacy single-key path
 // is used or when the master switch is off.
 func (h *Handler) authenticate(r *http.Request) (*config.ApiKeyEntry, error) {
+	provided := extractProvidedKey(r)
+
 	if !config.IsApiKeyRequired() {
+		// Even when auth is not required, try to identify the caller for affinity/usage tracking.
+		if provided != "" && config.HasApiKeys() {
+			if entry := config.FindApiKeyByValue(provided); entry != nil && entry.Enabled {
+				return entry, nil
+			}
+		}
 		return nil, nil
 	}
-
-	provided := extractProvidedKey(r)
 
 	if config.HasApiKeys() {
 		if provided == "" {

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -38,6 +38,8 @@ type Handler struct {
 	modelsCacheTime int64
 	promptCache     *promptCacheTracker
 	tokenRefreshMu  sync.Mutex
+	// 会话粘性：apiKeyID → accountID
+	sessionAffinity sync.Map
 }
 
 type thinkingStreamSource int
@@ -867,7 +869,7 @@ func (h *Handler) handleClaudeStream(w http.ResponseWriter, payload *KiroPayload
 	}
 
 	for attempt := 0; attempt < maxAccountRetryAttempts; attempt++ {
-		account := h.pool.GetNextForModelExcluding(model, excluded)
+		account := h.getAffinityAccount(apiKeyID, model, excluded)
 		if account == nil {
 			break
 		}
@@ -875,6 +877,7 @@ func (h *Handler) handleClaudeStream(w http.ResponseWriter, payload *KiroPayload
 			lastErr = err
 			excluded[account.ID] = true
 			h.handleAccountFailure(account, err)
+			h.sessionAffinity.Delete(apiKeyID)
 			continue
 		}
 		cacheUsage := h.promptCache.Compute(account.ID, cacheProfile)
@@ -1339,13 +1342,45 @@ func (h *Handler) recordFailure() {
 	atomic.AddInt64(&h.failedRequests, 1)
 }
 
+// getAffinityAccount implements session affinity: returns the previously-bound
+// account for the given apiKeyID if still available, otherwise falls back to
+// weighted round-robin and remembers the new assignment.
+func (h *Handler) getAffinityAccount(apiKeyID, model string, excluded map[string]bool) *config.Account {
+	// 1. Try sticky account
+	if apiKeyID != "" {
+		if accID, ok := h.sessionAffinity.Load(apiKeyID); ok {
+			id := accID.(string)
+			if !excluded[id] {
+				acc := h.pool.GetByID(id)
+				if acc != nil && acc.Enabled {
+					logger.Debugf("[Affinity] Hit: apiKey=%s → account=%s", apiKeyID[:8], acc.Email)
+					return acc
+				}
+			}
+			// Bound account unavailable, clear binding
+			h.sessionAffinity.Delete(apiKeyID)
+			logger.Debugf("[Affinity] Cleared stale binding for apiKey=%s", apiKeyID[:8])
+		}
+	}
+
+	// 2. Fallback to normal round-robin
+	acc := h.pool.GetNextForModelExcluding(model, excluded)
+
+	// 3. Remember the new assignment
+	if acc != nil && apiKeyID != "" {
+		h.sessionAffinity.Store(apiKeyID, acc.ID)
+		logger.Debugf("[Affinity] New binding: apiKey=%s → account=%s", apiKeyID[:8], acc.Email)
+	}
+	return acc
+}
+
 // handleClaudeNonStream Claude 非流式响应
 func (h *Handler) handleClaudeNonStream(w http.ResponseWriter, payload *KiroPayload, model string, thinking bool, thinkingOpts claudeThinkingResponseOptions, estimatedInputTokens int, cacheProfile *promptCacheProfile, apiKeyID string) {
 	excluded := make(map[string]bool)
 	var lastErr error
 
 	for attempt := 0; attempt < maxAccountRetryAttempts; attempt++ {
-		account := h.pool.GetNextForModelExcluding(model, excluded)
+		account := h.getAffinityAccount(apiKeyID, model, excluded)
 		if account == nil {
 			break
 		}
@@ -1353,6 +1388,7 @@ func (h *Handler) handleClaudeNonStream(w http.ResponseWriter, payload *KiroPayl
 			lastErr = err
 			excluded[account.ID] = true
 			h.handleAccountFailure(account, err)
+			h.sessionAffinity.Delete(apiKeyID)
 			continue
 		}
 		cacheUsage := h.promptCache.Compute(account.ID, cacheProfile)
@@ -1530,7 +1566,7 @@ func (h *Handler) handleOpenAIStream(w http.ResponseWriter, payload *KiroPayload
 	var lastErr error
 
 	for attempt := 0; attempt < maxAccountRetryAttempts; attempt++ {
-		account := h.pool.GetNextForModelExcluding(model, excluded)
+		account := h.getAffinityAccount(apiKeyID, model, excluded)
 		if account == nil {
 			break
 		}
@@ -1538,6 +1574,7 @@ func (h *Handler) handleOpenAIStream(w http.ResponseWriter, payload *KiroPayload
 			lastErr = err
 			excluded[account.ID] = true
 			h.handleAccountFailure(account, err)
+			h.sessionAffinity.Delete(apiKeyID)
 			continue
 		}
 
@@ -1905,7 +1942,7 @@ func (h *Handler) handleOpenAINonStream(w http.ResponseWriter, payload *KiroPayl
 	var lastErr error
 
 	for attempt := 0; attempt < maxAccountRetryAttempts; attempt++ {
-		account := h.pool.GetNextForModelExcluding(model, excluded)
+		account := h.getAffinityAccount(apiKeyID, model, excluded)
 		if account == nil {
 			break
 		}
@@ -1913,6 +1950,7 @@ func (h *Handler) handleOpenAINonStream(w http.ResponseWriter, payload *KiroPayl
 			lastErr = err
 			excluded[account.ID] = true
 			h.handleAccountFailure(account, err)
+			h.sessionAffinity.Delete(apiKeyID)
 			continue
 		}
 

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -9,6 +9,7 @@ import (
 	"kiro-go/logger"
 	"kiro-go/pool"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -40,6 +41,8 @@ type Handler struct {
 	tokenRefreshMu  sync.Mutex
 	// 会话粘性：apiKeyID → accountID
 	sessionAffinity sync.Map
+	// 请求日志
+	requestLogs *LogStore
 }
 
 type thinkingStreamSource int
@@ -227,6 +230,7 @@ func NewHandler() *Handler {
 		stopRefresh:     make(chan struct{}),
 		stopStatsSaver:  make(chan struct{}),
 		promptCache:     newPromptCacheTracker(defaultPromptCacheTTL),
+		requestLogs:     NewLogStore(defaultMaxLogs),
 	}
 	// 启动后台刷新
 	go h.backgroundRefresh()
@@ -828,6 +832,7 @@ func (h *Handler) handleClaudeMessagesInternal(w http.ResponseWriter, r *http.Re
 
 // handleClaudeStream Claude 流式响应
 func (h *Handler) handleClaudeStream(w http.ResponseWriter, payload *KiroPayload, model string, thinking bool, thinkingOpts claudeThinkingResponseOptions, estimatedInputTokens int, cacheProfile *promptCacheProfile, apiKeyID string) {
+	startTime := time.Now()
 	w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
@@ -1207,6 +1212,7 @@ func (h *Handler) handleClaudeStream(w http.ResponseWriter, payload *KiroPayload
 				continue
 			}
 			h.recordFailure()
+			h.recordRequestLog("/v1/messages", model, 500, 0, 0, 0, 0, 0, time.Since(startTime).Milliseconds(), apiKeyID)
 			h.sendSSE(w, flusher, "error", map[string]interface{}{
 				"type":  "error",
 				"error": map[string]string{"type": "api_error", "message": err.Error()},
@@ -1239,6 +1245,7 @@ func (h *Handler) handleClaudeStream(w http.ResponseWriter, payload *KiroPayload
 		h.pool.RecordSuccess(account.ID)
 		h.pool.UpdateStats(account.ID, inputTokens+outputTokens, credits)
 		h.promptCache.Update(account.ID, cacheProfile)
+		h.recordRequestLog("/v1/messages", model, 200, inputTokens, outputTokens, cacheUsage.CacheReadInputTokens, cacheUsage.CacheCreationInputTokens, credits, time.Since(startTime).Milliseconds(), apiKeyID)
 
 		stopReason := "end_turn"
 		if len(toolUses) > 0 {
@@ -1266,6 +1273,7 @@ func (h *Handler) handleClaudeStream(w http.ResponseWriter, payload *KiroPayload
 	}
 
 	h.recordFailure()
+	h.recordRequestLog("/v1/messages", model, 500, 0, 0, 0, 0, 0, time.Since(startTime).Milliseconds(), apiKeyID)
 	h.sendClaudeError(w, 500, "api_error", lastErr.Error())
 }
 
@@ -1376,6 +1384,7 @@ func (h *Handler) getAffinityAccount(apiKeyID, model string, excluded map[string
 
 // handleClaudeNonStream Claude 非流式响应
 func (h *Handler) handleClaudeNonStream(w http.ResponseWriter, payload *KiroPayload, model string, thinking bool, thinkingOpts claudeThinkingResponseOptions, estimatedInputTokens int, cacheProfile *promptCacheProfile, apiKeyID string) {
+	startTime := time.Now()
 	excluded := make(map[string]bool)
 	var lastErr error
 
@@ -1452,6 +1461,7 @@ func (h *Handler) handleClaudeNonStream(w http.ResponseWriter, payload *KiroPayl
 		h.pool.RecordSuccess(account.ID)
 		h.pool.UpdateStats(account.ID, inputTokens+outputTokens, credits)
 		h.promptCache.Update(account.ID, cacheProfile)
+		h.recordRequestLog("/v1/messages", model, 200, inputTokens, outputTokens, cacheUsage.CacheReadInputTokens, cacheUsage.CacheCreationInputTokens, credits, time.Since(startTime).Milliseconds(), apiKeyID)
 
 		responseThinkingContent := rawThinkingContent
 		includeEmptyThinkingBlock := thinking && thinkingOpts.OmitDisplay && rawThinkingContent != ""
@@ -1492,6 +1502,7 @@ func (h *Handler) handleClaudeNonStream(w http.ResponseWriter, payload *KiroPayl
 	}
 
 	h.recordFailure()
+	h.recordRequestLog("/v1/messages", model, 500, 0, 0, 0, 0, 0, time.Since(startTime).Milliseconds(), apiKeyID)
 	h.sendClaudeError(w, 500, "api_error", lastErr.Error())
 }
 
@@ -1548,6 +1559,7 @@ func (h *Handler) handleOpenAIChat(w http.ResponseWriter, r *http.Request) {
 
 // handleOpenAIStream OpenAI 流式响应
 func (h *Handler) handleOpenAIStream(w http.ResponseWriter, payload *KiroPayload, model string, thinking bool, estimatedInputTokens int, apiKeyID string) {
+	startTime := time.Now()
 	w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
@@ -1868,6 +1880,7 @@ func (h *Handler) handleOpenAIStream(w http.ResponseWriter, payload *KiroPayload
 				continue
 			}
 			h.recordFailure()
+			h.recordRequestLog("/v1/chat/completions", model, 500, 0, 0, 0, 0, 0, time.Since(startTime).Milliseconds(), apiKeyID)
 			return
 		}
 
@@ -1898,6 +1911,7 @@ func (h *Handler) handleOpenAIStream(w http.ResponseWriter, payload *KiroPayload
 		h.recordSuccessForApiKey(apiKeyID, inputTokens, outputTokens, credits)
 		h.pool.RecordSuccess(account.ID)
 		h.pool.UpdateStats(account.ID, inputTokens+outputTokens, credits)
+		h.recordRequestLog("/v1/chat/completions", model, 200, inputTokens, outputTokens, 0, 0, credits, time.Since(startTime).Milliseconds(), apiKeyID)
 
 		finishReason := "stop"
 		if len(toolCalls) > 0 {
@@ -1933,11 +1947,13 @@ func (h *Handler) handleOpenAIStream(w http.ResponseWriter, payload *KiroPayload
 	}
 
 	h.recordFailure()
+	h.recordRequestLog("/v1/chat/completions", model, 500, 0, 0, 0, 0, 0, time.Since(startTime).Milliseconds(), apiKeyID)
 	h.sendOpenAIError(w, 500, "server_error", lastErr.Error())
 }
 
 // handleOpenAINonStream OpenAI 非流式响应
 func (h *Handler) handleOpenAINonStream(w http.ResponseWriter, payload *KiroPayload, model string, thinking bool, estimatedInputTokens int, apiKeyID string) {
+	startTime := time.Now()
 	excluded := make(map[string]bool)
 	var lastErr error
 
@@ -2002,6 +2018,7 @@ func (h *Handler) handleOpenAINonStream(w http.ResponseWriter, payload *KiroPayl
 		h.recordSuccessForApiKey(apiKeyID, inputTokens, outputTokens, credits)
 		h.pool.RecordSuccess(account.ID)
 		h.pool.UpdateStats(account.ID, inputTokens+outputTokens, credits)
+		h.recordRequestLog("/v1/chat/completions", model, 200, inputTokens, outputTokens, 0, 0, credits, time.Since(startTime).Milliseconds(), apiKeyID)
 
 		thinkingFormat := config.GetThinkingConfig().OpenAIFormat
 		resp := KiroToOpenAIResponseWithReasoning(finalContent, reasoningContent, toolUses, inputTokens, outputTokens, model, thinkingFormat)
@@ -2016,6 +2033,7 @@ func (h *Handler) handleOpenAINonStream(w http.ResponseWriter, payload *KiroPayl
 	}
 
 	h.recordFailure()
+	h.recordRequestLog("/v1/chat/completions", model, 500, 0, 0, 0, 0, 0, time.Since(startTime).Milliseconds(), apiKeyID)
 	h.sendOpenAIError(w, 500, "server_error", lastErr.Error())
 }
 
@@ -2191,6 +2209,12 @@ func (h *Handler) handleAdminAPI(w http.ResponseWriter, r *http.Request) {
 		h.apiUpdateApiKey(w, r, strings.TrimPrefix(path, "/api-keys/"))
 	case strings.HasPrefix(path, "/api-keys/") && r.Method == "DELETE":
 		h.apiDeleteApiKey(w, r, strings.TrimPrefix(path, "/api-keys/"))
+	case path == "/logs" && r.Method == "GET":
+		h.apiGetLogs(w, r)
+	case path == "/logs/stats" && r.Method == "GET":
+		h.apiGetLogStats(w, r)
+	case path == "/logs" && r.Method == "DELETE":
+		h.apiClearLogs(w, r)
 	default:
 		w.WriteHeader(404)
 		json.NewEncoder(w).Encode(map[string]string{"error": "Not Found"})
@@ -3652,4 +3676,61 @@ func clampInt(v, min, max int) int {
 		return max
 	}
 	return v
+}
+
+// ==================== 请求日志 API ====================
+
+func (h *Handler) apiGetLogs(w http.ResponseWriter, r *http.Request) {
+	filter := r.URL.Query().Get("apiKey")
+	limitStr := r.URL.Query().Get("limit")
+	limit := 100
+	if limitStr != "" {
+		if v, err := strconv.Atoi(limitStr); err == nil && v > 0 {
+			limit = v
+		}
+	}
+
+	var logs []RequestLog
+	if filter != "" {
+		logs = h.requestLogs.GetFiltered(filter, limit)
+	} else {
+		logs = h.requestLogs.GetLast(limit)
+	}
+
+	if logs == nil {
+		logs = []RequestLog{}
+	}
+	json.NewEncoder(w).Encode(logs)
+}
+
+func (h *Handler) apiGetLogStats(w http.ResponseWriter, r *http.Request) {
+	json.NewEncoder(w).Encode(h.requestLogs.Stats())
+}
+
+func (h *Handler) apiClearLogs(w http.ResponseWriter, r *http.Request) {
+	h.requestLogs.Clear()
+	json.NewEncoder(w).Encode(map[string]bool{"success": true})
+}
+
+// recordRequestLog records a completed request to the log store.
+func (h *Handler) recordRequestLog(path, model string, status int, inputTokens, outputTokens, cacheRead, cacheWrite int, credits float64, latencyMs int64, apiKeyID string) {
+	name := ""
+	if apiKeyID != "" {
+		if entry := config.GetApiKeyEntry(apiKeyID); entry != nil {
+			name = entry.Name
+		}
+	}
+	h.requestLogs.Add(RequestLog{
+		Path:         path,
+		Model:        model,
+		Status:       status,
+		InputTokens:  inputTokens,
+		OutputTokens: outputTokens,
+		CacheRead:    cacheRead,
+		CacheWrite:   cacheWrite,
+		Credits:      credits,
+		LatencyMs:    latencyMs,
+		ApiKeyID:     apiKeyID,
+		ApiKeyName:   name,
+	})
 }

--- a/proxy/log_store.go
+++ b/proxy/log_store.go
@@ -1,0 +1,154 @@
+package proxy
+
+import (
+	"sync"
+	"time"
+)
+
+const defaultMaxLogs = 1000
+
+// RequestLog represents a single API request log entry.
+type RequestLog struct {
+	Timestamp    int64   `json:"timestamp"`
+	Path         string  `json:"path"`
+	Model        string  `json:"model"`
+	Status       int     `json:"status"`
+	InputTokens  int     `json:"inputTokens"`
+	OutputTokens int     `json:"outputTokens"`
+	CacheRead    int     `json:"cacheRead"`
+	CacheWrite   int     `json:"cacheWrite"`
+	Credits      float64 `json:"credits"`
+	LatencyMs    int64   `json:"latencyMs"`
+	ApiKeyID     string  `json:"apiKeyId"`
+	ApiKeyName   string  `json:"apiKeyName"`
+	Error        string  `json:"error,omitempty"`
+}
+
+// LogStore stores recent request logs in memory with a fixed capacity.
+type LogStore struct {
+	mu      sync.RWMutex
+	logs    []RequestLog
+	maxLogs int
+}
+
+// NewLogStore creates a log store with the given capacity.
+func NewLogStore(maxLogs int) *LogStore {
+	if maxLogs <= 0 {
+		maxLogs = defaultMaxLogs
+	}
+	return &LogStore{
+		logs:    make([]RequestLog, 0, maxLogs),
+		maxLogs: maxLogs,
+	}
+}
+
+// Add appends a log entry, evicting the oldest if at capacity.
+func (s *LogStore) Add(entry RequestLog) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if entry.Timestamp == 0 {
+		entry.Timestamp = time.Now().UnixMilli()
+	}
+
+	s.logs = append(s.logs, entry)
+	if len(s.logs) > s.maxLogs {
+		// Remove oldest entries
+		excess := len(s.logs) - s.maxLogs
+		s.logs = s.logs[excess:]
+	}
+}
+
+// GetLast returns the most recent n entries (newest last).
+func (s *LogStore) GetLast(n int) []RequestLog {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if n <= 0 || len(s.logs) == 0 {
+		return nil
+	}
+	start := len(s.logs) - n
+	if start < 0 {
+		start = 0
+	}
+	result := make([]RequestLog, len(s.logs)-start)
+	copy(result, s.logs[start:])
+	return result
+}
+
+// GetFiltered returns recent entries filtered by apiKeyID or apiKeyName.
+func (s *LogStore) GetFiltered(filter string, limit int) []RequestLog {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if filter == "" {
+		return s.GetLastUnlocked(limit)
+	}
+
+	var result []RequestLog
+	// Iterate from newest to oldest
+	for i := len(s.logs) - 1; i >= 0; i-- {
+		entry := s.logs[i]
+		if entry.ApiKeyID == filter || entry.ApiKeyName == filter {
+			result = append(result, entry)
+			if limit > 0 && len(result) >= limit {
+				break
+			}
+		}
+	}
+	// Reverse to get chronological order
+	for i, j := 0, len(result)-1; i < j; i, j = i+1, j-1 {
+		result[i], result[j] = result[j], result[i]
+	}
+	return result
+}
+
+// GetLastUnlocked returns recent entries without lock (caller must hold RLock).
+func (s *LogStore) GetLastUnlocked(n int) []RequestLog {
+	if n <= 0 || len(s.logs) == 0 {
+		return nil
+	}
+	start := len(s.logs) - n
+	if start < 0 {
+		start = 0
+	}
+	result := make([]RequestLog, len(s.logs)-start)
+	copy(result, s.logs[start:])
+	return result
+}
+
+// Stats returns aggregate statistics.
+type LogStats struct {
+	Total       int   `json:"total"`
+	Success     int   `json:"success"`
+	Failed      int   `json:"failed"`
+	TotalInput  int64 `json:"totalInput"`
+	TotalOutput int64 `json:"totalOutput"`
+	TotalCache  int64 `json:"totalCacheRead"`
+}
+
+func (s *LogStore) Stats() LogStats {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var stats LogStats
+	stats.Total = len(s.logs)
+	for _, l := range s.logs {
+		if l.Status == 200 {
+			stats.Success++
+		} else {
+			stats.Failed++
+		}
+		stats.TotalInput += int64(l.InputTokens)
+		stats.TotalOutput += int64(l.OutputTokens)
+		stats.TotalCache += int64(l.CacheRead)
+	}
+	return stats
+}
+
+// Clear removes all logs.
+func (s *LogStore) Clear() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.logs = s.logs[:0]
+}

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -128,6 +128,7 @@ func (h *Handler) handleResponsesNonStream(
 	estimatedInputTokens int, apiKeyID, respID string,
 	req *ResponsesRequest, storedInput json.RawMessage, storeResponse bool,
 ) {
+	startTime := time.Now()
 	excluded := make(map[string]bool)
 	var lastErr error
 
@@ -188,6 +189,7 @@ func (h *Handler) handleResponsesNonStream(
 		h.recordSuccessForApiKey(apiKeyID, inputTokens, outputTokens, credits)
 		h.pool.RecordSuccess(account.ID)
 		h.pool.UpdateStats(account.ID, inputTokens+outputTokens, credits)
+		h.recordRequestLog("/v1/responses", model, 200, inputTokens, outputTokens, 0, 0, credits, time.Since(startTime).Milliseconds(), apiKeyID)
 
 		respObj := buildResponsesObject(respID, model, finalContent, toolUses, inputTokens, outputTokens, req)
 		respObj.StoredInput = storedInput
@@ -209,6 +211,7 @@ func (h *Handler) handleResponsesNonStream(
 		return
 	}
 	h.recordFailure()
+	h.recordRequestLog("/v1/responses", model, 500, 0, 0, 0, 0, 0, time.Since(startTime).Milliseconds(), apiKeyID)
 	h.sendOpenAIError(w, 500, "server_error", lastErr.Error())
 }
 
@@ -274,6 +277,7 @@ func (h *Handler) handleResponsesStream(
 	estimatedInputTokens int, apiKeyID, respID string,
 	req *ResponsesRequest, storedInput json.RawMessage, storeResponse bool,
 ) {
+	startTime := time.Now()
 	w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
@@ -487,6 +491,7 @@ func (h *Handler) handleResponsesStream(
 				},
 			})
 			h.recordFailure()
+			h.recordRequestLog("/v1/responses", model, 500, 0, 0, 0, 0, 0, time.Since(startTime).Milliseconds(), apiKeyID)
 			return
 		}
 
@@ -533,6 +538,7 @@ func (h *Handler) handleResponsesStream(
 		h.recordSuccessForApiKey(apiKeyID, inputTokens, outputTokens, credits)
 		h.pool.RecordSuccess(account.ID)
 		h.pool.UpdateStats(account.ID, inputTokens+outputTokens, credits)
+		h.recordRequestLog("/v1/responses", model, 200, inputTokens, outputTokens, 0, 0, credits, time.Since(startTime).Milliseconds(), apiKeyID)
 
 		respObj := buildResponsesObject(respID, model, finalContent, toolUses, inputTokens, outputTokens, req)
 		respObj.CreatedAt = createdAt
@@ -569,6 +575,7 @@ func (h *Handler) handleResponsesStream(
 		return
 	}
 	h.recordFailure()
+	h.recordRequestLog("/v1/responses", model, 500, 0, 0, 0, 0, 0, time.Since(startTime).Milliseconds(), apiKeyID)
 	send("response.failed", map[string]interface{}{
 		"type": "response.failed",
 		"response": map[string]interface{}{

--- a/web/app.js
+++ b/web/app.js
@@ -2573,6 +2573,7 @@
     qsa('.tab').forEach(el => el.classList.toggle('active', el.dataset.tab === tab));
     qsa('.tab-content').forEach(c => c.classList.add('hidden'));
     $('tab' + tab.charAt(0).toUpperCase() + tab.slice(1)).classList.remove('hidden');
+    if (tab === 'logs') loadLogs();
   }
 
   // Event wiring
@@ -2772,6 +2773,7 @@
     bindModalEvents();
     bindDetailEvents();
     bindTestEvents();
+    bindLogsEvents();
   }
 
   // Init
@@ -2790,6 +2792,107 @@
     setInterval(() => {
       if (!$('mainPage').classList.contains('hidden')) loadStats();
     }, 10000);
+
+    // Auto-refresh logs every 5s when logs tab is active
+    setInterval(() => {
+      const logsTab = $('tabLogs');
+      if (logsTab && !logsTab.classList.contains('hidden')) loadLogs();
+    }, 5000);
+  }
+
+  // ==================== Request Logs ====================
+  let logsAutoRefreshActive = false;
+
+  async function loadLogs() {
+    const filter = ($('logsFilterInput') || {}).value || '';
+    const params = new URLSearchParams({ limit: '100' });
+    if (filter) params.set('apiKey', filter);
+    try {
+      const [logsRes, statsRes] = await Promise.all([
+        api('/logs?' + params.toString()),
+        api('/logs/stats')
+      ]);
+      const logs = await logsRes.json();
+      const stats = await statsRes.json();
+      renderLogsStats(stats);
+      renderLogsTable(logs);
+    } catch (e) {
+      console.error('Failed to load logs', e);
+    }
+  }
+
+  function renderLogsStats(stats) {
+    const el = $('logsStats');
+    if (!el) return;
+    el.innerHTML =
+      '<span><b>总计:</b> ' + (stats.total || 0) + '</span>' +
+      '<span style="color:var(--success);"><b>成功:</b> ' + (stats.success || 0) + '</span>' +
+      '<span style="color:var(--danger);"><b>失败:</b> ' + (stats.failed || 0) + '</span>' +
+      '<span><b>输入Token:</b> ' + formatNumber(stats.totalInput || 0) + '</span>' +
+      '<span><b>输出Token:</b> ' + formatNumber(stats.totalOutput || 0) + '</span>' +
+      '<span><b>缓存读:</b> ' + formatNumber(stats.totalCacheRead || 0) + '</span>';
+  }
+
+  function formatNumber(n) {
+    if (n >= 1000000) return (n / 1000000).toFixed(1) + 'M';
+    if (n >= 1000) return (n / 1000).toFixed(1) + 'K';
+    return String(n);
+  }
+
+  function renderLogsTable(logs) {
+    const tbody = $('logsTableBody');
+    const empty = $('logsEmpty');
+    if (!tbody) return;
+    if (!logs || logs.length === 0) {
+      tbody.innerHTML = '';
+      if (empty) empty.style.display = 'block';
+      return;
+    }
+    if (empty) empty.style.display = 'none';
+    // Show newest first
+    const sorted = logs.slice().reverse();
+    tbody.innerHTML = sorted.map(log => {
+      const time = new Date(log.timestamp).toLocaleString('zh-CN', { hour12: false });
+      const statusColor = log.status === 200 ? 'color:#22c55e;font-weight:600;' : 'color:#ef4444;font-weight:600;';
+      const keyDisplay = log.apiKeyName || (log.apiKeyId ? log.apiKeyId.substring(0, 8) + '...' : '-');
+      return '<tr style="border-bottom:1px solid var(--border);">' +
+        '<td style="padding:6px 12px;white-space:nowrap;">' + escapeHtml(time) + '</td>' +
+        '<td style="padding:6px 12px;">' + escapeHtml(log.path) + '</td>' +
+        '<td style="padding:6px 12px;">' + escapeHtml(log.model) + '</td>' +
+        '<td style="padding:6px 12px;' + statusColor + '">' + log.status + '</td>' +
+        '<td style="padding:6px 12px;">' + (log.inputTokens || 0) + '</td>' +
+        '<td style="padding:6px 12px;">' + (log.outputTokens || 0) + '</td>' +
+        '<td style="padding:6px 12px;">' + (log.cacheRead || 0) + '</td>' +
+        '<td style="padding:6px 12px;">' + (log.cacheWrite || 0) + '</td>' +
+        '<td style="padding:6px 12px;">' + (log.credits ? log.credits.toFixed(4) : '-') + '</td>' +
+        '<td style="padding:6px 12px;">' + (log.latencyMs || 0) + 'ms</td>' +
+        '<td style="padding:6px 12px;" title="' + escapeAttr(log.apiKeyId || '') + '">' + escapeHtml(keyDisplay) + '</td>' +
+        '</tr>';
+    }).join('');
+  }
+
+  async function clearLogs() {
+    try {
+      await api('/logs', { method: 'DELETE' });
+      loadLogs();
+    } catch (e) {
+      console.error('Failed to clear logs', e);
+    }
+  }
+
+  function bindLogsEvents() {
+    const refreshBtn = $('logsRefreshBtn');
+    if (refreshBtn) refreshBtn.addEventListener('click', loadLogs);
+    const clearBtn = $('logsClearBtn');
+    if (clearBtn) clearBtn.addEventListener('click', clearLogs);
+    const filterInput = $('logsFilterInput');
+    if (filterInput) {
+      let debounceTimer;
+      filterInput.addEventListener('input', () => {
+        clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(loadLogs, 300);
+      });
+    }
   }
 
   if (document.readyState === 'loading') {

--- a/web/index.html
+++ b/web/index.html
@@ -107,6 +107,7 @@
                 data-i18n="tabs.settings"></span></button>
             <button type="button" class="tab" data-tab="api"><i class="fa-solid fa-plug tab-icon"></i><span
                 data-i18n="tabs.api"></span></button>
+            <button type="button" class="tab" data-tab="logs"><i class="fa-solid fa-clipboard-list tab-icon"></i><span>日志</span></button>
           </div>
         </nav>
         <div class="topbar-actions flex-wrap justify-end">
@@ -485,6 +486,42 @@
           </div>
           <p class="api-hint"><i class="fa-solid fa-key"></i><span data-i18n="api.statsHint"></span></p>
         </section>
+      </div>
+
+      <!-- Logs tab -->
+      <div id="tabLogs" class="tab-content hidden">
+        <div class="card">
+          <div class="card-header" style="display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:8px;">
+            <span class="card-title">请求日志</span>
+            <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;">
+              <input type="text" id="logsFilterInput" placeholder="按 Key 名称搜索..." style="padding:4px 8px;border:1px solid var(--border);border-radius:6px;font-size:13px;background:var(--bg-secondary);color:var(--text-primary);width:180px;" />
+              <button class="btn btn-outline btn-sm" id="logsRefreshBtn" type="button"><i class="fa-solid fa-rotate"></i> 刷新</button>
+              <button class="btn btn-outline btn-sm" id="logsClearBtn" type="button" style="color:var(--danger);border-color:var(--danger);"><i class="fa-solid fa-trash"></i> 清空</button>
+            </div>
+          </div>
+          <div id="logsStats" style="display:flex;gap:16px;padding:8px 16px;font-size:13px;color:var(--text-secondary);flex-wrap:wrap;"></div>
+          <div style="overflow-x:auto;">
+            <table style="width:100%;border-collapse:collapse;font-size:13px;">
+              <thead>
+                <tr style="border-bottom:1px solid var(--border);text-align:left;">
+                  <th style="padding:8px 12px;">时间</th>
+                  <th style="padding:8px 12px;">路径</th>
+                  <th style="padding:8px 12px;">模型</th>
+                  <th style="padding:8px 12px;">状态</th>
+                  <th style="padding:8px 12px;">输入</th>
+                  <th style="padding:8px 12px;">输出</th>
+                  <th style="padding:8px 12px;">缓存读</th>
+                  <th style="padding:8px 12px;">缓存写</th>
+                  <th style="padding:8px 12px;">Credits</th>
+                  <th style="padding:8px 12px;">耗时</th>
+                  <th style="padding:8px 12px;">Key</th>
+                </tr>
+              </thead>
+              <tbody id="logsTableBody"></tbody>
+            </table>
+          </div>
+          <div id="logsEmpty" style="text-align:center;padding:32px;color:var(--text-secondary);display:none;">暂无日志</div>
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
## Session Affinity

Same API key routes to the same backend account across requests, improving prompt cache hit rate.

- API key → account binding stored in memory (sync.Map)
- Falls back to weighted round-robin when bound account is unavailable
- Binding auto-clears on account failure for automatic recovery
- Works even when `requireApiKey` is false (identifies key without enforcing auth)

## Request Logs Panel

New "日志" tab in admin panel for viewing request history.

- In-memory ring buffer (1000 entries max, reset on restart)
- Columns: time, path, model, status, input/output tokens, cache read/write, credits, latency, key name
- Filter by API key name
- Auto-refresh every 5 seconds
- Stats summary (total/success/failed/tokens)
- Admin API: `GET /admin/api/logs`, `GET /admin/api/logs/stats`, `DELETE /admin/api/logs`
