### PR TITLE
fix(stream): 正确读取上游 stopReason、工具调用与客户端取消

### DIFF
--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -886,7 +886,7 @@ func (h *Handler) handleClaudeMessagesInternal(w http.ResponseWriter, r *http.Re
 	// and returns client tool_use blocks as-is.
 	if hasWebSearchAmongTools(&req) {
 		logger.Infof("[WebSearch] Mixed tools with native web_search, entering agentic loop")
-		h.runWebSearchLoop(w, &req, thinking, estimatedInputTokens, apiKeyID)
+		h.runWebSearchLoop(r.Context(), w, &req, thinking, estimatedInputTokens, apiKeyID)
 		return
 	}
 
@@ -895,14 +895,14 @@ func (h *Handler) handleClaudeMessagesInternal(w http.ResponseWriter, r *http.Re
 
 	// Stream or non-stream
 	if req.Stream {
-		h.handleClaudeStream(w, kiroPayload, req.Model, thinking, thinkingResponseOpts, estimatedInputTokens, cacheProfile, apiKeyID)
+		h.handleClaudeStream(r.Context(), w, kiroPayload, req.Model, thinking, thinkingResponseOpts, estimatedInputTokens, cacheProfile, apiKeyID)
 	} else {
-		h.handleClaudeNonStream(w, kiroPayload, req.Model, thinking, thinkingResponseOpts, estimatedInputTokens, cacheProfile, apiKeyID)
+		h.handleClaudeNonStream(r.Context(), w, kiroPayload, req.Model, thinking, thinkingResponseOpts, estimatedInputTokens, cacheProfile, apiKeyID)
 	}
 }
 
 // handleClaudeStream Claude 流式响应
-func (h *Handler) handleClaudeStream(w http.ResponseWriter, payload *KiroPayload, model string, thinking bool, thinkingOpts claudeThinkingResponseOptions, estimatedInputTokens int, cacheProfile *promptCacheProfile, apiKeyID string) {
+func (h *Handler) handleClaudeStream(ctx context.Context, w http.ResponseWriter, payload *KiroPayload, model string, thinking bool, thinkingOpts claudeThinkingResponseOptions, estimatedInputTokens int, cacheProfile *promptCacheProfile, apiKeyID string) {
 	w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
@@ -962,6 +962,7 @@ func (h *Handler) handleClaudeStream(w http.ResponseWriter, payload *KiroPayload
 		var credits float64
 		var realInputTokens int
 		var toolUses []KiroToolUse
+		var upstreamStopReason string
 		var nextContentIndex int
 		var rawContentBuilder strings.Builder
 		var rawThinkingBuilder strings.Builder
@@ -1271,10 +1272,16 @@ func (h *Handler) handleClaudeStream(w http.ResponseWriter, payload *KiroPayload
 			OnContextUsage: func(pct float64) {
 				realInputTokens = int(pct * float64(getContextWindowSize(model)) / 100.0)
 			},
+			OnStopReason: func(reason string) {
+				upstreamStopReason = reason
+			},
 		}
 
-		err := CallKiroAPI(account, payload, callback)
+		err := CallKiroAPIContext(ctx, account, payload, callback)
 		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
 			lastErr = err
 			excluded[account.ID] = true
 			h.handleAccountFailure(account, err)
@@ -1316,10 +1323,7 @@ func (h *Handler) handleClaudeStream(w http.ResponseWriter, payload *KiroPayload
 		h.promptCache.Update(account.ID, cacheProfile)
 		h.recordSuccessLog("claude", model, account.ID, inputTokens+outputTokens, credits, time.Since(reqStart).Milliseconds())
 
-		stopReason := "end_turn"
-		if len(toolUses) > 0 {
-			stopReason = "tool_use"
-		}
+		stopReason := mapClaudeStopReason(upstreamStopReason, len(toolUses))
 
 		ensureMessageStart()
 		h.sendSSE(w, flusher, "message_delta", map[string]interface{}{
@@ -1499,7 +1503,7 @@ func (h *Handler) getRequestLogs() []RequestLog {
 }
 
 // handleClaudeNonStream Claude 非流式响应
-func (h *Handler) handleClaudeNonStream(w http.ResponseWriter, payload *KiroPayload, model string, thinking bool, thinkingOpts claudeThinkingResponseOptions, estimatedInputTokens int, cacheProfile *promptCacheProfile, apiKeyID string) {
+func (h *Handler) handleClaudeNonStream(ctx context.Context, w http.ResponseWriter, payload *KiroPayload, model string, thinking bool, thinkingOpts claudeThinkingResponseOptions, estimatedInputTokens int, cacheProfile *promptCacheProfile, apiKeyID string) {
 	excluded := make(map[string]bool)
 	var lastErr error
 	reqStart := time.Now()
@@ -1523,6 +1527,7 @@ func (h *Handler) handleClaudeNonStream(w http.ResponseWriter, payload *KiroPayl
 		var inputTokens, outputTokens int
 		var credits float64
 		var realInputTokens int
+		var upstreamStopReason string
 
 		callback := &KiroStreamCallback{
 			OnText: func(text string, isThinking bool) {
@@ -1545,10 +1550,16 @@ func (h *Handler) handleClaudeNonStream(w http.ResponseWriter, payload *KiroPayl
 			OnContextUsage: func(pct float64) {
 				realInputTokens = int(pct * float64(getContextWindowSize(model)) / 100.0)
 			},
+			OnStopReason: func(reason string) {
+				upstreamStopReason = reason
+			},
 		}
 
-		err := CallKiroAPI(account, payload, callback)
+		err := CallKiroAPIContext(ctx, account, payload, callback)
 		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
 			lastErr = err
 			excluded[account.ID] = true
 			h.handleAccountFailure(account, err)
@@ -1596,7 +1607,7 @@ func (h *Handler) handleClaudeNonStream(w http.ResponseWriter, payload *KiroPayl
 			}
 		}
 
-		resp := KiroToClaudeResponse(finalContent, responseThinkingContent, includeEmptyThinkingBlock, toolUses, inputTokens, outputTokens, model)
+		resp := KiroToClaudeResponse(finalContent, responseThinkingContent, includeEmptyThinkingBlock, toolUses, inputTokens, outputTokens, model, upstreamStopReason)
 		resp.Usage.InputTokens = billedClaudeInputTokens(inputTokens, cacheUsage)
 		resp.Usage.CacheCreationInputTokens = cacheUsage.CacheCreationInputTokens
 		resp.Usage.CacheReadInputTokens = cacheUsage.CacheReadInputTokens
@@ -1665,14 +1676,14 @@ func (h *Handler) handleOpenAIChat(w http.ResponseWriter, r *http.Request) {
 
 	apiKeyID := apiKeyIDFromContext(r.Context())
 	if req.Stream {
-		h.handleOpenAIStream(w, kiroPayload, req.Model, thinking, estimatedInputTokens, apiKeyID)
+		h.handleOpenAIStream(r.Context(), w, kiroPayload, req.Model, thinking, estimatedInputTokens, apiKeyID)
 	} else {
-		h.handleOpenAINonStream(w, kiroPayload, req.Model, thinking, estimatedInputTokens, apiKeyID)
+		h.handleOpenAINonStream(r.Context(), w, kiroPayload, req.Model, thinking, estimatedInputTokens, apiKeyID)
 	}
 }
 
 // handleOpenAIStream OpenAI 流式响应
-func (h *Handler) handleOpenAIStream(w http.ResponseWriter, payload *KiroPayload, model string, thinking bool, estimatedInputTokens int, apiKeyID string) {
+func (h *Handler) handleOpenAIStream(ctx context.Context, w http.ResponseWriter, payload *KiroPayload, model string, thinking bool, estimatedInputTokens int, apiKeyID string) {
 	w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
@@ -1703,6 +1714,7 @@ func (h *Handler) handleOpenAIStream(w http.ResponseWriter, payload *KiroPayload
 			continue
 		}
 
+		var upstreamStopReason string
 		var toolCalls []ToolCall
 		var toolCallIndex int
 		var inputTokens, outputTokens int
@@ -1717,6 +1729,17 @@ func (h *Handler) handleOpenAIStream(w http.ResponseWriter, payload *KiroPayload
 		var thinkingStarted bool
 		var eventThinkingOpen bool
 		responseStarted := false
+
+		sendStreamError := func(err error) {
+			data, _ := json.Marshal(map[string]interface{}{
+				"error": map[string]string{
+					"message": err.Error(),
+					"type":    "server_error",
+				},
+			})
+			fmt.Fprintf(w, "data: %s\n\n", data)
+			flusher.Flush()
+		}
 
 		sendChunk := func(content string, thinkingState int) {
 			if content == "" && thinkingState == 2 {
@@ -1972,6 +1995,9 @@ func (h *Handler) handleOpenAIStream(w http.ResponseWriter, payload *KiroPayload
 				flusher.Flush()
 				responseStarted = true
 			},
+			OnStopReason: func(reason string) {
+				upstreamStopReason = reason
+			},
 			OnComplete: func(inTok, outTok int) {
 				inputTokens = inTok
 				outputTokens = outTok
@@ -1984,8 +2010,11 @@ func (h *Handler) handleOpenAIStream(w http.ResponseWriter, payload *KiroPayload
 			},
 		}
 
-		err := CallKiroAPI(account, payload, callback)
+		err := CallKiroAPIContext(ctx, account, payload, callback)
 		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
 			lastErr = err
 			excluded[account.ID] = true
 			h.handleAccountFailure(account, err)
@@ -1993,6 +2022,7 @@ func (h *Handler) handleOpenAIStream(w http.ResponseWriter, payload *KiroPayload
 				continue
 			}
 			h.recordFailureWithDetails("openai", model, account.ID, err)
+			sendStreamError(err)
 			return
 		}
 
@@ -2024,11 +2054,7 @@ func (h *Handler) handleOpenAIStream(w http.ResponseWriter, payload *KiroPayload
 		h.pool.RecordSuccess(account.ID)
 		h.pool.UpdateStats(account.ID, inputTokens+outputTokens, credits)
 		h.recordSuccessLog("openai", model, account.ID, inputTokens+outputTokens, credits, time.Since(reqStart).Milliseconds())
-
-		finishReason := "stop"
-		if len(toolCalls) > 0 {
-			finishReason = "tool_calls"
-		}
+		finishReason := mapOpenAIFinishReason(upstreamStopReason, len(toolCalls))
 
 		chunk := map[string]interface{}{
 			"id":      chatID,
@@ -2063,7 +2089,7 @@ func (h *Handler) handleOpenAIStream(w http.ResponseWriter, payload *KiroPayload
 }
 
 // handleOpenAINonStream OpenAI 非流式响应
-func (h *Handler) handleOpenAINonStream(w http.ResponseWriter, payload *KiroPayload, model string, thinking bool, estimatedInputTokens int, apiKeyID string) {
+func (h *Handler) handleOpenAINonStream(ctx context.Context, w http.ResponseWriter, payload *KiroPayload, model string, thinking bool, estimatedInputTokens int, apiKeyID string) {
 	excluded := make(map[string]bool)
 	var lastErr error
 	reqStart := time.Now()
@@ -2086,6 +2112,7 @@ func (h *Handler) handleOpenAINonStream(w http.ResponseWriter, payload *KiroPayl
 		var inputTokens, outputTokens int
 		var credits float64
 		var realInputTokens int
+		var upstreamStopReason string
 
 		callback := &KiroStreamCallback{
 			OnText: func(text string, isThinking bool) {
@@ -2101,10 +2128,16 @@ func (h *Handler) handleOpenAINonStream(w http.ResponseWriter, payload *KiroPayl
 			OnContextUsage: func(pct float64) {
 				realInputTokens = int(pct * float64(getContextWindowSize(model)) / 100.0)
 			},
+			OnStopReason: func(reason string) {
+				upstreamStopReason = reason
+			},
 		}
 
-		err := CallKiroAPI(account, payload, callback)
+		err := CallKiroAPIContext(ctx, account, payload, callback)
 		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
 			lastErr = err
 			excluded[account.ID] = true
 			h.handleAccountFailure(account, err)
@@ -2131,7 +2164,7 @@ func (h *Handler) handleOpenAINonStream(w http.ResponseWriter, payload *KiroPayl
 		h.recordSuccessLog("openai", model, account.ID, inputTokens+outputTokens, credits, time.Since(reqStart).Milliseconds())
 
 		thinkingFormat := config.GetThinkingConfig().OpenAIFormat
-		resp := KiroToOpenAIResponseWithReasoning(finalContent, reasoningContent, toolUses, inputTokens, outputTokens, model, thinkingFormat)
+		resp := KiroToOpenAIResponseWithReasoning(finalContent, reasoningContent, toolUses, inputTokens, outputTokens, model, thinkingFormat, upstreamStopReason)
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		json.NewEncoder(w).Encode(resp)
 		return
@@ -4040,8 +4073,11 @@ func (h *Handler) apiTestAccount(w http.ResponseWriter, r *http.Request, id stri
 		OnContextUsage: func(pct float64) {},
 	}
 
-	err := CallKiroAPI(account, kiroPayload, callback)
+	err := CallKiroAPIContext(r.Context(), account, kiroPayload, callback)
 	if err != nil {
+		if r.Context().Err() != nil {
+			return
+		}
 		w.WriteHeader(500)
 		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 		return

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -1,6 +1,8 @@
 package proxy
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"kiro-go/config"
 	accountpool "kiro-go/pool"
@@ -98,7 +100,7 @@ func TestClaudeNonStreamRetriesNextAccountAfterPreResponseFailure(t *testing.T) 
 	}
 
 	rec := httptest.NewRecorder()
-	h.handleClaudeNonStream(rec, payload, "claude-sonnet-4.5", false, claudeThinkingResponseOptions{}, 1, nil, "")
+	h.handleClaudeNonStream(context.Background(), rec, payload, "claude-sonnet-4.5", false, claudeThinkingResponseOptions{}, 1, nil, "")
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected retry to succeed, status=%d body=%s", rec.Code, rec.Body.String())
@@ -120,6 +122,51 @@ func TestClaudeNonStreamRetriesNextAccountAfterPreResponseFailure(t *testing.T) 
 	}
 	if len(resp.Content) == 0 || resp.Content[0].Text != "retried successfully" {
 		t.Fatalf("expected retried response content, got %#v", resp.Content)
+	}
+}
+
+func TestOpenAIHandlerPropagatesClientCancellation(t *testing.T) {
+	cfgFile := t.TempDir() + "/config.json"
+	if err := config.Init(cfgFile); err != nil {
+		t.Fatalf("config.Init: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), "request-id", "client-cancel"))
+	defer cancel()
+	if err := config.AddAccount(config.Account{
+		ID: "cancel-test", Enabled: true, AuthMethod: "api_key", KiroApiKey: "ksk_test", ProxyURL: kiroRetryTestProxyURL,
+	}); err != nil {
+		t.Fatalf("add account: %v", err)
+	}
+
+	var calls int
+	oldClient, hadOldClient := proxyClientCache.Load(kiroRetryTestProxyURL)
+	proxyClientCache.Store(kiroRetryTestProxyURL, &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		if got := req.Context().Value("request-id"); got != "client-cancel" {
+			t.Fatalf("upstream request context value = %v, want client-cancel", got)
+		}
+		cancel()
+		return kiroStreamTestResponse(bytes.NewReader(nil)), nil
+	})})
+	t.Cleanup(func() {
+		if hadOldClient {
+			proxyClientCache.Store(kiroRetryTestProxyURL, oldClient)
+		} else {
+			proxyClientCache.Delete(kiroRetryTestProxyURL)
+		}
+	})
+
+	p := accountpool.GetPool()
+	p.Reload()
+	h := &Handler{pool: p, promptCache: newPromptCacheTracker(defaultPromptCacheTTL)}
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"claude-sonnet-4.5","messages":[{"role":"user","content":"hello"}]}`)).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	h.handleOpenAIChat(rec, req)
+	if calls != 1 {
+		t.Fatalf("upstream calls=%d, want 1 after cancellation", calls)
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("canceled request must not write a proxy response, got %s", rec.Body.String())
 	}
 }
 
@@ -478,5 +525,179 @@ func TestBuildAnthropicModelsResponseGeneratesThinkingVariants(t *testing.T) {
 	}
 	if supportsImage, ok := models[0]["supports_image"].(bool); !ok || !supportsImage {
 		t.Fatalf("expected image capability to be preserved, got %#v", models[0]["supports_image"])
+	}
+}
+
+func TestOpenAIStreamReportsPostOutputUpstreamFailure(t *testing.T) {
+	cfgFile := t.TempDir() + "/config.json"
+	if err := config.Init(cfgFile); err != nil {
+		t.Fatalf("config.Init: %v", err)
+	}
+	if err := config.AddAccount(config.Account{
+		ID:          "test-account",
+		Enabled:     true,
+		AccessToken: "token-test",
+		ProfileArn:  "arn:aws:codewhisperer:profile/test",
+	}); err != nil {
+		t.Fatalf("add account: %v", err)
+	}
+	if err := config.UpdatePreferredEndpoint("kiro"); err != nil {
+		t.Fatalf("set preferred endpoint: %v", err)
+	}
+	if err := config.UpdateEndpointFallback(false); err != nil {
+		t.Fatalf("disable endpoint fallback: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(awsEventStreamFrame(t, "assistantResponseEvent", map[string]interface{}{
+			"content": strings.Repeat("partial answer ", 8),
+		}))
+		_, _ = w.Write([]byte{0, 0, 1})
+	}))
+	defer server.Close()
+	defer swapKiroEndpointsForTest(t, server)()
+
+	p := accountpool.GetPool()
+	p.Reload()
+	h := &Handler{
+		pool:        p,
+		promptCache: newPromptCacheTracker(defaultPromptCacheTTL),
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{
+		"model":"claude-sonnet-4.5",
+		"messages":[{"role":"user","content":"hello"}],
+		"stream":true
+	}`))
+	rec := httptest.NewRecorder()
+	h.handleOpenAIChat(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected stream status 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "partial answer") {
+		t.Fatalf("expected partial content before failure, got %s", body)
+	}
+	if !strings.Contains(body, `"error"`) || !strings.Contains(body, `"message"`) {
+		t.Fatalf("expected an SSE error after partial content, got %s", body)
+	}
+	if strings.Contains(body, "[DONE]") {
+		t.Fatalf("a failed stream must not report completion, got %s", body)
+	}
+}
+
+func TestClaudeResponsePreservesUpstreamMaxTokensStopReason(t *testing.T) {
+	cfgFile := t.TempDir() + "/config.json"
+	if err := config.Init(cfgFile); err != nil {
+		t.Fatalf("config.Init: %v", err)
+	}
+	if err := config.AddAccount(config.Account{
+		ID:          "test-account",
+		Enabled:     true,
+		AccessToken: "token-test",
+		ProfileArn:  "arn:aws:codewhisperer:profile/test",
+	}); err != nil {
+		t.Fatalf("add account: %v", err)
+	}
+	if err := config.UpdatePreferredEndpoint("kiro"); err != nil {
+		t.Fatalf("set preferred endpoint: %v", err)
+	}
+	if err := config.UpdateEndpointFallback(false); err != nil {
+		t.Fatalf("disable endpoint fallback: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(awsEventStreamFrame(t, "assistantResponseEvent", map[string]interface{}{
+			"content": "partial answer",
+		}))
+		_, _ = w.Write(awsEventStreamFrame(t, "metadataEvent", map[string]interface{}{
+			"stopReason": "MAX_TOKENS",
+		}))
+	}))
+	defer server.Close()
+	defer swapKiroEndpointsForTest(t, server)()
+
+	p := accountpool.GetPool()
+	p.Reload()
+	h := &Handler{
+		pool:        p,
+		promptCache: newPromptCacheTracker(defaultPromptCacheTTL),
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{
+		"model":"claude-sonnet-4.5",
+		"max_tokens":100,
+		"messages":[{"role":"user","content":"hello"}]
+	}`))
+	rec := httptest.NewRecorder()
+	h.handleClaudeMessages(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var response ClaudeResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v body=%s", err, rec.Body.String())
+	}
+	if response.StopReason != "max_tokens" {
+		t.Fatalf("stop_reason=%q, want max_tokens", response.StopReason)
+	}
+}
+
+func TestOpenAIStreamPreservesUpstreamMaxTokensFinishReason(t *testing.T) {
+	cfgFile := t.TempDir() + "/config.json"
+	if err := config.Init(cfgFile); err != nil {
+		t.Fatalf("config.Init: %v", err)
+	}
+	if err := config.AddAccount(config.Account{
+		ID:          "test-account",
+		Enabled:     true,
+		AccessToken: "token-test",
+		ProfileArn:  "arn:aws:codewhisperer:profile/test",
+	}); err != nil {
+		t.Fatalf("add account: %v", err)
+	}
+	if err := config.UpdatePreferredEndpoint("kiro"); err != nil {
+		t.Fatalf("set preferred endpoint: %v", err)
+	}
+	if err := config.UpdateEndpointFallback(false); err != nil {
+		t.Fatalf("disable endpoint fallback: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(awsEventStreamFrame(t, "assistantResponseEvent", map[string]interface{}{
+			"content": "partial answer",
+		}))
+		_, _ = w.Write(awsEventStreamFrame(t, "metadataEvent", map[string]interface{}{
+			"stopReason": "MAX_TOKENS",
+		}))
+	}))
+	defer server.Close()
+	defer swapKiroEndpointsForTest(t, server)()
+
+	p := accountpool.GetPool()
+	p.Reload()
+	h := &Handler{
+		pool:        p,
+		promptCache: newPromptCacheTracker(defaultPromptCacheTTL),
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{
+		"model":"claude-sonnet-4.5",
+		"messages":[{"role":"user","content":"hello"}],
+		"stream":true
+	}`))
+	rec := httptest.NewRecorder()
+	h.handleOpenAIChat(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected stream status 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"finish_reason":"length"`) {
+		t.Fatalf("expected finish_reason=length, got %s", rec.Body.String())
 	}
 }

--- a/proxy/kiro.go
+++ b/proxy/kiro.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash/crc32"
 	"io"
 	"kiro-go/config"
 	"kiro-go/logger"
@@ -28,18 +29,17 @@ const (
 	// streamRetryBackoff spaces out a retry of a stream that died before
 	// delivering any output callback. Upstream drops cluster in time, so an
 	// immediate retry tends to hit the same blip.
-	streamRetryBackoff = 700 * time.Millisecond
-
-	// maxStreamAttemptsPerEndpoint includes the initial request. One retry
-	// covers the observed transient drops without multiplying the existing
-	// endpoint and account fallback budgets more than necessary.
+	streamRetryBackoff           = 700 * time.Millisecond
 	maxStreamAttemptsPerEndpoint = 2
+	maxEventStreamMessageSize    = 16 * 1024 * 1024
 )
 
 var (
 	errEmptyKiroStream         = errors.New("upstream stream ended before any output")
 	errIncompleteKiroToolInput = errors.New("upstream stream ended with incomplete tool input")
-	streamRetryWait            = time.Sleep
+	errInvalidKiroEventStream  = errors.New("invalid upstream event stream")
+	errKiroEventStreamUpstream = errors.New("upstream event stream error")
+	streamRetryWait            = waitForStreamRetry
 	resolveKiroEndpoints       = endpointsForAccount
 )
 
@@ -270,6 +270,7 @@ type KiroStreamCallback struct {
 	OnError        func(err error)
 	OnCredits      func(credits float64)
 	OnContextUsage func(percentage float64)
+	OnStopReason   func(reason string)
 }
 
 // ==================== API Call ====================
@@ -348,6 +349,14 @@ func getSortedEndpoints(preferred string) []kiroEndpoint {
 
 // CallKiroAPI calls the Kiro streaming API, trying each configured endpoint with automatic fallback.
 func CallKiroAPI(account *config.Account, payload *KiroPayload, callback *KiroStreamCallback) error {
+	return CallKiroAPIContext(context.Background(), account, payload, callback)
+}
+
+// CallKiroAPIContext calls Kiro while respecting cancellation from the client request.
+func CallKiroAPIContext(ctx context.Context, account *config.Account, payload *KiroPayload, callback *KiroStreamCallback) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	originalProfileArn := ""
 	if payload != nil {
 		originalProfileArn = payload.ProfileArn
@@ -403,6 +412,9 @@ endpointLoop:
 		// Target the profile's data-plane region; endpoint URLs are declared for us-east-1.
 		// API Key accounts use the CLI runtime host instead of IDE/Q hosts.
 		epURL := regionalizeURLForProfile(ep.URL, account, payload.ProfileArn)
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if isAPIKey {
 			epURL = cliRuntimeURL(account)
 		}
@@ -416,13 +428,15 @@ endpointLoop:
 		invocationID := uuid.New().String()
 
 		for streamAttempt := 1; streamAttempt <= maxStreamAttemptsPerEndpoint; streamAttempt++ {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
 			// Requests and bodies cannot be reused after an HTTP attempt.
-			req, err := http.NewRequest("POST", epURL, bytes.NewReader(reqBody))
+			req, err := http.NewRequestWithContext(ctx, "POST", epURL, bytes.NewReader(reqBody))
 			if err != nil {
 				lastErr = err
 				continue endpointLoop
 			}
-
 			if isAPIKey {
 				req.Header.Set("Content-Type", "application/x-amz-json-1.0")
 			} else {
@@ -481,6 +495,9 @@ endpointLoop:
 			}
 			lastErr = err
 			// "Emitted" deliberately means that an output callback ran. This
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
 			// conservative boundary also protects buffered/non-stream callers:
 			// retrying after their callback mutated state would concatenate two
 			// attempts even if no network bytes were flushed yet.
@@ -499,7 +516,9 @@ endpointLoop:
 
 			logger.Warnf("[KiroAPI] Endpoint %s stream failed before any output (attempt %d/%d): %v",
 				ep.Name, streamAttempt, maxStreamAttemptsPerEndpoint, err)
-			streamRetryWait(streamRetryBackoff)
+			if err := streamRetryWait(ctx, streamRetryBackoff); err != nil {
+				return err
+			}
 			if !hasSameEndpointRetry {
 				continue endpointLoop
 			}
@@ -527,6 +546,17 @@ func accountEmailForLog(account *config.Account) string {
 	return account.Email
 }
 
+func waitForStreamRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
 // ==================== Event Stream Parsing ====================
 
 // parseEventStream decodes an AWS binary Event Stream response body.
@@ -548,7 +578,7 @@ func parseEventStreamTracked(body io.Reader, callback *KiroStreamCallback) (emit
 	var totalCredits float64
 	var contextUsagePercentages []float64
 	var sawOutput bool
-	var currentToolUse *toolUseState
+	pending := &pendingToolUses{}
 	trackedCallback := *callback
 	originalOnToolUse := trackedCallback.OnToolUse
 	trackedCallback.OnToolUse = func(toolUse KiroToolUse) {
@@ -561,7 +591,7 @@ func parseEventStreamTracked(body io.Reader, callback *KiroStreamCallback) (emit
 	callback = &trackedCallback
 
 	for {
-		// Prelude: 12 bytes (total_len + headers_len + crc)
+		// Prelude: total length, headers length, and prelude CRC.
 		prelude := make([]byte, 12)
 		_, readErr := io.ReadFull(body, prelude)
 		if readErr == io.EOF {
@@ -571,54 +601,50 @@ func parseEventStreamTracked(body io.Reader, callback *KiroStreamCallback) (emit
 			return emitted, readErr
 		}
 
-		totalLength := int(prelude[0])<<24 | int(prelude[1])<<16 | int(prelude[2])<<8 | int(prelude[3])
-		headersLength := int(prelude[4])<<24 | int(prelude[5])<<16 | int(prelude[6])<<8 | int(prelude[7])
-
-		if totalLength < 16 {
-			continue
+		totalLength := int(eventStreamUint32(prelude[0:4]))
+		headersLength := int(eventStreamUint32(prelude[4:8]))
+		if totalLength < 16 || totalLength > maxEventStreamMessageSize {
+			return emitted, fmt.Errorf("%w: invalid frame length %d", errInvalidKiroEventStream, totalLength)
+		}
+		if headersLength > totalLength-16 {
+			return emitted, fmt.Errorf("%w: invalid headers length %d", errInvalidKiroEventStream, headersLength)
+		}
+		if got, want := eventStreamUint32(prelude[8:12]), crc32.ChecksumIEEE(prelude[:8]); got != want {
+			return emitted, fmt.Errorf("%w: prelude CRC mismatch", errInvalidKiroEventStream)
 		}
 
-		// Read the remaining message bytes.
-		remaining := totalLength - 12
-		msgBuf := make([]byte, remaining)
-		_, err = io.ReadFull(body, msgBuf)
-		if err != nil {
+		remaining := totalLength - len(prelude)
+		message := make([]byte, remaining)
+		if _, err := io.ReadFull(body, message); err != nil {
 			return emitted, err
 		}
-
-		if headersLength > len(msgBuf)-4 {
-			continue
+		if got, want := eventStreamUint32(message[len(message)-4:]), eventStreamChecksum(prelude, message[:len(message)-4]); got != want {
+			return emitted, fmt.Errorf("%w: message CRC mismatch", errInvalidKiroEventStream)
 		}
 
-		eventType := extractEventType(msgBuf[0:headersLength])
-		payloadBytes := msgBuf[headersLength : len(msgBuf)-4]
-		if len(payloadBytes) == 0 {
-			continue
+		headers, headerErr := parseEventStreamHeaders(message[:headersLength])
+		if headerErr != nil {
+			return emitted, fmt.Errorf("%w: %v", errInvalidKiroEventStream, headerErr)
+		}
+		payloadBytes := message[headersLength : len(message)-4]
+		event := make(map[string]interface{})
+		if len(payloadBytes) > 0 {
+			if err := json.Unmarshal(payloadBytes, &event); err != nil {
+				return emitted, fmt.Errorf("%w: decode payload: %v", errInvalidKiroEventStream, err)
+			}
 		}
 
-		var event map[string]interface{}
-		if err := json.Unmarshal(payloadBytes, &event); err != nil {
-			continue
+		if messageType := headers[":message-type"]; messageType == "error" || messageType == "exception" {
+			detail, _ := event["message"].(string)
+			if detail == "" {
+				detail = messageType
+			}
+			return emitted, fmt.Errorf("%w: %s", errKiroEventStreamUpstream, detail)
 		}
 
 		inputTokens, outputTokens = updateTokensFromEvent(event, inputTokens, outputTokens)
 
-		// Dispatch by event type.
-		switch eventType {
-		// Both text streams are passed through verbatim. Kiro sends
-		// assistantResponseEvent and reasoningContentEvent as pure incremental deltas
-		// (verified against real upstream traffic), never as cumulative snapshots, and
-		// never replays a chunk: ordering and at-most-once delivery are already
-		// guaranteed by TCP, and a dropped stream is retried as a whole new request
-		// rather than resumed.
-		//
-		// Do NOT reintroduce content-based de-duplication here. At the string level a
-		// replayed chunk is indistinguishable from text that simply repeats itself, and
-		// the wire protocol carries no sequence number or message id to tell them apart
-		// (the AWS event-stream base spec defines none), so such a heuristic can only
-		// guess -- and when it guesses wrong it silently eats real output. The previous
-		// implementation turned "6666666666" into "666", "abababab" into "abab" and
-		// "1833" into "183", on both streams.
+		switch headers[":event-type"] {
 		case "assistantResponseEvent":
 			if content, ok := event["content"].(string); ok && content != "" {
 				sawOutput = true
@@ -636,11 +662,9 @@ func parseEventStreamTracked(body io.Reader, callback *KiroStreamCallback) (emit
 				}
 			}
 		case "toolUseEvent":
-			nextToolUse, toolErr := handleToolUseEvent(event, currentToolUse, callback)
-			if toolErr != nil {
+			if toolErr := handleToolUseEvent(event, pending, callback); toolErr != nil {
 				return emitted, toolErr
 			}
-			currentToolUse = nextToolUse
 		case "meteringEvent":
 			if usage, ok := event["usage"].(float64); ok {
 				totalCredits += usage
@@ -649,29 +673,31 @@ func parseEventStreamTracked(body io.Reader, callback *KiroStreamCallback) (emit
 			if pct, ok := event["contextUsagePercentage"].(float64); ok {
 				contextUsagePercentages = append(contextUsagePercentages, pct)
 			}
+		case "metadataEvent":
+			// stopReason rides inside metadataEvent on the wire; there is no
+			// standalone stop reason event type. Its absence after content is
+			// how callers detect a truncated stream.
+			if reason := firstStringField(event, "stopReason", "stop_reason"); reason != "" && callback.OnStopReason != nil {
+				callback.OnStopReason(reason)
+			}
 		}
 	}
 
-	if currentToolUse != nil {
-		if err := finishToolUse(currentToolUse, callback); err != nil {
-			return emitted, err
-		}
+	// Flush tools that never received a stop frame, in arrival order.
+	if err := pending.flushAll(callback); err != nil {
+		return emitted, err
 	}
-
 	if !sawOutput {
 		return emitted, errEmptyKiroStream
 	}
-
 	if callback.OnCredits != nil && totalCredits > 0 {
 		callback.OnCredits(totalCredits)
 	}
-
 	if callback.OnContextUsage != nil {
 		for _, percentage := range contextUsagePercentages {
 			callback.OnContextUsage(percentage)
 		}
 	}
-
 	if callback.OnComplete != nil {
 		callback.OnComplete(inputTokens, outputTokens)
 	}
@@ -841,52 +867,156 @@ type toolUseState struct {
 	GeneratedID bool
 }
 
-func handleToolUseEvent(event map[string]interface{}, current *toolUseState, callback *KiroStreamCallback) (*toolUseState, error) {
+// pendingToolUses tracks the tool calls in flight for one stream. Entries are
+// keyed by toolUseId so interleaved parallel frames accumulate independently,
+// and `order` preserves arrival sequence: tool call order is semantic for
+// clients, so a bare map range (randomised in Go) must never decide it.
+type pendingToolUses struct {
+	byID   map[string]*toolUseState
+	order  []string
+	lastID string
+}
+
+func (p *pendingToolUses) get(id string) *toolUseState {
+	if p.byID == nil {
+		return nil
+	}
+	return p.byID[id]
+}
+
+func (p *pendingToolUses) add(state *toolUseState) {
+	if p.byID == nil {
+		p.byID = make(map[string]*toolUseState)
+	}
+	p.byID[state.ToolUseID] = state
+	p.order = append(p.order, state.ToolUseID)
+	p.lastID = state.ToolUseID
+}
+
+// rekey moves an entry from a locally generated id to the real id from
+// upstream, keeping its position in the arrival order.
+func (p *pendingToolUses) rekey(state *toolUseState, newID string) {
+	oldID := state.ToolUseID
+	delete(p.byID, oldID)
+	for i, id := range p.order {
+		if id == oldID {
+			p.order[i] = newID
+			break
+		}
+	}
+	state.ToolUseID = newID
+	state.GeneratedID = false
+	p.byID[newID] = state
+	if p.lastID == oldID {
+		p.lastID = newID
+	}
+}
+
+func (p *pendingToolUses) remove(id string) {
+	delete(p.byID, id)
+	for i, existing := range p.order {
+		if existing == id {
+			p.order = append(p.order[:i], p.order[i+1:]...)
+			break
+		}
+	}
+	if p.lastID == id {
+		p.lastID = ""
+	}
+}
+
+// flushAll emits every tool still open when the stream ended, in arrival order.
+// It stops at the first incomplete tool so the caller can retry the request
+// rather than deliver a call with missing arguments.
+func (p *pendingToolUses) flushAll(callback *KiroStreamCallback) error {
+	order := p.order
+	byID := p.byID
+	p.byID = nil
+	p.order = nil
+	p.lastID = ""
+	for _, id := range order {
+		state := byID[id]
+		if state == nil {
+			continue
+		}
+		if err := finishToolUse(state, callback); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// handleToolUseEvent accumulates one toolUseEvent frame into pending.
+// Frames for different toolUseIds stay open concurrently so interleaved
+// parallel tool calls reassemble correctly; a fragment that omits toolUseId
+// continues the most recently seen tool.
+func handleToolUseEvent(event map[string]interface{}, pending *pendingToolUses, callback *KiroStreamCallback) error {
 	toolUseID := firstStringField(event, "toolUseId", "toolUseID", "tool_use_id", "id")
 	name := firstStringField(event, "name", "toolName", "tool_name")
 	isStop := firstBoolField(event, "stop", "isStop", "done")
 
-	if toolUseID != "" && name != "" {
-		if current == nil {
-			current = &toolUseState{ToolUseID: toolUseID, Name: name}
-		} else if current.ToolUseID != toolUseID {
-			if current.GeneratedID && current.Name == name {
-				current.ToolUseID = toolUseID
-				current.GeneratedID = false
-			} else {
-				if err := finishToolUse(current, callback); err != nil {
-					return current, err
-				}
-				current = &toolUseState{ToolUseID: toolUseID, Name: name}
+	var state *toolUseState
+
+	switch {
+	case toolUseID != "":
+		state = pending.get(toolUseID)
+		if state == nil && pending.lastID != "" {
+			// Upstream may send the opening fragment without an id and only
+			// reveal the real one later. Adopt the synthetic entry we opened
+			// for it instead of splitting one logical call across two entries
+			// (which also splits its argument JSON, so neither half parses).
+			if prev := pending.get(pending.lastID); prev != nil && prev.GeneratedID && (name == "" || prev.Name == name) {
+				pending.rekey(prev, toolUseID)
+				state = prev
 			}
 		}
-	} else if name != "" && current == nil {
-		current = &toolUseState{ToolUseID: "toolu_" + uuid.New().String(), Name: name, GeneratedID: true}
-	} else if name != "" && current != nil && current.Name != name {
-		if err := finishToolUse(current, callback); err != nil {
-			return current, err
+		if state == nil {
+			if name == "" {
+				// Orphan fragment: an id never seen before and no name to open with.
+				return nil
+			}
+			state = &toolUseState{ToolUseID: toolUseID, Name: name}
+			pending.add(state)
+		} else {
+			if name != "" && state.Name == "" {
+				state.Name = name
+			}
+			pending.lastID = state.ToolUseID
 		}
-		current = &toolUseState{ToolUseID: "toolu_" + uuid.New().String(), Name: name, GeneratedID: true}
+	case pending.lastID != "" && pending.get(pending.lastID) != nil:
+		state = pending.get(pending.lastID)
+		if name != "" && state.Name != name {
+			// Name changed with no id: close the tool in flight rather than
+			// appending foreign arguments to it, then open a new one.
+			if err := finishToolUse(state, callback); err != nil {
+				return err
+			}
+			pending.remove(state.ToolUseID)
+			state = &toolUseState{ToolUseID: "toolu_" + uuid.New().String(), Name: name, GeneratedID: true}
+			pending.add(state)
+		}
+	case name != "":
+		state = &toolUseState{ToolUseID: "toolu_" + uuid.New().String(), Name: name, GeneratedID: true}
+		pending.add(state)
+	default:
+		return nil
 	}
 
-	if current != nil {
-		if input, ok := event["input"].(string); ok {
-			current.InputBuffer.WriteString(input)
-		} else if inputObj, ok := event["input"].(map[string]interface{}); ok {
-			data, _ := json.Marshal(inputObj)
-			current.InputBuffer.Reset()
-			current.InputBuffer.Write(data)
-		}
+	if input, ok := event["input"].(string); ok {
+		state.InputBuffer.WriteString(input)
+	} else if inputObj, ok := event["input"].(map[string]interface{}); ok {
+		data, _ := json.Marshal(inputObj)
+		state.InputBuffer.Reset()
+		state.InputBuffer.Write(data)
 	}
 
-	if isStop && current != nil {
-		if err := finishToolUse(current, callback); err != nil {
-			return current, err
+	if isStop {
+		if err := finishToolUse(state, callback); err != nil {
+			return err
 		}
-		return nil, nil
+		pending.remove(state.ToolUseID)
 	}
-
-	return current, nil
+	return nil
 }
 
 func finishToolUse(state *toolUseState, callback *KiroStreamCallback) error {
@@ -934,56 +1064,58 @@ func firstBoolField(m map[string]interface{}, keys ...string) bool {
 	return false
 }
 
-// extractEventType extracts the event type string from AWS Event Stream message headers.
-func extractEventType(headers []byte) string {
-	offset := 0
-	for offset < len(headers) {
-		if offset >= len(headers) {
-			break
-		}
-		nameLen := int(headers[offset])
+func eventStreamUint32(data []byte) uint32 {
+	return uint32(data[0])<<24 | uint32(data[1])<<16 | uint32(data[2])<<8 | uint32(data[3])
+}
+
+func eventStreamChecksum(prelude, message []byte) uint32 {
+	checksum := crc32.Update(0, crc32.IEEETable, prelude)
+	return crc32.Update(checksum, crc32.IEEETable, message)
+}
+
+func parseEventStreamHeaders(data []byte) (map[string]string, error) {
+	headers := make(map[string]string)
+	for offset := 0; offset < len(data); {
+		nameLength := int(data[offset])
 		offset++
-		if offset+nameLen > len(headers) {
-			break
+		if nameLength == 0 || offset+nameLength >= len(data) {
+			return nil, errors.New("malformed event header name")
 		}
-		name := string(headers[offset : offset+nameLen])
-		offset += nameLen
-		if offset >= len(headers) {
-			break
-		}
-		valueType := headers[offset]
+		name := string(data[offset : offset+nameLength])
+		offset += nameLength
+		valueType := data[offset]
 		offset++
 
-		if valueType == 7 { // String
-			if offset+2 > len(headers) {
-				break
-			}
-			valueLen := int(headers[offset])<<8 | int(headers[offset+1])
-			offset += 2
-			if offset+valueLen > len(headers) {
-				break
-			}
-			value := string(headers[offset : offset+valueLen])
-			offset += valueLen
-			if name == ":event-type" {
-				return value
-			}
+		valueLength := 0
+		switch valueType {
+		case 0, 1:
 			continue
-		}
-
-		// Skip other value types by their fixed byte widths.
-		skipSizes := map[byte]int{0: 0, 1: 0, 2: 1, 3: 2, 4: 4, 5: 8, 8: 8, 9: 16}
-		if valueType == 6 {
-			if offset+2 > len(headers) {
-				break
+		case 2:
+			valueLength = 1
+		case 3:
+			valueLength = 2
+		case 4:
+			valueLength = 4
+		case 5, 8:
+			valueLength = 8
+		case 9:
+			valueLength = 16
+		case 6, 7:
+			if offset+2 > len(data) {
+				return nil, errors.New("malformed variable event header")
 			}
-			l := int(headers[offset])<<8 | int(headers[offset+1])
-			offset += 2 + l
-		} else if skip, ok := skipSizes[valueType]; ok {
-			offset += skip
-		} else {
-			break
+			valueLength = int(data[offset])<<8 | int(data[offset+1])
+			offset += 2
+		default:
+			return nil, fmt.Errorf("unsupported event header type %d", valueType)
 		}
+		if offset+valueLength > len(data) {
+			return nil, errors.New("truncated event header value")
+		}
+		if valueType == 7 {
+			headers[name] = string(data[offset : offset+valueLength])
+		}
+		offset += valueLength
 	}
-	return ""
+	return headers, nil
 }

--- a/proxy/kiro_test.go
+++ b/proxy/kiro_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"errors"
+	"hash/crc32"
 	"io"
 	"kiro-go/config"
 	"net/http"
@@ -50,6 +51,49 @@ func TestParseEventStreamAssistantRepeatedContentIsNotDropped(t *testing.T) {
 			}
 			if got != tc.want {
 				t.Fatalf("assistant text corrupted: got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseEventStreamTrackedRejectsInvalidOrUpstreamErrorFrames(t *testing.T) {
+	validText := awsEventStreamFrame(t, "assistantResponseEvent", map[string]interface{}{
+		"content": "partial answer",
+	})
+	corruptFrame := append([]byte(nil), awsEventStreamFrame(t, "assistantResponseEvent", map[string]interface{}{
+		"content": "corrupt",
+	})...)
+	corruptFrame[len(corruptFrame)-5] ^= 1
+
+	upstreamError := awsEventStreamFrameWithHeaders(t, map[string]string{
+		":message-type": "exception",
+		":event-type":   "error",
+	}, map[string]interface{}{
+		"message": "upstream denied request",
+	})
+
+	for _, tc := range []struct {
+		name   string
+		stream []byte
+	}{
+		{name: "message CRC mismatch", stream: append(validText, corruptFrame...)},
+		{name: "upstream exception", stream: append(validText, upstreamError...)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var text string
+			var completed int
+			emitted, err := parseEventStreamTracked(bytes.NewReader(tc.stream), &KiroStreamCallback{
+				OnText:     func(chunk string, _ bool) { text += chunk },
+				OnComplete: func(int, int) { completed++ },
+			})
+			if err == nil {
+				t.Fatal("expected invalid upstream frame to fail parsing")
+			}
+			if !emitted || text != "partial answer" {
+				t.Fatalf("expected the first text frame to have been emitted, emitted=%v text=%q", emitted, text)
+			}
+			if completed != 0 {
+				t.Fatalf("failed stream must not complete, got %d completion callbacks", completed)
 			}
 		})
 	}
@@ -143,13 +187,46 @@ func TestParseEventStreamNilCallbackFieldsAreNoOp(t *testing.T) {
 	}
 }
 
+func TestParseEventStreamPreservesInterleavedToolInputs(t *testing.T) {
+	var stream bytes.Buffer
+	for _, event := range []map[string]interface{}{
+		{"toolUseId": "toolu_a", "name": "lookup", "input": `{"query":"a`},
+		{"toolUseId": "toolu_b", "name": "lookup", "input": `{"query":"b`},
+		{"toolUseId": "toolu_a", "name": "lookup", "input": `1"}`, "stop": true},
+		{"toolUseId": "toolu_b", "name": "lookup", "input": `2"}`, "stop": true},
+	} {
+		stream.Write(awsEventStreamFrame(t, "toolUseEvent", event))
+	}
+
+	var toolUses []KiroToolUse
+	err := parseEventStream(bytes.NewReader(stream.Bytes()), &KiroStreamCallback{
+		OnToolUse: func(toolUse KiroToolUse) {
+			toolUses = append(toolUses, toolUse)
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if len(toolUses) != 2 {
+		t.Fatalf("tool uses=%d, want 2 (%#v)", len(toolUses), toolUses)
+	}
+	got := map[string]string{}
+	for _, toolUse := range toolUses {
+		got[toolUse.ToolUseID], _ = toolUse.Input["query"].(string)
+	}
+	if got["toolu_a"] != "a1" || got["toolu_b"] != "b2" {
+		t.Fatalf("interleaved inputs=%#v, want toolu_a=a1 and toolu_b=b2", got)
+	}
+}
+
 func TestHandleToolUseEventGeneratesMissingToolUseID(t *testing.T) {
 	var toolUses []KiroToolUse
-	current, err := handleToolUseEvent(map[string]interface{}{
+	pending := &pendingToolUses{}
+	err := handleToolUseEvent(map[string]interface{}{
 		"name":  "mcpIdaProMcpStatus",
 		"input": `{"server":"ida-pro-mcp"}`,
 		"stop":  true,
-	}, nil, &KiroStreamCallback{
+	}, pending, &KiroStreamCallback{
 		OnToolUse: func(toolUse KiroToolUse) {
 			toolUses = append(toolUses, toolUse)
 		},
@@ -158,8 +235,8 @@ func TestHandleToolUseEventGeneratesMissingToolUseID(t *testing.T) {
 		t.Fatalf("unexpected tool use error: %v", err)
 	}
 
-	if current != nil {
-		t.Fatalf("expected stopped tool use to clear current state")
+	if len(pending.order) != 0 {
+		t.Fatalf("expected stopped tool use to clear pending state, got %d", len(pending.order))
 	}
 	if len(toolUses) != 1 {
 		t.Fatalf("expected one tool use, got %d", len(toolUses))
@@ -179,26 +256,25 @@ func TestHandleToolUseEventReplacesGeneratedIDWhenRealIDArrives(t *testing.T) {
 			toolUses = append(toolUses, toolUse)
 		},
 	}
+	pending := &pendingToolUses{}
 
-	current, err := handleToolUseEvent(map[string]interface{}{
+	if err := handleToolUseEvent(map[string]interface{}{
 		"name":  "mcpIdaProMcpStatus",
 		"input": `{"server":`,
-	}, nil, callback)
-	if err != nil {
+	}, pending, callback); err != nil {
 		t.Fatalf("unexpected first tool fragment error: %v", err)
 	}
-	current, err = handleToolUseEvent(map[string]interface{}{
+	if err := handleToolUseEvent(map[string]interface{}{
 		"toolUseId": "toolu_real",
 		"name":      "mcpIdaProMcpStatus",
 		"input":     `"ida-pro-mcp"}`,
 		"stop":      true,
-	}, current, callback)
-	if err != nil {
+	}, pending, callback); err != nil {
 		t.Fatalf("unexpected completed tool error: %v", err)
 	}
 
-	if current != nil {
-		t.Fatalf("expected stopped tool use to clear current state")
+	if len(pending.order) != 0 {
+		t.Fatalf("expected stopped tool use to clear pending state, got %d", len(pending.order))
 	}
 	if len(toolUses) != 1 {
 		t.Fatalf("expected one completed tool use, got %d", len(toolUses))
@@ -316,27 +392,37 @@ func assertProxyURL(t *testing.T, got *url.URL, want string) {
 
 func awsEventStreamFrame(t *testing.T, eventType string, payload map[string]interface{}) []byte {
 	t.Helper()
+	return awsEventStreamFrameWithHeaders(t, map[string]string{
+		":event-type": eventType,
+	}, payload)
+}
+
+func awsEventStreamFrameWithHeaders(t *testing.T, headers map[string]string, payload map[string]interface{}) []byte {
+	t.Helper()
 
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
 		t.Fatalf("marshal payload: %v", err)
 	}
 
-	headerValue := []byte(eventType)
-	headers := make([]byte, 0, 1+len(":event-type")+1+2+len(headerValue))
-	headers = append(headers, byte(len(":event-type")))
-	headers = append(headers, []byte(":event-type")...)
-	headers = append(headers, byte(7))
-	headers = append(headers, byte(len(headerValue)>>8), byte(len(headerValue)))
-	headers = append(headers, headerValue...)
+	headerBytes := make([]byte, 0)
+	for name, value := range headers {
+		headerBytes = append(headerBytes, byte(len(name)))
+		headerBytes = append(headerBytes, name...)
+		headerBytes = append(headerBytes, byte(7))
+		headerBytes = append(headerBytes, byte(len(value)>>8), byte(len(value)))
+		headerBytes = append(headerBytes, value...)
+	}
 
-	totalLength := 12 + len(headers) + len(payloadBytes) + 4
+	totalLength := 12 + len(headerBytes) + len(payloadBytes) + 4
 	frame := make([]byte, 12, totalLength)
 	binary.BigEndian.PutUint32(frame[0:4], uint32(totalLength))
-	binary.BigEndian.PutUint32(frame[4:8], uint32(len(headers)))
-	frame = append(frame, headers...)
+	binary.BigEndian.PutUint32(frame[4:8], uint32(len(headerBytes)))
+	binary.BigEndian.PutUint32(frame[8:12], crc32.ChecksumIEEE(frame[:8]))
+	frame = append(frame, headerBytes...)
 	frame = append(frame, payloadBytes...)
 	frame = append(frame, 0, 0, 0, 0)
+	binary.BigEndian.PutUint32(frame[len(frame)-4:], crc32.ChecksumIEEE(frame[:len(frame)-4]))
 	return frame
 }
 
@@ -735,6 +821,32 @@ func TestCallKiroAPIDoesNotFallbackAfterTimedOutTransport(t *testing.T) {
 	}
 }
 
+func TestCallKiroAPIContextStopsRetryWhenClientCancels(t *testing.T) {
+	type requestContextKey struct{}
+	baseContext := context.WithValue(context.Background(), requestContextKey{}, "client-request")
+	ctx, cancel := context.WithCancel(baseContext)
+	defer cancel()
+
+	var calls, waits int
+	installKiroStreamTestClient(t, roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		if got := req.Context().Value(requestContextKey{}); got != "client-request" {
+			t.Fatalf("upstream request context value = %v, want client-request", got)
+		}
+		cancel()
+		return kiroStreamTestResponse(bytes.NewReader(nil)), nil
+	}))
+	installKiroRetryWait(t, func(time.Duration) { waits++ })
+
+	err := CallKiroAPIContext(ctx, newKiroRetryTestAPIKeyAccount(""), newKiroRetryTestPayload(), &KiroStreamCallback{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation, got %v", err)
+	}
+	if calls != 1 || waits != 0 {
+		t.Fatalf("calls=%d waits=%d, want no retry or wait after client cancellation", calls, waits)
+	}
+}
+
 func installKiroRetryTestEndpoints(t *testing.T) {
 	t.Helper()
 	oldResolver := resolveKiroEndpoints
@@ -763,7 +875,10 @@ func installKiroStreamTestClient(t *testing.T, transport http.RoundTripper) {
 func installKiroRetryWait(t *testing.T, wait func(time.Duration)) {
 	t.Helper()
 	oldWait := streamRetryWait
-	streamRetryWait = wait
+	streamRetryWait = func(_ context.Context, delay time.Duration) error {
+		wait(delay)
+		return nil
+	}
 	t.Cleanup(func() { streamRetryWait = oldWait })
 }
 

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -114,17 +115,17 @@ func (h *Handler) handleOpenAIResponses(w http.ResponseWriter, r *http.Request) 
 	respID := generateResponseID()
 
 	if req.Stream {
-		h.handleResponsesStream(w, kiroPayload, actualModel, thinking, estimatedInputTokens,
+		h.handleResponsesStream(r.Context(), w, kiroPayload, actualModel, thinking, estimatedInputTokens,
 			apiKeyID, respID, &req, storedInputCopy, storeResponse)
 		return
 	}
 
-	h.handleResponsesNonStream(w, kiroPayload, actualModel, thinking, estimatedInputTokens,
+	h.handleResponsesNonStream(r.Context(), w, kiroPayload, actualModel, thinking, estimatedInputTokens,
 		apiKeyID, respID, &req, storedInputCopy, storeResponse)
 }
 
 func (h *Handler) handleResponsesNonStream(
-	w http.ResponseWriter, payload *KiroPayload, model string, thinking bool,
+	ctx context.Context, w http.ResponseWriter, payload *KiroPayload, model string, thinking bool,
 	estimatedInputTokens int, apiKeyID, respID string,
 	req *ResponsesRequest, storedInput json.RawMessage, storeResponse bool,
 ) {
@@ -149,6 +150,7 @@ func (h *Handler) handleResponsesNonStream(
 		var inputTokens, outputTokens int
 		var credits float64
 		var realInputTokens int
+		var upstreamStopReason string
 
 		callback := &KiroStreamCallback{
 			OnText: func(text string, isThinking bool) {
@@ -164,10 +166,16 @@ func (h *Handler) handleResponsesNonStream(
 			OnContextUsage: func(pct float64) {
 				realInputTokens = int(pct * float64(getContextWindowSize(model)) / 100.0)
 			},
+			OnStopReason: func(reason string) {
+				upstreamStopReason = reason
+			},
 		}
 
-		err := CallKiroAPI(account, payload, callback)
+		err := CallKiroAPIContext(ctx, account, payload, callback)
 		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
 			lastErr = err
 			excluded[account.ID] = true
 			h.handleAccountFailure(account, err)
@@ -191,7 +199,7 @@ func (h *Handler) handleResponsesNonStream(
 		h.pool.UpdateStats(account.ID, inputTokens+outputTokens, credits)
 		h.recordSuccessLog("responses", model, account.ID, inputTokens+outputTokens, credits, time.Since(reqStart).Milliseconds())
 
-		respObj := buildResponsesObject(respID, model, finalContent, toolUses, inputTokens, outputTokens, req)
+		respObj := buildResponsesObject(respID, model, finalContent, toolUses, inputTokens, outputTokens, req, upstreamStopReason)
 		respObj.StoredInput = storedInput
 		respObj.Instructions = req.Instructions
 
@@ -214,9 +222,20 @@ func (h *Handler) handleResponsesNonStream(
 	h.sendOpenAIError(w, 500, "server_error", lastErr.Error())
 }
 
+func mapResponsesCompletion(reason string) (status, incompleteReason string) {
+	switch strings.ToLower(strings.TrimSpace(reason)) {
+	case "max_tokens", "max_output_tokens", "length", "model_context_window_exceeded", "context_window_exceeded":
+		return "incomplete", "max_output_tokens"
+	case "refusal", "content_filter", "content_filtered", "guardrail_intervened":
+		return "incomplete", "content_filter"
+	default:
+		return "completed", ""
+	}
+}
+
 func buildResponsesObject(
 	id, model, content string, toolUses []KiroToolUse,
-	inputTokens, outputTokens int, req *ResponsesRequest,
+	inputTokens, outputTokens int, req *ResponsesRequest, upstreamStopReason string,
 ) *ResponsesObject {
 	output := make([]ResponseOutputItem, 0, 1+len(toolUses))
 
@@ -258,21 +277,28 @@ func buildResponsesObject(
 		})
 	}
 
+	status, incompleteReason := mapResponsesCompletion(upstreamStopReason)
+	var incompleteDetails *ResponsesIncompleteDetails
+	if incompleteReason != "" {
+		incompleteDetails = &ResponsesIncompleteDetails{Reason: incompleteReason}
+	}
+
 	return &ResponsesObject{
 		ID:                 id,
 		Object:             "response",
 		CreatedAt:          time.Now().Unix(),
-		Status:             "completed",
+		Status:             status,
 		Model:              model,
 		Output:             output,
 		Usage:              ResponsesUsage{InputTokens: inputTokens, OutputTokens: outputTokens, TotalTokens: inputTokens + outputTokens},
 		PreviousResponseID: req.PreviousResponseID,
 		Metadata:           req.Metadata,
+		IncompleteDetails:  incompleteDetails,
 	}
 }
 
 func (h *Handler) handleResponsesStream(
-	w http.ResponseWriter, payload *KiroPayload, model string, thinking bool,
+	ctx context.Context, w http.ResponseWriter, payload *KiroPayload, model string, thinking bool,
 	estimatedInputTokens int, apiKeyID, respID string,
 	req *ResponsesRequest, storedInput json.RawMessage, storeResponse bool,
 ) {
@@ -335,13 +361,14 @@ func (h *Handler) handleResponsesStream(
 		})
 
 		var (
-			fullText        strings.Builder
-			reasoningText   strings.Builder
-			toolUses        []KiroToolUse
-			inputTokens     int
-			outputTokens    int
-			credits         float64
-			realInputTokens int
+			fullText           strings.Builder
+			reasoningText      strings.Builder
+			toolUses           []KiroToolUse
+			inputTokens        int
+			outputTokens       int
+			credits            float64
+			realInputTokens    int
+			upstreamStopReason string
 		)
 
 		messageItemID := generateOutputItemID("msg")
@@ -468,10 +495,16 @@ func (h *Handler) handleResponsesStream(
 			OnContextUsage: func(pct float64) {
 				realInputTokens = int(pct * float64(getContextWindowSize(model)) / 100.0)
 			},
+			OnStopReason: func(reason string) {
+				upstreamStopReason = reason
+			},
 		}
 
-		err := CallKiroAPI(account, payload, callback)
+		err := CallKiroAPIContext(ctx, account, payload, callback)
 		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
 			if !responseStarted {
 				lastErr = err
 				excluded[account.ID] = true
@@ -538,7 +571,7 @@ func (h *Handler) handleResponsesStream(
 		h.pool.UpdateStats(account.ID, inputTokens+outputTokens, credits)
 		h.recordSuccessLog("responses", model, account.ID, inputTokens+outputTokens, credits, time.Since(reqStart).Milliseconds())
 
-		respObj := buildResponsesObject(respID, model, finalContent, toolUses, inputTokens, outputTokens, req)
+		respObj := buildResponsesObject(respID, model, finalContent, toolUses, inputTokens, outputTokens, req, upstreamStopReason)
 		respObj.CreatedAt = createdAt
 		respObj.StoredInput = storedInput
 		respObj.Instructions = req.Instructions

--- a/proxy/responses_handler_test.go
+++ b/proxy/responses_handler_test.go
@@ -105,6 +105,75 @@ func TestResponsesStoreAndLoad(t *testing.T) {
 	}
 }
 
+func TestResponsesNonStreamPreservesUpstreamIncompleteStatus(t *testing.T) {
+	h, cleanup := setupResponsesTestHandler(t)
+	defer cleanup()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(awsEventStreamFrame(t, "assistantResponseEvent", map[string]interface{}{
+			"content": "partial answer",
+		}))
+		_, _ = w.Write(awsEventStreamFrame(t, "metadataEvent", map[string]interface{}{
+			"stopReason": "MAX_TOKENS",
+		}))
+	}))
+	defer server.Close()
+	defer swapKiroEndpointsForTest(t, server)()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"claude-sonnet-4.5",
+		"input":"hello"
+	}`))
+	rec := httptest.NewRecorder()
+	h.handleOpenAIResponses(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var response ResponsesObject
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v body=%s", err, rec.Body.String())
+	}
+	if response.Status != "incomplete" {
+		t.Fatalf("status=%q, want incomplete", response.Status)
+	}
+	if response.IncompleteDetails == nil || response.IncompleteDetails.Reason != "max_output_tokens" {
+		t.Fatalf("incomplete_details=%#v, want max_output_tokens", response.IncompleteDetails)
+	}
+}
+
+func TestMapResponsesCompletion(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		reason string
+		status string
+		detail string
+	}{
+		{name: "max tokens", reason: "MAX_TOKENS", status: "incomplete", detail: "max_output_tokens"},
+		{name: "max output tokens alias", reason: "max_output_tokens", status: "incomplete", detail: "max_output_tokens"},
+		{name: "length alias", reason: "length", status: "incomplete", detail: "max_output_tokens"},
+		{name: "context limit", reason: "CONTEXT_WINDOW_EXCEEDED", status: "incomplete", detail: "max_output_tokens"},
+		{name: "model context limit alias", reason: "model_context_window_exceeded", status: "incomplete", detail: "max_output_tokens"},
+		{name: "content filter", reason: "CONTENT_FILTERED", status: "incomplete", detail: "content_filter"},
+		{name: "refusal alias", reason: "refusal", status: "incomplete", detail: "content_filter"},
+		{name: "guardrail alias", reason: "guardrail_intervened", status: "incomplete", detail: "content_filter"},
+		// END_TURN is the literal the Kiro IDE bundle compares against.
+		{name: "end turn", reason: "END_TURN", status: "completed"},
+		// Absent metadataEvent: reported as completed here on purpose. Detecting
+		// that as truncation is the stream integrity layer's job, not this map's.
+		{name: "empty reports completed", reason: "", status: "completed"},
+		{name: "normal completion", reason: "COMPLETE", status: "completed"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			status, detail := mapResponsesCompletion(tc.reason)
+			if status != tc.status || detail != tc.detail {
+				t.Fatalf("mapResponsesCompletion(%q) = (%q, %q), want (%q, %q)", tc.reason, status, detail, tc.status, tc.detail)
+			}
+		})
+	}
+}
+
 func TestResponsesPreviousResponseIDExpands(t *testing.T) {
 	prev := &ResponsesObject{
 		ID:          "resp_prev",
@@ -353,6 +422,39 @@ func TestResponsesNonStreamRoundTrip(t *testing.T) {
 	}
 	if loaded.ID != resp.ID {
 		t.Fatalf("stored response id mismatch")
+	}
+}
+
+func TestResponsesStreamPreservesUpstreamIncompleteStatus(t *testing.T) {
+	h, cleanup := setupResponsesTestHandler(t)
+	defer cleanup()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(awsEventStreamFrame(t, "assistantResponseEvent", map[string]interface{}{
+			"content": "partial answer",
+		}))
+		_, _ = w.Write(awsEventStreamFrame(t, "metadataEvent", map[string]interface{}{
+			"stopReason": "MAX_TOKENS",
+		}))
+	}))
+	defer server.Close()
+	defer swapKiroEndpointsForTest(t, server)()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+		"model":"claude-sonnet-4.5",
+		"input":"hello",
+		"stream":true,
+		"store":false
+	}`))
+	rec := httptest.NewRecorder()
+	h.handleOpenAIResponses(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"status":"incomplete"`) || !strings.Contains(rec.Body.String(), `"reason":"max_output_tokens"`) {
+		t.Fatalf("expected incomplete response.completed event, got %s", rec.Body.String())
 	}
 }
 

--- a/proxy/responses_types.go
+++ b/proxy/responses_types.go
@@ -17,20 +17,21 @@ type ResponsesRequest struct {
 }
 
 type ResponsesObject struct {
-	ID                 string               `json:"id"`
-	Object             string               `json:"object"`
-	CreatedAt          int64                `json:"created_at"`
-	Status             string               `json:"status"`
-	Model              string               `json:"model"`
-	Output             []ResponseOutputItem `json:"output"`
-	Usage              ResponsesUsage       `json:"usage"`
-	PreviousResponseID string               `json:"previous_response_id,omitempty"`
-	Metadata           map[string]string    `json:"metadata,omitempty"`
-	Error              *ResponsesError      `json:"error,omitempty"`
-	Instructions       string               `json:"instructions,omitempty"`
-	StoredInput        json.RawMessage      `json:"-"`
-	StoredInstr        string               `json:"-"`
-	StoredAt           int64                `json:"stored_at,omitempty"`
+	ID                 string                      `json:"id"`
+	Object             string                      `json:"object"`
+	CreatedAt          int64                       `json:"created_at"`
+	Status             string                      `json:"status"`
+	Model              string                      `json:"model"`
+	Output             []ResponseOutputItem        `json:"output"`
+	Usage              ResponsesUsage              `json:"usage"`
+	PreviousResponseID string                      `json:"previous_response_id,omitempty"`
+	Metadata           map[string]string           `json:"metadata,omitempty"`
+	Error              *ResponsesError             `json:"error,omitempty"`
+	IncompleteDetails  *ResponsesIncompleteDetails `json:"incomplete_details,omitempty"`
+	Instructions       string                      `json:"instructions,omitempty"`
+	StoredInput        json.RawMessage             `json:"-"`
+	StoredInstr        string                      `json:"-"`
+	StoredAt           int64                       `json:"stored_at,omitempty"`
 }
 
 type ResponseOutputItem struct {
@@ -59,4 +60,8 @@ type ResponsesError struct {
 	Type    string `json:"type"`
 	Code    string `json:"code,omitempty"`
 	Message string `json:"message"`
+}
+
+type ResponsesIncompleteDetails struct {
+	Reason string `json:"reason"`
 }

--- a/proxy/tool_use_order_test.go
+++ b/proxy/tool_use_order_test.go
@@ -1,0 +1,214 @@
+package proxy
+
+// Regression coverage for the tool-use state machine in parseEventStream.
+// Tool call identity and order are semantic for clients: a duplicated emit
+// makes the client run a write or shell tool twice, and a reordered emit
+// changes which result is matched to which call.
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+// A tool that opens with both id and name, then continues with fragments that
+// carry only input and no id, must accumulate into the same entry. This is the
+// shape the upstream actually sends for a long argument list, and it used to be
+// lost: an id-keyed frame and an id-less frame were dispatched to two separate
+// state machines, so the continuation fragments landed nowhere and the call
+// failed with an incomplete-input error mid-turn.
+func TestParseEventStreamIDFirstThenIDLessContinuationAccumulates(t *testing.T) {
+	var stream bytes.Buffer
+	for _, event := range []map[string]interface{}{
+		{"toolUseId": "toolu_1", "name": "lookup", "input": `{"query":"a`},
+		{"input": `b`},
+		{"input": `c"}`, "stop": true},
+	} {
+		stream.Write(awsEventStreamFrame(t, "toolUseEvent", event))
+	}
+
+	var toolUses []KiroToolUse
+	err := parseEventStream(bytes.NewReader(stream.Bytes()), &KiroStreamCallback{
+		OnToolUse: func(toolUse KiroToolUse) { toolUses = append(toolUses, toolUse) },
+	})
+	if err != nil {
+		t.Fatalf("id-less continuation fragments must not be dropped: %v", err)
+	}
+	if len(toolUses) != 1 {
+		t.Fatalf("tool uses=%d, want exactly 1: %#v", len(toolUses), toolUses)
+	}
+	if toolUses[0].ToolUseID != "toolu_1" || toolUses[0].Name != "lookup" {
+		t.Fatalf("id=%q name=%q, want toolu_1/lookup", toolUses[0].ToolUseID, toolUses[0].Name)
+	}
+	if got := toolUses[0].Input["query"]; got != "abc" {
+		t.Fatalf("input=%#v, want the three fragments joined into \"abc\"", toolUses[0].Input)
+	}
+}
+
+// A fragment that arrives without toolUseId opens a synthetic entry. When the
+// real id shows up on a later fragment of the same tool, it must adopt that
+// entry instead of opening a second one, otherwise the same logical tool call
+// is emitted twice: once under the generated id and once under the real id.
+func TestParseEventStreamRekeysGeneratedToolIDInsteadOfSplitting(t *testing.T) {
+	var stream bytes.Buffer
+	for _, event := range []map[string]interface{}{
+		{"name": "lookup", "input": `{"query":`},
+		{"toolUseId": "toolu_real", "name": "lookup", "input": `"kiro"}`, "stop": true},
+	} {
+		stream.Write(awsEventStreamFrame(t, "toolUseEvent", event))
+	}
+
+	var toolUses []KiroToolUse
+	err := parseEventStream(bytes.NewReader(stream.Bytes()), &KiroStreamCallback{
+		OnToolUse: func(toolUse KiroToolUse) { toolUses = append(toolUses, toolUse) },
+	})
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if len(toolUses) != 1 {
+		t.Fatalf("tool uses=%d, want exactly 1: %#v", len(toolUses), toolUses)
+	}
+	if toolUses[0].ToolUseID != "toolu_real" {
+		t.Fatalf("tool use id=%q, want the real upstream id", toolUses[0].ToolUseID)
+	}
+	if got := toolUses[0].Input["query"]; got != "kiro" {
+		t.Fatalf("input=%#v, want the joined fragments", toolUses[0].Input)
+	}
+}
+
+// Rekeying must keep the entry's position in arrival order: a tool that opened
+// first still has to be emitted first once its real id replaces the generated
+// one.
+func TestParseEventStreamRekeyKeepsArrivalPosition(t *testing.T) {
+	var stream bytes.Buffer
+	for _, event := range []map[string]interface{}{
+		{"name": "first_tool", "input": `{"k":`},
+		{"toolUseId": "toolu_first", "name": "first_tool", "input": `1}`},
+		{"toolUseId": "toolu_second", "name": "second_tool", "input": `{"k":2}`},
+	} {
+		stream.Write(awsEventStreamFrame(t, "toolUseEvent", event))
+	}
+
+	var order []string
+	err := parseEventStream(bytes.NewReader(stream.Bytes()), &KiroStreamCallback{
+		OnToolUse: func(toolUse KiroToolUse) { order = append(order, toolUse.ToolUseID) },
+	})
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if len(order) != 2 || order[0] != "toolu_first" || order[1] != "toolu_second" {
+		t.Fatalf("emit order=%v, want [toolu_first toolu_second]", order)
+	}
+}
+
+// Tools left open at EOF must be flushed in arrival order, including one that
+// started life without an id. The id-less opener is the part that regressed:
+// pre-fix it lived in a separate single-slot path that was always flushed
+// before the id-keyed map, so it could not stay behind a tool that arrived
+// later. Run repeatedly because a map-iteration flush can match by luck.
+func TestParseEventStreamFlushesPendingToolsInArrivalOrder(t *testing.T) {
+	for iteration := 0; iteration < 20; iteration++ {
+		var stream bytes.Buffer
+		// First tool opens without an id and only later learns it, so it must
+		// hold position 0 against three tools that arrive with ids up front.
+		stream.Write(awsEventStreamFrame(t, "toolUseEvent", map[string]interface{}{
+			"name": "lookup_0", "input": `{"query":`,
+		}))
+		stream.Write(awsEventStreamFrame(t, "toolUseEvent", map[string]interface{}{
+			"toolUseId": "toolu_0", "name": "lookup_0", "input": `0}`,
+		}))
+		want := []string{"toolu_0"}
+		for i := 1; i < 4; i++ {
+			id := fmt.Sprintf("toolu_%d", i)
+			want = append(want, id)
+			stream.Write(awsEventStreamFrame(t, "toolUseEvent", map[string]interface{}{
+				"toolUseId": id,
+				"name":      fmt.Sprintf("lookup_%d", i),
+				"input":     fmt.Sprintf(`{"query":%d}`, i),
+			}))
+		}
+
+		var order []string
+		err := parseEventStream(bytes.NewReader(stream.Bytes()), &KiroStreamCallback{
+			OnToolUse: func(toolUse KiroToolUse) { order = append(order, toolUse.ToolUseID) },
+		})
+		if err != nil {
+			t.Fatalf("iteration %d: unexpected parse error: %v", iteration, err)
+		}
+		if len(order) != len(want) {
+			t.Fatalf("iteration %d: emitted %d tools (%v), want %d", iteration, len(order), order, len(want))
+		}
+		for i := range want {
+			if order[i] != want[i] {
+				t.Fatalf("iteration %d: emit order=%v, want %v", iteration, order, want)
+			}
+		}
+	}
+}
+
+// An id-less fragment that switches tool name closes the tool in flight rather
+// than appending foreign arguments to it. The interleaved case is what
+// regressed: once a tool has been opened by an id-bearing frame, a following
+// id-less fragment for a different name must not be folded into it.
+func TestParseEventStreamIDLessNameChangeOpensNewTool(t *testing.T) {
+	var stream bytes.Buffer
+	for _, event := range []map[string]interface{}{
+		{"toolUseId": "toolu_first", "name": "first_tool", "input": `{"a":1}`},
+		{"name": "second_tool", "input": `{"b":2}`},
+	} {
+		stream.Write(awsEventStreamFrame(t, "toolUseEvent", event))
+	}
+
+	var toolUses []KiroToolUse
+	err := parseEventStream(bytes.NewReader(stream.Bytes()), &KiroStreamCallback{
+		OnToolUse: func(toolUse KiroToolUse) { toolUses = append(toolUses, toolUse) },
+	})
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if len(toolUses) != 2 {
+		t.Fatalf("tool uses=%d, want 2: %#v", len(toolUses), toolUses)
+	}
+	if toolUses[0].Name != "first_tool" || toolUses[1].Name != "second_tool" {
+		t.Fatalf("names=[%q %q], want [first_tool second_tool]", toolUses[0].Name, toolUses[1].Name)
+	}
+	if toolUses[0].ToolUseID != "toolu_first" {
+		t.Fatalf("first tool id=%q, want toolu_first", toolUses[0].ToolUseID)
+	}
+	if got := toolUses[0].Input["a"]; got != float64(1) {
+		t.Fatalf("first tool input=%#v, want {\"a\":1}", toolUses[0].Input)
+	}
+	if got := toolUses[1].Input["b"]; got != float64(2) {
+		t.Fatalf("second tool input=%#v, want {\"b\":2}", toolUses[1].Input)
+	}
+	if _, leaked := toolUses[0].Input["b"]; leaked {
+		t.Fatalf("second tool args leaked into the first: %#v", toolUses[0].Input)
+	}
+}
+
+// stopReason rides inside metadataEvent. Upstream has been seen using both the
+// camelCase and snake_case spellings, and missing it means a truncated stream
+// is reported to the client as a normal end_turn.
+func TestParseEventStreamReadsStopReasonKeyVariants(t *testing.T) {
+	for _, key := range []string{"stopReason", "stop_reason"} {
+		t.Run(key, func(t *testing.T) {
+			var stream bytes.Buffer
+			stream.Write(awsEventStreamFrame(t, "assistantResponseEvent",
+				map[string]interface{}{"content": "done"}))
+			stream.Write(awsEventStreamFrame(t, "metadataEvent",
+				map[string]interface{}{key: "end_turn"}))
+
+			var reason string
+			err := parseEventStream(bytes.NewReader(stream.Bytes()), &KiroStreamCallback{
+				OnText:       func(string, bool) {},
+				OnStopReason: func(r string) { reason = r },
+			})
+			if err != nil {
+				t.Fatalf("unexpected parse error: %v", err)
+			}
+			if reason != "end_turn" {
+				t.Fatalf("stop reason=%q, want end_turn", reason)
+			}
+		})
+	}
+}

--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -275,31 +275,30 @@ func ClaudeToKiro(req *ClaudeRequest, thinking bool) *KiroPayload {
 		history = append(priming, history...)
 	}
 
-	// Decide whether the current tool results form a valid "active" tool turn:
-	// the last history assistant must carry matching structured toolUses. If not
-	// (orphaned tool results, e.g. after context compaction), flatten them into
-	// the current message text so the upstream does not reject the request.
+	// Keep structured tool results only while they answer the final assistant
+	// tool turn. Older tool cycles are flattened by sanitizeKiroHistory because
+	// Kiro rejects structured tool calls and results in history.
 	currentToolResultIDs := collectToolResultIDs(currentToolResults)
 	keepCurrentToolResults := currentToolResultsMatchLastAssistant(history, currentToolResultIDs)
 
-	// Flatten structured tool calls/results that live in history; upstream only
-	// accepts a single active tool turn (last assistant toolUses ⟺ current toolResults).
 	if keepCurrentToolResults {
 		history = sanitizeKiroHistory(history, currentToolResultIDs)
 	} else {
 		history = sanitizeKiroHistory(history, nil)
 	}
 
-	// 构建最终内容
-	finalContent := ""
-	if currentContent != "" {
-		finalContent = currentContent
-	} else if len(currentImages) > 0 {
-		finalContent = normalizeUserContent("", true)
-	} else if len(currentToolResults) > 0 {
-		finalContent = buildToolResultsContinuation(currentToolResults)
-	} else {
-		finalContent = minimalFallbackUserContent
+	// 构建最终内容。工具结果既保留结构化配对，也携带可读文本；
+	// 同一消息带有图片时，图片占位文本不能覆盖工具结果内容。
+	finalContent := currentContent
+	if len(currentToolResults) > 0 {
+		finalContent = joinHistoryText(finalContent, buildToolResultsContinuation(currentToolResults))
+	}
+	if finalContent == "" {
+		if len(currentImages) > 0 {
+			finalContent = normalizeUserContent("", true)
+		} else {
+			finalContent = minimalFallbackUserContent
+		}
 	}
 
 	// 转换工具
@@ -995,7 +994,28 @@ func shortenToolName(name string) string {
 
 // ==================== Kiro -> Claude 转换 ====================
 
-func KiroToClaudeResponse(content, thinkingContent string, includeEmptyThinkingBlock bool, toolUses []KiroToolUse, inputTokens, outputTokens int, model string) *ClaudeResponse {
+func mapClaudeStopReason(reason string, toolCount int) string {
+	if toolCount > 0 {
+		return "tool_use"
+	}
+
+	switch strings.ToLower(strings.TrimSpace(reason)) {
+	case "max_tokens", "max_output_tokens", "length":
+		return "max_tokens"
+	case "model_context_window_exceeded", "context_window_exceeded":
+		return "model_context_window_exceeded"
+	case "refusal", "content_filter", "content_filtered", "guardrail_intervened":
+		return "refusal"
+	case "stop_sequence":
+		return "stop_sequence"
+	case "pause_turn":
+		return "pause_turn"
+	default:
+		return "end_turn"
+	}
+}
+
+func KiroToClaudeResponse(content, thinkingContent string, includeEmptyThinkingBlock bool, toolUses []KiroToolUse, inputTokens, outputTokens int, model, upstreamStopReason string) *ClaudeResponse {
 	blocks := make([]ClaudeContentBlock, 0)
 
 	if thinkingContent != "" || includeEmptyThinkingBlock {
@@ -1021,10 +1041,7 @@ func KiroToClaudeResponse(content, thinkingContent string, includeEmptyThinkingB
 		})
 	}
 
-	stopReason := "end_turn"
-	if len(toolUses) > 0 {
-		stopReason = "tool_use"
-	}
+	stopReason := mapClaudeStopReason(upstreamStopReason, len(toolUses))
 
 	return &ClaudeResponse{
 		ID:         "msg_" + uuid.New().String(),
@@ -1037,6 +1054,21 @@ func KiroToClaudeResponse(content, thinkingContent string, includeEmptyThinkingB
 			InputTokens:  inputTokens,
 			OutputTokens: outputTokens,
 		},
+	}
+}
+
+func mapOpenAIFinishReason(reason string, toolCount int) string {
+	if toolCount > 0 {
+		return "tool_calls"
+	}
+
+	switch strings.ToLower(strings.TrimSpace(reason)) {
+	case "max_tokens", "max_output_tokens", "length", "model_context_window_exceeded", "context_window_exceeded":
+		return "length"
+	case "refusal", "content_filter", "content_filtered", "guardrail_intervened":
+		return "content_filter"
+	default:
+		return "stop"
 	}
 }
 
@@ -1285,8 +1317,9 @@ func OpenAIToKiro(req *OpenAIRequest, thinking bool) *KiroPayload {
 		history = append(priming, history...)
 	}
 
-	// Decide whether current tool results form a valid active tool turn; if not,
-	// flatten them into the current message text (see ClaudeToKiro for rationale).
+	// Keep structured tool results only while they answer the final assistant
+	// tool turn. Older tool cycles are flattened by sanitizeKiroHistory because
+	// Kiro rejects structured tool calls and results in history.
 	currentToolResultIDs := collectToolResultIDs(currentToolResults)
 	keepCurrentToolResults := currentToolResultsMatchLastAssistant(history, currentToolResultIDs)
 
@@ -1295,14 +1328,15 @@ func OpenAIToKiro(req *OpenAIRequest, thinking bool) *KiroPayload {
 	} else {
 		history = sanitizeKiroHistory(history, nil)
 	}
-
-	// 构建最终内容
+	// 构建最终内容。工具结果既保留结构化配对，也携带可读文本；
+	// 同一消息带有图片时，图片占位文本不能覆盖工具结果内容。
 	finalContent := currentContent
+	if len(currentToolResults) > 0 {
+		finalContent = joinHistoryText(finalContent, buildToolResultsContinuation(currentToolResults))
+	}
 	if finalContent == "" {
 		if len(currentImages) > 0 {
 			finalContent = normalizeUserContent("", true)
-		} else if len(currentToolResults) > 0 {
-			finalContent = buildToolResultsContinuation(currentToolResults)
 		} else {
 			finalContent = minimalFallbackUserContent
 		}
@@ -1453,17 +1487,22 @@ func collectToolResultIDs(toolResults []KiroToolResult) map[string]bool {
 
 // currentToolResultsMatchLastAssistant reports whether the current message's
 // tool results answer the structured tool calls of the final history assistant
-// message. Only in that case may the current toolResults stay structured.
+// message.
 func currentToolResultsMatchLastAssistant(history []KiroHistoryMessage, currentToolResultIDs map[string]bool) bool {
-	if len(currentToolResultIDs) == 0 || len(history) == 0 {
+	if len(history) == 0 {
 		return false
 	}
 	last := history[len(history)-1]
-	if last.AssistantResponseMessage == nil || len(last.AssistantResponseMessage.ToolUses) == 0 {
+	return last.AssistantResponseMessage != nil &&
+		toolResultsAnswerToolUses(last.AssistantResponseMessage.ToolUses, currentToolResultIDs)
+}
+
+func toolResultsAnswerToolUses(toolUses []KiroToolUse, toolResultIDs map[string]bool) bool {
+	if len(toolUses) == 0 || len(toolResultIDs) == 0 {
 		return false
 	}
-	for _, tu := range last.AssistantResponseMessage.ToolUses {
-		if !currentToolResultIDs[tu.ToolUseID] {
+	for _, tu := range toolUses {
+		if !toolResultIDs[tu.ToolUseID] {
 			return false
 		}
 	}
@@ -2157,8 +2196,8 @@ func extractThinkingFromContent(content string) (string, string) {
 }
 
 // KiroToOpenAIResponseWithReasoning 带 reasoning_content 的 OpenAI 响应
-func KiroToOpenAIResponseWithReasoning(content, reasoningContent string, toolUses []KiroToolUse, inputTokens, outputTokens int, model, thinkingFormat string) map[string]interface{} {
-	finishReason := "stop"
+func KiroToOpenAIResponseWithReasoning(content, reasoningContent string, toolUses []KiroToolUse, inputTokens, outputTokens int, model, thinkingFormat, upstreamStopReason string) map[string]interface{} {
+	finishReason := mapOpenAIFinishReason(upstreamStopReason, len(toolUses))
 
 	message := map[string]interface{}{
 		"role": "assistant",
@@ -2179,7 +2218,6 @@ func KiroToOpenAIResponseWithReasoning(content, reasoningContent string, toolUse
 			}
 		}
 		message["tool_calls"] = toolCalls
-		finishReason = "tool_calls"
 	} else {
 		// 根据配置格式化 thinking 输出
 		if reasoningContent != "" {

--- a/proxy/translator_test.go
+++ b/proxy/translator_test.go
@@ -268,7 +268,7 @@ func TestClaudeToKiroDropsLeadingAssistantHistory(t *testing.T) {
 }
 
 func TestKiroToClaudeResponseCanEmitEmptyThinkingBlock(t *testing.T) {
-	resp := KiroToClaudeResponse("final answer", "", true, nil, 10, 20, "claude-sonnet-4.6")
+	resp := KiroToClaudeResponse("final answer", "", true, nil, 10, 20, "claude-sonnet-4.6", "")
 
 	if len(resp.Content) != 2 {
 		t.Fatalf("expected empty thinking block plus text block, got %d blocks", len(resp.Content))
@@ -281,6 +281,71 @@ func TestKiroToClaudeResponseCanEmitEmptyThinkingBlock(t *testing.T) {
 	}
 	if resp.Content[1].Type != "text" || resp.Content[1].Text != "final answer" {
 		t.Fatalf("expected text block to be preserved, got %#v", resp.Content[1])
+	}
+}
+
+func TestMapClaudeStopReason(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		reason    string
+		toolCount int
+		want      string
+	}{
+		{name: "max tokens", reason: "MAX_TOKENS", want: "max_tokens"},
+		{name: "max output tokens alias", reason: "max_output_tokens", want: "max_tokens"},
+		{name: "length alias", reason: "length", want: "max_tokens"},
+		{name: "context limit", reason: "CONTEXT_WINDOW_EXCEEDED", want: "model_context_window_exceeded"},
+		{name: "model context limit alias", reason: "model_context_window_exceeded", want: "model_context_window_exceeded"},
+		{name: "content filter", reason: "CONTENT_FILTERED", want: "refusal"},
+		{name: "refusal alias", reason: "refusal", want: "refusal"},
+		{name: "guardrail alias", reason: "guardrail_intervened", want: "refusal"},
+		{name: "stop sequence", reason: "STOP_SEQUENCE", want: "stop_sequence"},
+		{name: "pause", reason: "PAUSE_TURN", want: "pause_turn"},
+		// END_TURN is the only stopReason literal the Kiro IDE bundle compares
+		// against, so it is the realistic "finished normally" input.
+		{name: "end turn", reason: "END_TURN", want: "end_turn"},
+		// Absent metadataEvent leaves the reason empty. Mapping it to end_turn is
+		// the deliberate fallback for clients that require a terminal reason; the
+		// truncation itself is caught by the stream integrity layer, not here.
+		{name: "empty falls back to end turn", reason: "", want: "end_turn"},
+		{name: "unknown defaults to end turn", reason: "COMPLETE", want: "end_turn"},
+		{name: "tool use takes priority", reason: "MAX_TOKENS", toolCount: 1, want: "tool_use"},
+		{name: "tool use wins over empty reason", reason: "", toolCount: 2, want: "tool_use"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := mapClaudeStopReason(tc.reason, tc.toolCount); got != tc.want {
+				t.Fatalf("mapClaudeStopReason(%q, %d) = %q, want %q", tc.reason, tc.toolCount, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMapOpenAIFinishReason(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		reason    string
+		toolCount int
+		want      string
+	}{
+		{name: "max tokens", reason: "MAX_TOKENS", want: "length"},
+		{name: "max output tokens alias", reason: "max_output_tokens", want: "length"},
+		{name: "length alias", reason: "length", want: "length"},
+		{name: "context limit", reason: "CONTEXT_WINDOW_EXCEEDED", want: "length"},
+		{name: "model context limit alias", reason: "model_context_window_exceeded", want: "length"},
+		{name: "content filter", reason: "CONTENT_FILTERED", want: "content_filter"},
+		{name: "refusal alias", reason: "refusal", want: "content_filter"},
+		{name: "guardrail alias", reason: "guardrail_intervened", want: "content_filter"},
+		{name: "end turn", reason: "END_TURN", want: "stop"},
+		{name: "empty falls back to stop", reason: "", want: "stop"},
+		{name: "unknown defaults to stop", reason: "COMPLETE", want: "stop"},
+		{name: "tool calls take priority", reason: "MAX_TOKENS", toolCount: 1, want: "tool_calls"},
+		{name: "tool calls win over empty reason", reason: "", toolCount: 2, want: "tool_calls"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := mapOpenAIFinishReason(tc.reason, tc.toolCount); got != tc.want {
+				t.Fatalf("mapOpenAIFinishReason(%q, %d) = %q, want %q", tc.reason, tc.toolCount, got, tc.want)
+			}
+		})
 	}
 }
 
@@ -309,6 +374,17 @@ func TestToolResultsContinuationIncludesInstructionPrefix(t *testing.T) {
 	}
 	if !strings.Contains(content, "result-1") {
 		t.Fatalf("expected tool result text in continuation content, got %q", content)
+	}
+}
+
+func TestKiroToOpenAIResponseWithReasoningPreservesFinishReason(t *testing.T) {
+	response := KiroToOpenAIResponseWithReasoning("partial answer", "", nil, 10, 20, "claude-sonnet-4.5", "reasoning_content", "MAX_TOKENS")
+	choices, ok := response["choices"].([]map[string]interface{})
+	if !ok || len(choices) != 1 {
+		t.Fatalf("unexpected choices: %#v", response["choices"])
+	}
+	if got := choices[0]["finish_reason"]; got != "length" {
+		t.Fatalf("finish_reason=%#v, want length", got)
 	}
 }
 
@@ -554,12 +630,14 @@ func TestClaudeToolResultMixedTextAndImage(t *testing.T) {
 	if len(cur.Images) != 1 {
 		t.Fatalf("expected one image extracted, got %d", len(cur.Images))
 	}
-	if cur.UserInputMessageContext == nil || len(cur.UserInputMessageContext.ToolResults) != 1 {
-		t.Fatalf("expected one tool result")
+	if cur.UserInputMessageContext != nil && len(cur.UserInputMessageContext.ToolResults) != 0 {
+		t.Fatalf("orphan tool result must be flattened, got %#v", cur.UserInputMessageContext.ToolResults)
 	}
-	gotText := cur.UserInputMessageContext.ToolResults[0].Content[0].Text
-	if gotText != "here is the screenshot" {
-		t.Fatalf("expected original tool text preserved, got %q", gotText)
+	if !strings.Contains(cur.Content, toolResultsContinuationPrefix) {
+		t.Fatalf("expected tool result continuation, got %q", cur.Content)
+	}
+	if !strings.Contains(cur.Content, "here is the screenshot") {
+		t.Fatalf("expected original tool text preserved, got %q", cur.Content)
 	}
 }
 
@@ -624,15 +702,21 @@ func TestOpenAIToolResultImageCarriedWhenFollowedByUser(t *testing.T) {
 
 	payload := OpenAIToKiro(req, false)
 
-	var toolHistImages int
+	var toolHistImages, structuredToolResults int
 	for _, h := range payload.ConversationState.History {
-		if h.UserInputMessage != nil && h.UserInputMessage.UserInputMessageContext != nil &&
-			len(h.UserInputMessage.UserInputMessageContext.ToolResults) > 0 {
-			toolHistImages += len(h.UserInputMessage.Images)
+		if h.UserInputMessage == nil {
+			continue
+		}
+		toolHistImages += len(h.UserInputMessage.Images)
+		if context := h.UserInputMessage.UserInputMessageContext; context != nil {
+			structuredToolResults += len(context.ToolResults)
 		}
 	}
 	if toolHistImages != 1 {
-		t.Fatalf("expected tool image carried on the flushed tool-result history entry, got %d", toolHistImages)
+		t.Fatalf("expected tool image carried in history, got %d", toolHistImages)
+	}
+	if structuredToolResults != 0 {
+		t.Fatalf("history must not retain structured tool results, got %d", structuredToolResults)
 	}
 
 	cur := payload.ConversationState.CurrentMessage.UserInputMessage

--- a/proxy/websearch_loop.go
+++ b/proxy/websearch_loop.go
@@ -10,6 +10,7 @@
 package proxy
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"kiro-go/config"
@@ -33,7 +34,7 @@ type webSearchRoundOutcome struct {
 }
 
 // runWebSearchLoop is the mixed-tools entry point.
-func (h *Handler) runWebSearchLoop(w http.ResponseWriter, req *ClaudeRequest, thinking bool, estimatedInputTokens int, apiKeyID string) {
+func (h *Handler) runWebSearchLoop(ctx context.Context, w http.ResponseWriter, req *ClaudeRequest, thinking bool, estimatedInputTokens int, apiKeyID string) {
 	// Working copy of messages we will mutate as we feed search results back.
 	working := *req
 	working.Messages = append([]ClaudeMessage(nil), req.Messages...)
@@ -50,7 +51,10 @@ func (h *Handler) runWebSearchLoop(w http.ResponseWriter, req *ClaudeRequest, th
 	// Allow one extra iteration so a terminal flush can run after the last
 	// search-only round (same pattern as 0..=MAX_WEB_SEARCH_ROUNDS in kiro-rs).
 	for roundIdx := 0; roundIdx <= maxUses; roundIdx++ {
-		round, account, err := h.callUpstreamForWebSearch(&working, thinking, fallbackInput)
+		if ctx.Err() != nil {
+			return
+		}
+		round, account, err := h.callUpstreamForWebSearch(ctx, &working, thinking, fallbackInput)
 		if err != nil {
 			logger.Warnf("[WebSearchLoop] upstream round %d failed: %v", roundIdx, err)
 			accountID := ""
@@ -141,7 +145,7 @@ func (h *Handler) runWebSearchLoop(w http.ResponseWriter, req *ClaudeRequest, th
 }
 
 // callUpstreamForWebSearch converts the Claude request and buffers one Kiro stream.
-func (h *Handler) callUpstreamForWebSearch(req *ClaudeRequest, thinking bool, estimatedInputTokens int) (*webSearchRoundOutcome, *config.Account, error) {
+func (h *Handler) callUpstreamForWebSearch(ctx context.Context, req *ClaudeRequest, thinking bool, estimatedInputTokens int) (*webSearchRoundOutcome, *config.Account, error) {
 	payload := ClaudeToKiro(req, thinking)
 	excluded := make(map[string]bool)
 	var lastErr error
@@ -195,8 +199,11 @@ func (h *Handler) callUpstreamForWebSearch(req *ClaudeRequest, thinking bool, es
 			},
 		}
 
-		err := CallKiroAPI(account, payload, callback)
+		err := CallKiroAPIContext(ctx, account, payload, callback)
 		if err != nil {
+			if ctx.Err() != nil {
+				return nil, account, ctx.Err()
+			}
 			lastErr = err
 			excluded[account.ID] = true
 			h.handleAccountFailure(account, err)


### PR DESCRIPTION
## 摘要

修复代理把上游流「读错」的问题。线上表现是思考完整，但到该调工具或进入下一步时就停了，有时行有时不行。

根因在代理这边：

1. **stopReason 被丢掉。** 上游把 `stopReason` 放在 `metadataEvent` 里（官方 IDE 解包源码 `kiro.kiro-agent/dist/extension.js` 只从 `metadataEvent.stopReason` 读取，没有独立的 stop-reason 帧）。代理解析了这个事件却忽略了字段，六条路径各自硬编码终止原因，所以 `MAX_TOKENS`、内容过滤、上下文窗口溢出全部被当成正常结束。
2. **客户端取消被忽略。** `CallKiroAPI` 用的是 `context.Background()`，客户端 abort 后上游流和账号槽位还在跑。
3. **工具调用被拆成两次。** 带 `toolUseId` 的帧和不带的帧走两条并行路径。首个片段无 ID、真实 ID 后到时，同一个工具被拆成两次发射，参数 JSON 各自不完整；反过来，首帧带 ID、续帧无 ID 的长参数也会被静默丢弃。这两种都会让整轮工具调用失败。

## 改动

- 从 `metadataEvent` 读取 `stopReason` / `stop_reason`，按协议映射到 Claude / OpenAI / Responses。
- 新增 `CallKiroAPIContext`，六条路径都穿 `r.Context()`。
- 用统一的 `pendingToolUses` 状态机替换双路径：按 `toolUseId` 索引，显式 order 切片保序，`rekey` 把生成 ID 换成真实 ID 且保持位置。
- event-stream 帧做 CRC 与长度校验，不再信任上游帧格式。
- 半截工具参数报错，不以空 input 发射。

## 来源

官方 Kiro IDE 解包源码：

```
kiro-ide-unpack/app/extensions/kiro.kiro-agent/dist/extension.js
```

一手核实过：`metadataEvent` 是 stopReason 的唯一来源（`stopReasonEvent` 在 bundle 里 0 命中）；`END_TURN` 是 IDE 唯一硬编码比较的字面量。

## 测试

- 新增「首帧带 ID + 续帧无 ID」回归测试：在旧代码上真红，在本 PR 上绿。
- 三张映射表补了空 stopReason 与 `END_TURN`，以及所有别名。
- `gofmt` / `go vet` / `go build` / `go test ./... -count=1` 全绿。

## 说明

本 PR 只负责「把上游流正确读出来」。「判断读出来的流完不完整」见后续 PR（完整性重试），它依赖本 PR 修好的 `OnStopReason` 信号。