### PR TITLE
fix: classify major-only Claude versions (opus-5) as 1M context

### DIFF
--- a/proxy/context_window_test.go
+++ b/proxy/context_window_test.go
@@ -4,8 +4,8 @@ import "testing"
 
 // TestGetContextWindowSize verifies models are classified into the correct
 // context window. This drives the input-token count that clients use to decide
-// when to compact; misclassifying opus-4.8 (1M) as 200K under-reports tokens by
-// 5x and prevents timely compaction.
+// when to compact; misclassifying opus-4.8 or opus-5 (1M) as 200K under-reports
+// tokens by 5x and prevents timely compaction.
 func TestGetContextWindowSize(t *testing.T) {
 	cases := []struct {
 		model string
@@ -18,6 +18,14 @@ func TestGetContextWindowSize(t *testing.T) {
 		{"claude-sonnet-4.6", 1_000_000},
 		{"claude-opus-4.8-thinking", 1_000_000},
 		{"CLAUDE-OPUS-4.8", 1_000_000},
+		{"claude-opus-5", 1_000_000},
+		{"claude-opus-5-thinking", 1_000_000},
+		{"CLAUDE-OPUS-5", 1_000_000},
+		{"claude-opus-5.1", 1_000_000},
+		{"claude-opus-5-1", 1_000_000},
+		{"claude-sonnet-5", 1_000_000},
+		{"claude-haiku-5", 1_000_000},
+		{"claude-opus-6", 1_000_000},
 		{"claude-opus-4.5", 200_000},
 		{"claude-sonnet-4.5", 200_000},
 		{"claude-sonnet-4", 200_000},

--- a/proxy/kiro.go
+++ b/proxy/kiro.go
@@ -635,24 +635,32 @@ func getContextWindowSize(model string) int {
 	return 200_000
 }
 
-// largeContextMinor matches "claude-<family>-<major>.<minor>" (dot or dash form)
-// and is used to classify 1M-window models by version.
-var claudeVersionExtractor = regexp.MustCompile(`claude-(?:opus|sonnet|haiku)-(\d+)[.-](\d+)`)
+// claudeVersionExtractor matches "claude-<family>-<major>[.<minor>]" (dot or
+// dash form) and is used to classify 1M-window models by version. The minor
+// component is optional so major-only identifiers such as "claude-opus-5"
+// classify correctly instead of falling through to the 200K default.
+var claudeVersionExtractor = regexp.MustCompile(`claude-(?:opus|sonnet|haiku)-(\d+)(?:[.-](\d+))?`)
 
 func isLargeContextModel(model string) bool {
 	m := strings.ToLower(model)
 	if match := claudeVersionExtractor.FindStringSubmatch(m); match != nil {
 		major, errMaj := strconv.Atoi(match[1])
-		minor, errMin := strconv.Atoi(match[2])
-		if errMaj == nil && errMin == nil {
-			// 1M window for Claude >= 4.6 (4.6, 4.7, 4.8, ...) and any major >= 5.
+		if errMaj == nil {
+			// 1M window for any major >= 5 (claude-opus-5, claude-opus-5.1, ...).
 			if major > 4 {
 				return true
 			}
-			if major == 4 && minor >= 6 {
-				return true
+			// Within Claude 4.x the window depends on the minor version, so an
+			// absent minor (claude-sonnet-4) is treated as 4.0 -> 200K.
+			minor := 0
+			if match[2] != "" {
+				parsed, errMin := strconv.Atoi(match[2])
+				if errMin != nil {
+					return false
+				}
+				minor = parsed
 			}
-			return false
+			return major == 4 && minor >= 6
 		}
 	}
 	// Fallback substring checks for non-standard identifiers.


### PR DESCRIPTION
## Problem

`getContextWindowSize` misclassifies major-only Claude identifiers such as
`claude-opus-5` as a 200K-window model, so the upstream
`contextUsagePercentage` is converted into an input-token count that is 5x too
small. Clients rely on that number to decide when to compact, so they keep
believing the context is nearly empty and never compact in time.

The root cause is in the version extractor:

```go
var claudeVersionExtractor = regexp.MustCompile(`claude-(?:opus|sonnet|haiku)-(\d+)[.-](\d+)`)
```

The minor group is mandatory, so `claude-opus-5` never matches. Execution then
falls through to the substring fallback, whose tag list only covers `4.6`
through `4-9`, and finally returns `200_000`.

As a consequence the existing `if major > 4 { return true }` branch — and the
`and any major >= 5` promise in the doc comment — is unreachable dead code. It
reads correct but can never execute, because the regex rejects those
identifiers before the version comparison is reached.

Reproducible against `main` with no other changes:

```go
getContextWindowSize("claude-opus-5")          // 200000, want 1000000
getContextWindowSize("claude-opus-5-thinking") // 200000, want 1000000
```

## Fix

Make the minor component optional and treat an absent minor as `.0`:

```go
var claudeVersionExtractor = regexp.MustCompile(`claude-(?:opus|sonnet|haiku)-(\d+)(?:[.-](\d+))?`)
```

`major > 4` now returns 1M as the comment always intended. Within 4.x the minor
version still governs, and a missing minor is treated as `4.0`, so
`claude-sonnet-4` stays at 200K. That case is the main risk when relaxing the
regex, so it is asserted explicitly in the tests below.

## Behavior

| model | before | after |
|---|---|---|
| `claude-opus-5` | 200K | **1M** |
| `claude-opus-5-thinking` | 200K | **1M** |
| `claude-opus-5.1` | 200K | **1M** |
| `claude-sonnet-5` | 200K | **1M** |
| `claude-opus-6` | 200K | **1M** |
| `claude-opus-4.8` | 1M | 1M |
| `claude-opus-4.6` | 1M | 1M |
| `claude-sonnet-4` | 200K | 200K |
| `claude-opus-4.5` | 200K | 200K |
| `claude-haiku-4.5` | 200K | 200K |
| `unknown-model` | 200K | 200K |

Anthropic documents Opus 5 with a 1,000,000-token context window, which matches
the 1M classification.

## Tests

Six cases added to the existing `TestGetContextWindowSize`
(`claude-opus-5`, `claude-opus-5-thinking`, `claude-opus-5.1`,
`claude-sonnet-5`, `claude-haiku-5`, `claude-opus-6`). Every pre-existing case
is unchanged, including the 200K assertions that guard against over-promotion.

```
$ go test ./proxy/ -run TestGetContextWindowSize -v
=== RUN   TestGetContextWindowSize
--- PASS: TestGetContextWindowSize (0.00s)
ok      kiro-go/proxy
```

`go build ./...` and `go vet ./proxy/` are clean.

## Note on unrelated failures

`go test ./proxy/` also reports two failures on this branch:

```
--- FAIL: TestClaudeToolResultMixedTextAndImage
--- FAIL: TestOpenAIToolResultImageCarriedWhenFollowedByUser
```

Both reproduce identically on unmodified `main` (verified by stashing this diff
and re-running), so they are pre-existing and unrelated to this change. They are
left untouched to keep this diff focused on the context-window classification.
