### PR TITLE
fix: retry a stream that died before any output reached the client

### DIFF
--- a/proxy/kiro.go
+++ b/proxy/kiro.go
@@ -21,6 +21,11 @@ import (
 	"github.com/google/uuid"
 )
 
+// streamRetryBackoff spaces out a retry of a stream that died before emitting
+// anything. Upstream drops cluster in time, so retrying immediately tends to
+// hit the same blip; a short pause is what makes the retry worth attempting.
+const streamRetryBackoff = 700 * time.Millisecond
+
 // Endpoint configuration (auto-fallback on quota exhaustion).
 type kiroEndpoint struct {
 	URL       string
@@ -445,9 +450,22 @@ func CallKiroAPI(account *config.Account, payload *KiroPayload, callback *KiroSt
 			continue
 		}
 
-		err = parseEventStream(resp.Body, callback)
+		emitted, err := parseEventStreamTracked(resp.Body, callback)
 		resp.Body.Close()
-		return err
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		// A stream that died before emitting anything is safe to retry: the
+		// client has seen no bytes, so a fresh attempt cannot duplicate output.
+		// Once content is out, retrying would concatenate two partial answers,
+		// so surface the error and let the client decide.
+		if emitted {
+			return err
+		}
+		logger.Warnf("[KiroAPI] Endpoint %s stream failed before any output: %v", ep.Name, err)
+		time.Sleep(streamRetryBackoff)
+		continue
 	}
 
 	if lastErr != nil {
@@ -467,6 +485,15 @@ func accountEmailForLog(account *config.Account) string {
 
 // parseEventStream decodes an AWS binary Event Stream response body.
 func parseEventStream(body io.Reader, callback *KiroStreamCallback) error {
+	_, err := parseEventStreamTracked(body, callback)
+	return err
+}
+
+// parseEventStreamTracked is parseEventStream plus a report of whether any
+// content already reached the client. A failure before the first emission is
+// safe to retry, because a fresh attempt cannot duplicate output that was
+// never sent.
+func parseEventStreamTracked(body io.Reader, callback *KiroStreamCallback) (emitted bool, err error) {
 	if callback == nil {
 		callback = &KiroStreamCallback{}
 	}
@@ -479,12 +506,12 @@ func parseEventStream(body io.Reader, callback *KiroStreamCallback) error {
 	for {
 		// Prelude: 12 bytes (total_len + headers_len + crc)
 		prelude := make([]byte, 12)
-		_, err := io.ReadFull(body, prelude)
-		if err == io.EOF {
+		_, readErr := io.ReadFull(body, prelude)
+		if readErr == io.EOF {
 			break
 		}
-		if err != nil {
-			return err
+		if readErr != nil {
+			return emitted, readErr
 		}
 
 		totalLength := int(prelude[0])<<24 | int(prelude[1])<<16 | int(prelude[2])<<8 | int(prelude[3])
@@ -499,7 +526,7 @@ func parseEventStream(body io.Reader, callback *KiroStreamCallback) error {
 		msgBuf := make([]byte, remaining)
 		_, err = io.ReadFull(body, msgBuf)
 		if err != nil {
-			return err
+			return emitted, err
 		}
 
 		if headersLength > len(msgBuf)-4 {
@@ -538,16 +565,19 @@ func parseEventStream(body io.Reader, callback *KiroStreamCallback) error {
 		case "assistantResponseEvent":
 			if content, ok := event["content"].(string); ok && content != "" {
 				if callback.OnText != nil {
+					emitted = true
 					callback.OnText(content, false)
 				}
 			}
 		case "reasoningContentEvent":
 			if text, ok := event["text"].(string); ok && text != "" {
 				if callback.OnText != nil {
+					emitted = true
 					callback.OnText(text, true)
 				}
 			}
 		case "toolUseEvent":
+			emitted = true
 			currentToolUse = handleToolUseEvent(event, currentToolUse, callback)
 		case "meteringEvent":
 			if usage, ok := event["usage"].(float64); ok {
@@ -573,7 +603,7 @@ func parseEventStream(body io.Reader, callback *KiroStreamCallback) error {
 	if callback.OnComplete != nil {
 		callback.OnComplete(inputTokens, outputTokens)
 	}
-	return nil
+	return true, nil
 }
 
 func updateTokensFromEvent(event map[string]interface{}, currentInputTokens, currentOutputTokens int) (int, int) {

--- a/proxy/kiro.go
+++ b/proxy/kiro.go
@@ -4,11 +4,14 @@ package proxy
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"kiro-go/config"
 	"kiro-go/logger"
+	"net"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -21,10 +24,24 @@ import (
 	"github.com/google/uuid"
 )
 
-// streamRetryBackoff spaces out a retry of a stream that died before emitting
-// anything. Upstream drops cluster in time, so retrying immediately tends to
-// hit the same blip; a short pause is what makes the retry worth attempting.
-const streamRetryBackoff = 700 * time.Millisecond
+const (
+	// streamRetryBackoff spaces out a retry of a stream that died before
+	// delivering any output callback. Upstream drops cluster in time, so an
+	// immediate retry tends to hit the same blip.
+	streamRetryBackoff = 700 * time.Millisecond
+
+	// maxStreamAttemptsPerEndpoint includes the initial request. One retry
+	// covers the observed transient drops without multiplying the existing
+	// endpoint and account fallback budgets more than necessary.
+	maxStreamAttemptsPerEndpoint = 2
+)
+
+var (
+	errEmptyKiroStream         = errors.New("upstream stream ended before any output")
+	errIncompleteKiroToolInput = errors.New("upstream stream ended with incomplete tool input")
+	streamRetryWait            = time.Sleep
+	resolveKiroEndpoints       = endpointsForAccount
+)
 
 // Endpoint configuration (auto-fallback on quota exhaustion).
 type kiroEndpoint struct {
@@ -374,11 +391,12 @@ func CallKiroAPI(account *config.Account, payload *KiroPayload, callback *KiroSt
 	}
 
 	// Build endpoint list ordered by configuration / credential type.
-	endpoints := endpointsForAccount(account)
+	endpoints := resolveKiroEndpoints(account)
 	isAPIKey := config.IsAPIKeyAccount(account)
 
 	var lastErr error
-	for _, ep := range endpoints {
+endpointLoop:
+	for epIndex, ep := range endpoints {
 		// Update the origin field for the selected endpoint.
 		payload.ConversationState.CurrentMessage.UserInputMessage.Origin = ep.Origin
 
@@ -390,88 +408,116 @@ func CallKiroAPI(account *config.Account, payload *KiroPayload, callback *KiroSt
 		}
 
 		reqBody, _ := json.Marshal(payload)
-		req, err := http.NewRequest("POST", epURL, bytes.NewReader(reqBody))
-		if err != nil {
-			lastErr = err
-			continue
-		}
-
 		host := ""
 		if parsedURL, parseErr := url.Parse(epURL); parseErr == nil {
 			host = parsedURL.Host
 		}
 		headerValues := buildStreamingHeaderValues(account, host)
+		invocationID := uuid.New().String()
 
-		if isAPIKey {
-			req.Header.Set("Content-Type", "application/x-amz-json-1.0")
-		} else {
-			req.Header.Set("Content-Type", "application/json")
-		}
-		req.Header.Set("Accept", "*/*")
-		if ep.AmzTarget != "" {
-			req.Header.Set("X-Amz-Target", ep.AmzTarget)
-		}
-		applyKiroBaseHeaders(req, account, headerValues)
-		if !isAPIKey {
-			req.Header.Set("x-amzn-kiro-agent-mode", "vibe")
-		}
-		// CLI captures use optout=false; IDE path keeps true.
-		if isAPIKey {
-			req.Header.Set("x-amzn-codewhisperer-optout", "false")
-		} else {
-			req.Header.Set("x-amzn-codewhisperer-optout", "true")
-		}
-		req.Header.Set("Amz-Sdk-Request", "attempt=1; max=3")
-		req.Header.Set("Amz-Sdk-Invocation-Id", uuid.New().String())
-
-		resp, err := GetClientForProxy(ResolveAccountProxyURL(account)).Do(req)
-		if err != nil {
-			lastErr = err
-			logger.Warnf("[KiroAPI] Endpoint %s failed: %v", ep.Name, err)
-			continue
-		}
-
-		if resp.StatusCode == 429 {
-			resp.Body.Close()
-			logger.Warnf("[KiroAPI] Endpoint %s quota exhausted (429), trying next...", ep.Name)
-			lastErr = fmt.Errorf("quota exhausted on %s", ep.Name)
-			continue
-		}
-
-		if resp.StatusCode != 200 {
-			errBody, _ := io.ReadAll(resp.Body)
-			resp.Body.Close()
-			lastErr = fmt.Errorf("HTTP %d from %s: %s", resp.StatusCode, ep.Name, string(errBody))
-			// Authentication errors and payment errors are not retried across endpoints.
-			if resp.StatusCode == 401 || resp.StatusCode == 403 || resp.StatusCode == 402 {
-				return lastErr
+		for streamAttempt := 1; streamAttempt <= maxStreamAttemptsPerEndpoint; streamAttempt++ {
+			// Requests and bodies cannot be reused after an HTTP attempt.
+			req, err := http.NewRequest("POST", epURL, bytes.NewReader(reqBody))
+			if err != nil {
+				lastErr = err
+				continue endpointLoop
 			}
-			logger.Warnf("[KiroAPI] Endpoint %s error: %v", ep.Name, lastErr)
-			continue
-		}
 
-		emitted, err := parseEventStreamTracked(resp.Body, callback)
-		resp.Body.Close()
-		if err == nil {
-			return nil
+			if isAPIKey {
+				req.Header.Set("Content-Type", "application/x-amz-json-1.0")
+			} else {
+				req.Header.Set("Content-Type", "application/json")
+			}
+			req.Header.Set("Accept", "*/*")
+			if ep.AmzTarget != "" {
+				req.Header.Set("X-Amz-Target", ep.AmzTarget)
+			}
+			applyKiroBaseHeaders(req, account, headerValues)
+			if !isAPIKey {
+				req.Header.Set("x-amzn-kiro-agent-mode", "vibe")
+			}
+			// CLI captures use optout=false; IDE path keeps true.
+			if isAPIKey {
+				req.Header.Set("x-amzn-codewhisperer-optout", "false")
+			} else {
+				req.Header.Set("x-amzn-codewhisperer-optout", "true")
+			}
+			req.Header.Set("Amz-Sdk-Request", fmt.Sprintf("attempt=%d; max=%d", streamAttempt, maxStreamAttemptsPerEndpoint))
+			req.Header.Set("Amz-Sdk-Invocation-Id", invocationID)
+
+			resp, err := GetClientForProxy(ResolveAccountProxyURL(account)).Do(req)
+			if err != nil {
+				lastErr = err
+				logger.Warnf("[KiroAPI] Endpoint %s failed: %v", ep.Name, err)
+				if !isRetryableStreamError(err) {
+					return err
+				}
+				continue endpointLoop
+			}
+
+			if resp.StatusCode == 429 {
+				resp.Body.Close()
+				logger.Warnf("[KiroAPI] Endpoint %s quota exhausted (429), trying next...", ep.Name)
+				lastErr = fmt.Errorf("quota exhausted on %s", ep.Name)
+				continue endpointLoop
+			}
+
+			if resp.StatusCode != 200 {
+				errBody, _ := io.ReadAll(resp.Body)
+				resp.Body.Close()
+				lastErr = fmt.Errorf("HTTP %d from %s: %s", resp.StatusCode, ep.Name, string(errBody))
+				// Authentication errors and payment errors are not retried across endpoints.
+				if resp.StatusCode == 401 || resp.StatusCode == 403 || resp.StatusCode == 402 {
+					return lastErr
+				}
+				logger.Warnf("[KiroAPI] Endpoint %s error: %v", ep.Name, lastErr)
+				continue endpointLoop
+			}
+
+			emitted, err := parseEventStreamTracked(resp.Body, callback)
+			resp.Body.Close()
+			if err == nil {
+				return nil
+			}
+			lastErr = err
+			// "Emitted" deliberately means that an output callback ran. This
+			// conservative boundary also protects buffered/non-stream callers:
+			// retrying after their callback mutated state would concatenate two
+			// attempts even if no network bytes were flushed yet.
+			if emitted {
+				return err
+			}
+			if !isRetryableStreamError(err) {
+				return err
+			}
+
+			hasSameEndpointRetry := streamAttempt < maxStreamAttemptsPerEndpoint
+			hasEndpointFallback := epIndex+1 < len(endpoints)
+			if !hasSameEndpointRetry && !hasEndpointFallback {
+				break endpointLoop
+			}
+
+			logger.Warnf("[KiroAPI] Endpoint %s stream failed before any output (attempt %d/%d): %v",
+				ep.Name, streamAttempt, maxStreamAttemptsPerEndpoint, err)
+			streamRetryWait(streamRetryBackoff)
+			if !hasSameEndpointRetry {
+				continue endpointLoop
+			}
 		}
-		lastErr = err
-		// A stream that died before emitting anything is safe to retry: the
-		// client has seen no bytes, so a fresh attempt cannot duplicate output.
-		// Once content is out, retrying would concatenate two partial answers,
-		// so surface the error and let the client decide.
-		if emitted {
-			return err
-		}
-		logger.Warnf("[KiroAPI] Endpoint %s stream failed before any output: %v", ep.Name, err)
-		time.Sleep(streamRetryBackoff)
-		continue
 	}
 
 	if lastErr != nil {
 		return lastErr
 	}
 	return fmt.Errorf("all endpoints failed")
+}
+
+func isRetryableStreamError(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	var netErr net.Error
+	return !errors.As(err, &netErr) || !netErr.Timeout()
 }
 
 func accountEmailForLog(account *config.Account) string {
@@ -489,10 +535,9 @@ func parseEventStream(body io.Reader, callback *KiroStreamCallback) error {
 	return err
 }
 
-// parseEventStreamTracked is parseEventStream plus a report of whether any
-// content already reached the client. A failure before the first emission is
-// safe to retry, because a fresh attempt cannot duplicate output that was
-// never sent.
+// parseEventStreamTracked is parseEventStream plus a report of whether an
+// output callback was invoked. A failure before the first callback is safe to
+// retry because it cannot duplicate or concatenate caller state.
 func parseEventStreamTracked(body io.Reader, callback *KiroStreamCallback) (emitted bool, err error) {
 	if callback == nil {
 		callback = &KiroStreamCallback{}
@@ -501,7 +546,19 @@ func parseEventStreamTracked(body io.Reader, callback *KiroStreamCallback) (emit
 	// Read directly without bufio to avoid buffering latency in streaming responses.
 	var inputTokens, outputTokens int
 	var totalCredits float64
+	var contextUsagePercentages []float64
+	var sawOutput bool
 	var currentToolUse *toolUseState
+	trackedCallback := *callback
+	originalOnToolUse := trackedCallback.OnToolUse
+	trackedCallback.OnToolUse = func(toolUse KiroToolUse) {
+		sawOutput = true
+		if originalOnToolUse != nil {
+			emitted = true
+			originalOnToolUse(toolUse)
+		}
+	}
+	callback = &trackedCallback
 
 	for {
 		// Prelude: 12 bytes (total_len + headers_len + crc)
@@ -564,6 +621,7 @@ func parseEventStreamTracked(body io.Reader, callback *KiroStreamCallback) (emit
 		// "1833" into "183", on both streams.
 		case "assistantResponseEvent":
 			if content, ok := event["content"].(string); ok && content != "" {
+				sawOutput = true
 				if callback.OnText != nil {
 					emitted = true
 					callback.OnText(content, false)
@@ -571,39 +629,53 @@ func parseEventStreamTracked(body io.Reader, callback *KiroStreamCallback) (emit
 			}
 		case "reasoningContentEvent":
 			if text, ok := event["text"].(string); ok && text != "" {
+				sawOutput = true
 				if callback.OnText != nil {
 					emitted = true
 					callback.OnText(text, true)
 				}
 			}
 		case "toolUseEvent":
-			emitted = true
-			currentToolUse = handleToolUseEvent(event, currentToolUse, callback)
+			nextToolUse, toolErr := handleToolUseEvent(event, currentToolUse, callback)
+			if toolErr != nil {
+				return emitted, toolErr
+			}
+			currentToolUse = nextToolUse
 		case "meteringEvent":
 			if usage, ok := event["usage"].(float64); ok {
 				totalCredits += usage
 			}
 		case "contextUsageEvent":
 			if pct, ok := event["contextUsagePercentage"].(float64); ok {
-				if callback.OnContextUsage != nil {
-					callback.OnContextUsage(pct)
-				}
+				contextUsagePercentages = append(contextUsagePercentages, pct)
 			}
 		}
 	}
 
 	if currentToolUse != nil {
-		finishToolUse(currentToolUse, callback)
+		if err := finishToolUse(currentToolUse, callback); err != nil {
+			return emitted, err
+		}
+	}
+
+	if !sawOutput {
+		return emitted, errEmptyKiroStream
 	}
 
 	if callback.OnCredits != nil && totalCredits > 0 {
 		callback.OnCredits(totalCredits)
 	}
 
+	if callback.OnContextUsage != nil {
+		for _, percentage := range contextUsagePercentages {
+			callback.OnContextUsage(percentage)
+		}
+	}
+
 	if callback.OnComplete != nil {
 		callback.OnComplete(inputTokens, outputTokens)
 	}
-	return true, nil
+	return emitted, nil
 }
 
 func updateTokensFromEvent(event map[string]interface{}, currentInputTokens, currentOutputTokens int) (int, int) {
@@ -731,7 +803,6 @@ func collectUsageMaps(v interface{}, out *[]map[string]interface{}) {
 	}
 }
 
-
 func readTokenNumber(m map[string]interface{}, keys ...string) (int, bool) {
 	for _, k := range keys {
 		v, ok := m[k]
@@ -770,7 +841,7 @@ type toolUseState struct {
 	GeneratedID bool
 }
 
-func handleToolUseEvent(event map[string]interface{}, current *toolUseState, callback *KiroStreamCallback) *toolUseState {
+func handleToolUseEvent(event map[string]interface{}, current *toolUseState, callback *KiroStreamCallback) (*toolUseState, error) {
 	toolUseID := firstStringField(event, "toolUseId", "toolUseID", "tool_use_id", "id")
 	name := firstStringField(event, "name", "toolName", "tool_name")
 	isStop := firstBoolField(event, "stop", "isStop", "done")
@@ -783,14 +854,18 @@ func handleToolUseEvent(event map[string]interface{}, current *toolUseState, cal
 				current.ToolUseID = toolUseID
 				current.GeneratedID = false
 			} else {
-				finishToolUse(current, callback)
+				if err := finishToolUse(current, callback); err != nil {
+					return current, err
+				}
 				current = &toolUseState{ToolUseID: toolUseID, Name: name}
 			}
 		}
 	} else if name != "" && current == nil {
 		current = &toolUseState{ToolUseID: "toolu_" + uuid.New().String(), Name: name, GeneratedID: true}
 	} else if name != "" && current != nil && current.Name != name {
-		finishToolUse(current, callback)
+		if err := finishToolUse(current, callback); err != nil {
+			return current, err
+		}
 		current = &toolUseState{ToolUseID: "toolu_" + uuid.New().String(), Name: name, GeneratedID: true}
 	}
 
@@ -805,32 +880,40 @@ func handleToolUseEvent(event map[string]interface{}, current *toolUseState, cal
 	}
 
 	if isStop && current != nil {
-		finishToolUse(current, callback)
-		return nil
+		if err := finishToolUse(current, callback); err != nil {
+			return current, err
+		}
+		return nil, nil
 	}
 
-	return current
+	return current, nil
 }
 
-func finishToolUse(state *toolUseState, callback *KiroStreamCallback) {
-	if state == nil || state.Name == "" || callback == nil || callback.OnToolUse == nil {
-		return
+func finishToolUse(state *toolUseState, callback *KiroStreamCallback) error {
+	if state == nil || state.Name == "" {
+		return nil
 	}
 	if state.ToolUseID == "" {
 		state.ToolUseID = "toolu_" + uuid.New().String()
 	}
 	var input map[string]interface{}
 	if state.InputBuffer.Len() > 0 {
-		json.Unmarshal([]byte(state.InputBuffer.String()), &input)
+		if err := json.Unmarshal([]byte(state.InputBuffer.String()), &input); err != nil {
+			return fmt.Errorf("%w: %v", errIncompleteKiroToolInput, err)
+		}
 	}
 	if input == nil {
 		input = make(map[string]interface{})
+	}
+	if callback == nil || callback.OnToolUse == nil {
+		return nil
 	}
 	callback.OnToolUse(KiroToolUse{
 		ToolUseID: state.ToolUseID,
 		Name:      state.Name,
 		Input:     input,
 	})
+	return nil
 }
 
 func firstStringField(m map[string]interface{}, keys ...string) string {

--- a/proxy/kiro_test.go
+++ b/proxy/kiro_test.go
@@ -2,12 +2,15 @@ package proxy
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"io"
 	"kiro-go/config"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 )
@@ -142,7 +145,7 @@ func TestParseEventStreamNilCallbackFieldsAreNoOp(t *testing.T) {
 
 func TestHandleToolUseEventGeneratesMissingToolUseID(t *testing.T) {
 	var toolUses []KiroToolUse
-	current := handleToolUseEvent(map[string]interface{}{
+	current, err := handleToolUseEvent(map[string]interface{}{
 		"name":  "mcpIdaProMcpStatus",
 		"input": `{"server":"ida-pro-mcp"}`,
 		"stop":  true,
@@ -151,6 +154,9 @@ func TestHandleToolUseEventGeneratesMissingToolUseID(t *testing.T) {
 			toolUses = append(toolUses, toolUse)
 		},
 	})
+	if err != nil {
+		t.Fatalf("unexpected tool use error: %v", err)
+	}
 
 	if current != nil {
 		t.Fatalf("expected stopped tool use to clear current state")
@@ -174,16 +180,22 @@ func TestHandleToolUseEventReplacesGeneratedIDWhenRealIDArrives(t *testing.T) {
 		},
 	}
 
-	current := handleToolUseEvent(map[string]interface{}{
+	current, err := handleToolUseEvent(map[string]interface{}{
 		"name":  "mcpIdaProMcpStatus",
 		"input": `{"server":`,
 	}, nil, callback)
-	current = handleToolUseEvent(map[string]interface{}{
+	if err != nil {
+		t.Fatalf("unexpected first tool fragment error: %v", err)
+	}
+	current, err = handleToolUseEvent(map[string]interface{}{
 		"toolUseId": "toolu_real",
 		"name":      "mcpIdaProMcpStatus",
 		"input":     `"ida-pro-mcp"}`,
 		"stop":      true,
 	}, current, callback)
+	if err != nil {
+		t.Fatalf("unexpected completed tool error: %v", err)
+	}
 
 	if current != nil {
 		t.Fatalf("expected stopped tool use to clear current state")
@@ -422,5 +434,368 @@ func TestParseEventStreamTrackedThinkingCountsAsEmission(t *testing.T) {
 	}
 	if !emitted {
 		t.Fatalf("thinking text is client-visible, so it must count as emitted")
+	}
+}
+
+func TestParseEventStreamTrackedRejectsIncompleteToolOnCleanEOF(t *testing.T) {
+	frame := awsEventStreamFrame(t, "toolUseEvent", map[string]interface{}{
+		"toolUseId": "toolu_partial",
+		"name":      "lookup",
+		"input":     `{"query":`,
+	})
+
+	var toolUses, completed int
+	emitted, err := parseEventStreamTracked(bytes.NewReader(frame), &KiroStreamCallback{
+		OnToolUse:  func(KiroToolUse) { toolUses++ },
+		OnComplete: func(int, int) { completed++ },
+	})
+	if !errors.Is(err, errIncompleteKiroToolInput) {
+		t.Fatalf("expected incomplete tool error, got %v", err)
+	}
+	if emitted {
+		t.Fatal("an incomplete tool use that was not delivered must not count as emitted")
+	}
+	if toolUses != 0 || completed != 0 {
+		t.Fatalf("toolUses=%d completed=%d, want no callbacks", toolUses, completed)
+	}
+}
+
+func TestCallKiroAPIRetriesAPIKeyEndpointAfterEmptyStream(t *testing.T) {
+	var calls, completed int
+	var text string
+	var attempts, invocationIDs, hosts []string
+	installKiroStreamTestClient(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		attempts = append(attempts, req.Header.Get("Amz-Sdk-Request"))
+		invocationIDs = append(invocationIDs, req.Header.Get("Amz-Sdk-Invocation-Id"))
+		hosts = append(hosts, req.URL.Host)
+		if calls == 1 {
+			return kiroStreamTestResponse(bytes.NewReader(nil)), nil
+		}
+		return kiroStreamTestResponse(bytes.NewReader(awsEventStreamFrame(t,
+			"assistantResponseEvent", map[string]interface{}{"content": "recovered"}))), nil
+	}))
+
+	var waits int
+	installKiroRetryWait(t, func(delay time.Duration) {
+		waits++
+		if delay != streamRetryBackoff {
+			t.Errorf("retry delay = %s, want %s", delay, streamRetryBackoff)
+		}
+	})
+
+	err := CallKiroAPI(
+		newKiroRetryTestAPIKeyAccount("eu-west-1"),
+		newKiroRetryTestPayload(),
+		&KiroStreamCallback{
+			OnText:     func(chunk string, _ bool) { text += chunk },
+			OnComplete: func(int, int) { completed++ },
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 2 || waits != 1 {
+		t.Fatalf("calls=%d waits=%d, want calls=2 waits=1", calls, waits)
+	}
+	if text != "recovered" || completed != 1 {
+		t.Fatalf("text=%q completed=%d, want recovered and one completion", text, completed)
+	}
+	if got := strings.Join(attempts, ","); got != "attempt=1; max=2,attempt=2; max=2" {
+		t.Fatalf("attempt headers = %q", got)
+	}
+	if len(invocationIDs) != 2 || invocationIDs[0] == "" || invocationIDs[0] != invocationIDs[1] {
+		t.Fatalf("same endpoint retries must share an invocation ID: %q", invocationIDs)
+	}
+	if got := strings.Join(hosts, ","); got != "runtime.eu-west-1.kiro.dev,runtime.eu-west-1.kiro.dev" {
+		t.Fatalf("API key retry hosts = %q", got)
+	}
+}
+
+func TestCallKiroAPIRetriesCurrentEndpointBeforeFallback(t *testing.T) {
+	installKiroRetryTestEndpoints(t)
+
+	var trace, attempts, invocationIDs []string
+	var text string
+	var completed int
+	installKiroStreamTestClient(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		trace = append(trace, req.URL.Host)
+		attempts = append(attempts, req.Header.Get("Amz-Sdk-Request"))
+		invocationIDs = append(invocationIDs, req.Header.Get("Amz-Sdk-Invocation-Id"))
+		if req.URL.Host == "first.example" {
+			return kiroStreamTestResponse(&truncatedReader{
+				data: []byte{0, 0, 1},
+				err:  io.ErrUnexpectedEOF,
+			}), nil
+		}
+		return kiroStreamTestResponse(bytes.NewReader(awsEventStreamFrame(t,
+			"assistantResponseEvent", map[string]interface{}{"content": "fallback"}))), nil
+	}))
+	installKiroRetryWait(t, func(delay time.Duration) {
+		if delay != streamRetryBackoff {
+			t.Errorf("retry delay = %s, want %s", delay, streamRetryBackoff)
+		}
+		trace = append(trace, "wait")
+	})
+
+	err := CallKiroAPI(
+		newKiroRetryTestOAuthAccount(),
+		newKiroRetryTestPayload(),
+		&KiroStreamCallback{
+			OnText:     func(chunk string, _ bool) { text += chunk },
+			OnComplete: func(int, int) { completed++ },
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantTrace := "first.example,wait,first.example,wait,second.example"
+	if got := strings.Join(trace, ","); got != wantTrace {
+		t.Fatalf("request trace = %q, want %q", got, wantTrace)
+	}
+	wantAttempts := "attempt=1; max=2,attempt=2; max=2,attempt=1; max=2"
+	if got := strings.Join(attempts, ","); got != wantAttempts {
+		t.Fatalf("attempt headers = %q, want %q", got, wantAttempts)
+	}
+	if len(invocationIDs) != 3 ||
+		invocationIDs[0] == "" ||
+		invocationIDs[0] != invocationIDs[1] ||
+		invocationIDs[1] == invocationIDs[2] {
+		t.Fatalf("unexpected invocation IDs: %q", invocationIDs)
+	}
+	if text != "fallback" || completed != 1 {
+		t.Fatalf("text=%q completed=%d, want fallback and one completion", text, completed)
+	}
+}
+
+func TestCallKiroAPISingleEndpointStopsAfterFinalAttempt(t *testing.T) {
+	var calls, waits, completed int
+	var attempts []string
+	installKiroStreamTestClient(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		attempts = append(attempts, req.Header.Get("Amz-Sdk-Request"))
+		return kiroStreamTestResponse(&truncatedReader{
+			data: []byte{0, 0, 1},
+			err:  io.ErrUnexpectedEOF,
+		}), nil
+	}))
+	installKiroRetryWait(t, func(time.Duration) { waits++ })
+
+	err := CallKiroAPI(
+		newKiroRetryTestAPIKeyAccount(""),
+		newKiroRetryTestPayload(),
+		&KiroStreamCallback{OnComplete: func(int, int) { completed++ }},
+	)
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("expected final truncation error, got %v", err)
+	}
+	if calls != maxStreamAttemptsPerEndpoint || waits != maxStreamAttemptsPerEndpoint-1 {
+		t.Fatalf("calls=%d waits=%d, want calls=%d waits=%d",
+			calls, waits, maxStreamAttemptsPerEndpoint, maxStreamAttemptsPerEndpoint-1)
+	}
+	if completed != 0 {
+		t.Fatalf("failed attempts must not complete, got %d callbacks", completed)
+	}
+	wantAttempts := "attempt=1; max=2,attempt=2; max=2"
+	if got := strings.Join(attempts, ","); got != wantAttempts {
+		t.Fatalf("attempt headers = %q, want %q", got, wantAttempts)
+	}
+}
+
+func TestCallKiroAPIRetriesIncompleteToolUse(t *testing.T) {
+	var calls, waits, completed int
+	var toolUses []KiroToolUse
+	installKiroStreamTestClient(t, roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			frame := awsEventStreamFrame(t, "toolUseEvent", map[string]interface{}{
+				"toolUseId": "toolu_partial",
+				"name":      "lookup",
+				"input":     `{"query":`,
+				"stop":      true,
+			})
+			return kiroStreamTestResponse(bytes.NewReader(frame)), nil
+		}
+		frame := awsEventStreamFrame(t, "toolUseEvent", map[string]interface{}{
+			"toolUseId": "toolu_complete",
+			"name":      "lookup",
+			"input":     `{"query":"kiro"}`,
+			"stop":      true,
+		})
+		return kiroStreamTestResponse(bytes.NewReader(frame)), nil
+	}))
+	installKiroRetryWait(t, func(time.Duration) { waits++ })
+
+	err := CallKiroAPI(
+		newKiroRetryTestAPIKeyAccount(""),
+		newKiroRetryTestPayload(),
+		&KiroStreamCallback{
+			OnToolUse:  func(toolUse KiroToolUse) { toolUses = append(toolUses, toolUse) },
+			OnComplete: func(int, int) { completed++ },
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 2 || waits != 1 {
+		t.Fatalf("calls=%d waits=%d, want calls=2 waits=1", calls, waits)
+	}
+	if len(toolUses) != 1 || toolUses[0].ToolUseID != "toolu_complete" {
+		t.Fatalf("expected only the completed retry tool use, got %#v", toolUses)
+	}
+	if got := toolUses[0].Input["query"]; got != "kiro" {
+		t.Fatalf("tool input = %#v, want kiro", got)
+	}
+	if completed != 1 {
+		t.Fatalf("completion callbacks = %d, want 1", completed)
+	}
+}
+
+func TestCallKiroAPIDoesNotRetryAfterCompletedToolCallback(t *testing.T) {
+	var calls, waits, completed int
+	var toolUses []KiroToolUse
+	installKiroStreamTestClient(t, roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		frame := awsEventStreamFrame(t, "toolUseEvent", map[string]interface{}{
+			"toolUseId": "toolu_complete",
+			"name":      "lookup",
+			"input":     `{"query":"kiro"}`,
+			"stop":      true,
+		})
+		return kiroStreamTestResponse(&truncatedReader{
+			data: append(frame, 0, 0, 1),
+			err:  io.ErrUnexpectedEOF,
+		}), nil
+	}))
+	installKiroRetryWait(t, func(time.Duration) { waits++ })
+
+	err := CallKiroAPI(
+		newKiroRetryTestAPIKeyAccount(""),
+		newKiroRetryTestPayload(),
+		&KiroStreamCallback{
+			OnToolUse:  func(toolUse KiroToolUse) { toolUses = append(toolUses, toolUse) },
+			OnComplete: func(int, int) { completed++ },
+		},
+	)
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("expected truncation error, got %v", err)
+	}
+	if calls != 1 || waits != 0 {
+		t.Fatalf("calls=%d waits=%d, want no retry or wait after tool callback", calls, waits)
+	}
+	if len(toolUses) != 1 || toolUses[0].ToolUseID != "toolu_complete" {
+		t.Fatalf("expected one completed tool callback, got %#v", toolUses)
+	}
+	if completed != 0 {
+		t.Fatalf("completion callbacks = %d, want 0", completed)
+	}
+}
+
+func TestCallKiroAPIDoesNotRetryTimedOutStream(t *testing.T) {
+	var calls, waits int
+	installKiroStreamTestClient(t, roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		return kiroStreamTestResponse(&truncatedReader{err: context.DeadlineExceeded}), nil
+	}))
+	installKiroRetryWait(t, func(time.Duration) { waits++ })
+
+	err := CallKiroAPI(
+		newKiroRetryTestAPIKeyAccount(""),
+		newKiroRetryTestPayload(),
+		&KiroStreamCallback{},
+	)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline error, got %v", err)
+	}
+	if calls != 1 || waits != 0 {
+		t.Fatalf("calls=%d waits=%d, want no retry or wait after deadline", calls, waits)
+	}
+}
+
+func TestCallKiroAPIDoesNotFallbackAfterTimedOutTransport(t *testing.T) {
+	installKiroRetryTestEndpoints(t)
+
+	var calls, waits int
+	installKiroStreamTestClient(t, roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		return nil, context.DeadlineExceeded
+	}))
+	installKiroRetryWait(t, func(time.Duration) { waits++ })
+
+	err := CallKiroAPI(
+		newKiroRetryTestOAuthAccount(),
+		newKiroRetryTestPayload(),
+		&KiroStreamCallback{},
+	)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline error, got %v", err)
+	}
+	if calls != 1 || waits != 0 {
+		t.Fatalf("calls=%d waits=%d, want no fallback or wait after deadline", calls, waits)
+	}
+}
+
+func installKiroRetryTestEndpoints(t *testing.T) {
+	t.Helper()
+	oldResolver := resolveKiroEndpoints
+	resolveKiroEndpoints = func(*config.Account) []kiroEndpoint {
+		return []kiroEndpoint{
+			{URL: "https://first.example/generate", Origin: "AI_EDITOR", Name: "first"},
+			{URL: "https://second.example/generate", Origin: "AI_EDITOR", Name: "second"},
+		}
+	}
+	t.Cleanup(func() { resolveKiroEndpoints = oldResolver })
+}
+
+func installKiroStreamTestClient(t *testing.T, transport http.RoundTripper) {
+	t.Helper()
+	oldClient, hadOldClient := proxyClientCache.Load(kiroRetryTestProxyURL)
+	proxyClientCache.Store(kiroRetryTestProxyURL, &http.Client{Transport: transport})
+	t.Cleanup(func() {
+		if hadOldClient {
+			proxyClientCache.Store(kiroRetryTestProxyURL, oldClient)
+		} else {
+			proxyClientCache.Delete(kiroRetryTestProxyURL)
+		}
+	})
+}
+
+func installKiroRetryWait(t *testing.T, wait func(time.Duration)) {
+	t.Helper()
+	oldWait := streamRetryWait
+	streamRetryWait = wait
+	t.Cleanup(func() { streamRetryWait = oldWait })
+}
+
+func newKiroRetryTestPayload() *KiroPayload {
+	payload := &KiroPayload{}
+	payload.ConversationState.CurrentMessage.UserInputMessage.Content = "test"
+	return payload
+}
+
+const kiroRetryTestProxyURL = "test://kiro-retry-proxy"
+
+func newKiroRetryTestAPIKeyAccount(region string) *config.Account {
+	return &config.Account{
+		AuthMethod: "api_key",
+		KiroApiKey: "ksk_test",
+		Region:     region,
+		ProxyURL:   kiroRetryTestProxyURL,
+	}
+}
+
+func newKiroRetryTestOAuthAccount() *config.Account {
+	return &config.Account{
+		AccessToken: "access-token",
+		ProfileArn:  "arn:aws:codewhisperer:us-east-1:123456789012:profile/test",
+		ProxyURL:    kiroRetryTestProxyURL,
+	}
+}
+
+func kiroStreamTestResponse(body io.Reader) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(body),
+		Header:     make(http.Header),
 	}
 }

--- a/proxy/kiro_test.go
+++ b/proxy/kiro_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/json"
+	"io"
 	"kiro-go/config"
 	"net/http"
 	"net/url"
@@ -325,4 +326,101 @@ func awsEventStreamFrame(t *testing.T, eventType string, payload map[string]inte
 	frame = append(frame, payloadBytes...)
 	frame = append(frame, 0, 0, 0, 0)
 	return frame
+}
+
+// --- stream EOF retry safety -------------------------------------------------
+
+// truncatedReader yields the given bytes then fails, simulating an upstream
+// connection that dies mid-stream.
+type truncatedReader struct {
+	data []byte
+	pos  int
+	err  error
+}
+
+func (r *truncatedReader) Read(p []byte) (int, error) {
+	if r.pos >= len(r.data) {
+		return 0, r.err
+	}
+	n := copy(p, r.data[r.pos:])
+	r.pos += n
+	return n, nil
+}
+
+func TestParseEventStreamTrackedReportsNoEmissionOnEarlyFailure(t *testing.T) {
+	// Stream dies before any frame completes: nothing reached the client.
+	stream := &truncatedReader{data: []byte{0, 0, 1}, err: io.ErrUnexpectedEOF}
+
+	var emittedText int
+	emitted, err := parseEventStreamTracked(stream, &KiroStreamCallback{
+		OnText:    func(string, bool) { emittedText++ },
+		OnToolUse: func(KiroToolUse) { emittedText++ },
+	})
+	if err == nil {
+		t.Fatalf("expected a truncation error")
+	}
+	if emitted {
+		t.Fatalf("expected emitted=false when the stream died before any output")
+	}
+	if emittedText != 0 {
+		t.Fatalf("expected no callbacks, got %d", emittedText)
+	}
+}
+
+func TestParseEventStreamTrackedReportsEmissionAfterText(t *testing.T) {
+	// One complete text frame, then the connection dies.
+	frame := awsEventStreamFrame(t, "assistantResponseEvent", map[string]interface{}{
+		"content": "partial answer",
+	})
+	stream := &truncatedReader{
+		data: append(frame, 0, 0, 1),
+		err:  io.ErrUnexpectedEOF,
+	}
+
+	var got string
+	emitted, err := parseEventStreamTracked(stream, &KiroStreamCallback{
+		OnText: func(text string, _ bool) { got += text },
+	})
+	if err == nil {
+		t.Fatalf("expected a truncation error")
+	}
+	if !emitted {
+		t.Fatalf("expected emitted=true once text reached the client")
+	}
+	if got != "partial answer" {
+		t.Fatalf("expected the partial text to have been delivered, got %q", got)
+	}
+}
+
+func TestParseEventStreamTrackedReportsEmissionOnCleanStream(t *testing.T) {
+	stream := bytes.NewReader(awsEventStreamFrame(t, "assistantResponseEvent", map[string]interface{}{
+		"content": "done",
+	}))
+
+	emitted, err := parseEventStreamTracked(stream, &KiroStreamCallback{
+		OnText: func(string, bool) {},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !emitted {
+		t.Fatalf("expected emitted=true for a clean stream")
+	}
+}
+
+func TestParseEventStreamTrackedThinkingCountsAsEmission(t *testing.T) {
+	frame := awsEventStreamFrame(t, "reasoningContentEvent", map[string]interface{}{
+		"text": "let me think",
+	})
+	stream := &truncatedReader{data: append(frame, 0, 0, 1), err: io.ErrUnexpectedEOF}
+
+	emitted, err := parseEventStreamTracked(stream, &KiroStreamCallback{
+		OnText: func(string, bool) {},
+	})
+	if err == nil {
+		t.Fatalf("expected a truncation error")
+	}
+	if !emitted {
+		t.Fatalf("thinking text is client-visible, so it must count as emitted")
+	}
 }


### PR DESCRIPTION
Fixes #142.

## Problem

In `CallKiroAPI`, the stream-parsing stage is the only failure branch in the endpoint loop that returns unconditionally instead of falling through to the next endpoint:

```go
err = parseEventStream(resp.Body, callback)
resp.Body.Close()
return err          // no fallthrough
```

Every other failure mode there (`Do` error, 429, non-200) does `continue`. So an `unexpected EOF` from `q.us-east-1.amazonaws.com` is never retried — even when it lands before a single byte reached the client.

When that happens, the client gets a stream that is syntactically valid but protocol-incomplete: no `content_block_stop`, no `message_delta` (hence no `stop_reason`), no `message_stop`. Anthropic clients decide "was this complete?" from `stop_reason`, so Claude Code renders whatever arrived and ends the turn. The user sees an assistant turn with a half-finished sentence and no tool call — indistinguishable from the model deciding to stop. The only recovery is retyping "continue".

Captured tail of a real failure:

```
data: {"delta":{"text":"虽然返回 `Promise<R>`,校验失败却是同步 `throw`,不是","type":"text_delta"},"index":1,"type":"content_block_delta"}

event: error
data: {"error":{"message":"unexpected EOF","type":"api_error"},"type":"error"}
```

Measured on `ghcr.io/quorinex/kiro-go:latest`. Failure is random, not content-dependent — identical request bytes both succeed and fail:

| test | result |
|---|---|
| identical request ×12 | 1/12 failed |
| streaming w/ tools, larger context ×10 | 5/10 failed |
| same shape, thinking disabled ×8 | 1/8 failed |
| 32 requests during a calm upstream window | 0/32 failed |

These EOFs occur without any accompanying `HTTP 500` / `MODEL_TEMPORARILY_UNAVAILABLE` in the same window, so it is not just overload spillover. Client-side retry of the failed requests recovered 5/5 on the first attempt.

## Change

`parseEventStreamTracked` is `parseEventStream` plus a report of whether anything client-visible was already emitted (`assistantResponseEvent`, `reasoningContentEvent`, `toolUseEvent`). The existing `parseEventStream` signature stays as a thin wrapper, so existing callers and tests are untouched.

At the call site, a stream that failed with nothing emitted now falls through to the next endpoint after a short backoff:

```go
emitted, err := parseEventStreamTracked(resp.Body, callback)
resp.Body.Close()
if err == nil {
    return nil
}
lastErr = err
if emitted {
    return err
}
logger.Warnf("[KiroAPI] Endpoint %s stream failed before any output: %v", ep.Name, err)
time.Sleep(streamRetryBackoff)
continue
```

Two deliberate limits:

**Only the zero-output case retries.** Once content is out, a retry would concatenate two partial answers. Of 5 captured failures, 2 died with zero output and 3 after partial text (267 / 799 / 463 chars) — so this covers the safe subset, not all of them.

**The backoff is load-bearing.** Cross-endpoint attempts currently fire inside the same second and tend to fail together; client retries spaced seconds apart recovered 5/5. 700ms is a compromise — happy to adjust.

## A negative result worth recording

I also tried *completing the protocol* on truncation — synthesizing `content_block_stop` + `message_delta` + `message_stop` — and it makes things worse:

| strategy | `stop_reason` | client can detect truncation? |
|---|---|---|
| current (error event only) | absent | yes |
| synthesized `message_delta` | e.g. `max_tokens` | **no** — looks like a complete short answer |

So leaving `stop_reason` absent is the better half of that trade-off and is preserved here for the already-emitted path. Only the zero-output path changes.

Full coverage would need buffering until the first `content_block_stop` before forwarding, costing roughly 2s of first-token latency (measured 4.8s streaming TTFB vs 6.6s non-streaming total). Not attempted here — it is a larger behavioural change and worth deciding separately.

## Verification

- `go build ./...` and `go vet ./...` clean
- 4 new tests in `proxy/kiro_test.go`: no emission on early failure, emission after text, emission on a clean stream, thinking text counting as emission
- Mutation-tested both directions: forcing `emitted` to never set fails 2 tests; forcing it always true fails the zero-output assertion
- Full suite on this branch shows the same 2 failures as a clean `ec4ba56` checkout (`TestClaudeToolResultMixedTextAndImage`, `TestOpenAIToolResultImageCarriedWhenFollowedByUser`), verified by running baseline on the same commit. `TestClaudeNonStreamRetriesNextAccountAfterPreResponseFailure` flakes on a TempDir cleanup race, also present on baseline and unrelated to this change.

Rebased on `ec4ba56` (v1.1.5). I kept clear of the `normalizeChunk` removal from #138 — the emission flag is set where the callbacks fire, so it does not reintroduce any content-based inspection.
