### PR TITLE
fix: stop dropping repeated content from the response streams

### DIFF
--- a/proxy/kiro.go
+++ b/proxy/kiro.go
@@ -423,8 +423,6 @@ func parseEventStream(body io.Reader, callback *KiroStreamCallback) error {
 	var inputTokens, outputTokens int
 	var totalCredits float64
 	var currentToolUse *toolUseState
-	var lastAssistantContent string
-	var lastReasoningContent string
 
 	for {
 		// Prelude: 12 bytes (total_len + headers_len + crc)
@@ -471,18 +469,30 @@ func parseEventStream(body io.Reader, callback *KiroStreamCallback) error {
 
 		// Dispatch by event type.
 		switch eventType {
+		// Both text streams are passed through verbatim. Kiro sends
+		// assistantResponseEvent and reasoningContentEvent as pure incremental deltas
+		// (verified against real upstream traffic), never as cumulative snapshots, and
+		// never replays a chunk: ordering and at-most-once delivery are already
+		// guaranteed by TCP, and a dropped stream is retried as a whole new request
+		// rather than resumed.
+		//
+		// Do NOT reintroduce content-based de-duplication here. At the string level a
+		// replayed chunk is indistinguishable from text that simply repeats itself, and
+		// the wire protocol carries no sequence number or message id to tell them apart
+		// (the AWS event-stream base spec defines none), so such a heuristic can only
+		// guess -- and when it guesses wrong it silently eats real output. The previous
+		// implementation turned "6666666666" into "666", "abababab" into "abab" and
+		// "1833" into "183", on both streams.
 		case "assistantResponseEvent":
 			if content, ok := event["content"].(string); ok && content != "" {
-				normalized := normalizeChunk(content, &lastAssistantContent)
-				if normalized != "" && callback.OnText != nil {
-					callback.OnText(normalized, false)
+				if callback.OnText != nil {
+					callback.OnText(content, false)
 				}
 			}
 		case "reasoningContentEvent":
 			if text, ok := event["text"].(string); ok && text != "" {
-				normalized := normalizeChunk(text, &lastReasoningContent)
-				if normalized != "" && callback.OnText != nil {
-					callback.OnText(normalized, true)
+				if callback.OnText != nil {
+					callback.OnText(text, true)
 				}
 			}
 		case "toolUseEvent":
@@ -631,50 +641,6 @@ func collectUsageMaps(v interface{}, out *[]map[string]interface{}) {
 	}
 }
 
-func normalizeChunk(chunk string, previous *string) string {
-	if chunk == "" {
-		return ""
-	}
-
-	prev := *previous
-	if prev == "" {
-		*previous = chunk
-		return chunk
-	}
-
-	if chunk == prev {
-		return ""
-	}
-
-	if strings.HasPrefix(chunk, prev) {
-		delta := chunk[len(prev):]
-		*previous = chunk
-		return delta
-	}
-
-	if strings.HasPrefix(prev, chunk) {
-		return ""
-	}
-
-	maxOverlap := 0
-	maxLen := len(prev)
-	if len(chunk) < maxLen {
-		maxLen = len(chunk)
-	}
-	for i := maxLen; i > 0; i-- {
-		if strings.HasSuffix(prev, chunk[:i]) {
-			maxOverlap = i
-			break
-		}
-	}
-
-	*previous = chunk
-	if maxOverlap > 0 {
-		return chunk[maxOverlap:]
-	}
-
-	return chunk
-}
 
 func readTokenNumber(m map[string]interface{}, keys ...string) (int, bool) {
 	for _, k := range keys {

--- a/proxy/kiro_test.go
+++ b/proxy/kiro_test.go
@@ -11,37 +11,69 @@ import (
 	"time"
 )
 
-func TestNormalizeChunkBasicProgression(t *testing.T) {
-	prev := ""
+// Regression: an assistant stream whose chunks legitimately repeat must be reassembled
+// verbatim. The previous content-based de-duplication turned these exact inputs into
+// "666" and "abab" respectively, silently corrupting model output.
+func TestParseEventStreamAssistantRepeatedContentIsNotDropped(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		chunks []string
+		want   string
+	}{
+		{"repeated equal chunks", []string{"666", "666", "666", "6"}, "6666666666"},
+		{"repeated period", []string{"abab", "abab"}, "abababab"},
+		{"chunk equal to previous", []string{"ha", "ha", "ha"}, "hahaha"},
+		{"prefix shaped chunks", []string{"6", "66"}, "666"},
+		{"non repeating control", []string{"123", "4567890"}, "1234567890"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var stream bytes.Buffer
+			for _, c := range tc.chunks {
+				stream.Write(awsEventStreamFrame(t, "assistantResponseEvent",
+					map[string]interface{}{"content": c}))
+			}
 
-	if got := normalizeChunk("abc", &prev); got != "abc" {
-		t.Fatalf("expected first chunk to pass through, got %q", got)
-	}
-	if got := normalizeChunk("abcde", &prev); got != "de" {
-		t.Fatalf("expected appended delta, got %q", got)
+			var got string
+			err := parseEventStream(bytes.NewReader(stream.Bytes()), &KiroStreamCallback{
+				OnText: func(text string, reasoning bool) {
+					if !reasoning {
+						got += text
+					}
+				},
+			})
+			if err != nil {
+				t.Fatalf("unexpected parse error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("assistant text corrupted: got %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 
-func TestNormalizeChunkPrefixRewindDoesNotReplay(t *testing.T) {
-	prev := ""
-
-	_ = normalizeChunk("abcde", &prev)
-	if got := normalizeChunk("abc", &prev); got != "" {
-		t.Fatalf("expected rewind chunk to be ignored, got %q", got)
+// The reasoning stream is passed through verbatim too: it carries the same pure
+// incremental deltas as the assistant stream, and de-duplicating it dropped
+// legitimate repeated text in exactly the same way.
+func TestParseEventStreamReasoningRepeatedContentIsNotDropped(t *testing.T) {
+	var stream bytes.Buffer
+	for _, c := range []string{"666", "666", "666", "6"} {
+		stream.Write(awsEventStreamFrame(t, "reasoningContentEvent",
+			map[string]interface{}{"text": c}))
 	}
-	if prev != "abcde" {
-		t.Fatalf("expected previous snapshot to remain longest version, got %q", prev)
-	}
-	if got := normalizeChunk("abcdef", &prev); got != "f" {
-		t.Fatalf("expected only unseen suffix after rewind, got %q", got)
-	}
-}
 
-func TestNormalizeChunkOverlapDelta(t *testing.T) {
-	prev := "hello world"
-
-	if got := normalizeChunk("world!!!", &prev); got != "!!!" {
-		t.Fatalf("expected overlap suffix delta, got %q", got)
+	var got string
+	err := parseEventStream(bytes.NewReader(stream.Bytes()), &KiroStreamCallback{
+		OnText: func(text string, reasoning bool) {
+			if reasoning {
+				got += text
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if got != "6666666666" {
+		t.Fatalf("reasoning text corrupted: got %q, want %q", got, "6666666666")
 	}
 }
 


### PR DESCRIPTION
## The problem

`normalizeChunk()` decides whether a chunk is a replay by comparing it against the previous chunk's text. On a purely incremental stream that guess is wrong whenever the model's own output legitimately repeats itself, and the chunk is dropped **silently**.

Asking a model through the proxy to echo a string back verbatim:

| input | returned |
|---|---|
| `6666666666` | `666` |
| `abababab` | `abab` |
| `哈哈哈哈哈` | `哈哈` |
| `1833` | `183` |
| `2012` | `201` |
| `1234567890` | `1234567890` ✅ |
| `abcdefgh` | `abcdefgh` ✅ |

Anything without a repeat is fine; anything with one loses exactly one repeated unit. This affects Claude and GPT models alike, and `reasoningContentEvent` as well as `assistantResponseEvent` — a reasoning stream asked for ten `6` characters comes back with nine.

It is easy to miss (nobody notices a missing character), but it silently corrupts real output. It surfaced here as a translation task turning `1833` into `183` and `2012` into `201` — years and amounts quietly losing a digit.

Three branches cause it: `chunk == prev` (drop), `HasPrefix(prev, chunk)` (drop), and the longest-suffix overlap truncation. Chunks such as `["666","666","666","6"]` hit them one after another.

## Why passing through is safe

Kiro sends both text streams as **pure incremental deltas**, not cumulative snapshots:

- A raw upstream capture contains two consecutive content events, `"runtime"` then `"-raw-capture-auto"` — they only spell a word once concatenated. A cumulative stream would have made the second frame the whole string.
- Asking a model to echo `1234567890` yields a second frame of `"234567890"`, which does **not** repeat the already-sent `"1"`. Non-repeating text rules out coincidence here.
- Ordering and at-most-once delivery are already guaranteed by TCP, and a dropped stream is retried as a whole new request rather than resumed — so there is no replay to defend against in the first place.

More fundamentally: at the string level a replayed chunk is **indistinguishable** from text that simply repeats itself, and the AWS event-stream base spec defines no sequence number or message id to tell them apart. Content-based de-duplication can only ever guess — and when it guesses wrong it eats real output.

This is also what everyone else does. The official OpenAI and Anthropic SDKs accumulate deltas with plain `+=`. Gateways that transcode the very same Bedrock event-stream — LiteLLM, Portkey, one-api/new-api — pass content through untouched. LiteLLM does have cumulative-to-delta extraction, but scoped to the single provider documented to behave that way (`nlp_cloud`), and its repetition detector raises an error for the caller to retry rather than silently rewriting the text.

## The change

- `assistantResponseEvent` and `reasoningContentEvent` now pass content through verbatim; `normalizeChunk` and its two state variables are removed.
- The three `normalizeChunk` unit tests asserted the buggy behaviour as expected (`"expected rewind chunk to be ignored"`), so they are replaced by regression tests over **multi-frame** streams — a case no existing test covered, which is why this went unnoticed.
- Comments at both call sites record why content-based de-duplication must not be reintroduced.

`go test ./...` passes. Two failures in `translator_test.go` (`TestClaudeToolResultMixedTextAndImage`, `TestOpenAIToolResultImageCarriedWhenFollowedByUser`) are pre-existing on `main` and unrelated to this change.

## If cumulative streams do exist somewhere

I could not find any, but I cannot prove a negative. If a provider or endpoint is later found to send cumulative snapshots, the right fix is a narrow one scoped to it (as LiteLLM does for `nlp_cloud`) rather than a global heuristic — and ideally it should fail loudly rather than silently discard content.