### PR TITLE
fix: Codex additional_tools parsing + full spawn_agent/Multi-Agent V2 support

### DIFF
--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -276,6 +276,21 @@ func customToolNameSet(tools []OpenAITool) map[string]bool {
 	return set
 }
 
+// toolNamespaceMap maps a tool's name back to the Responses API "namespace"
+// group it was flattened out of (see decodeResponsesTool). Codex's own
+// FunctionCall wire format carries this as a sibling "namespace" field
+// alongside the bare "name" -- a response missing it doesn't match Codex's
+// internal ToolName{name, namespace} registration for that tool.
+func toolNamespaceMap(tools []OpenAITool) map[string]string {
+	m := make(map[string]string, len(tools))
+	for _, t := range tools {
+		if t.Namespace != "" {
+			m[t.Function.Name] = t.Namespace
+		}
+	}
+	return m
+}
+
 // customToolCallInput extracts the raw string argument Kiro returned for a
 // custom tool call, per the single "input" field declared in
 // customToolInputSchema.
@@ -292,6 +307,7 @@ func buildResponsesObject(
 ) *ResponsesObject {
 	output := make([]ResponseOutputItem, 0, 1+len(toolUses))
 	customTools := customToolNameSet(req.Tools)
+	namespaces := toolNamespaceMap(req.Tools)
 
 	if strings.TrimSpace(content) != "" {
 		output = append(output, ResponseOutputItem{
@@ -325,6 +341,7 @@ func buildResponsesObject(
 			Status:    "completed",
 			CallID:    tu.ToolUseID,
 			Name:      tu.Name,
+			Namespace: namespaces[tu.Name],
 			Arguments: string(args),
 		})
 	}
@@ -408,6 +425,7 @@ func (h *Handler) handleResponsesStream(
 	responseStarted := false
 	reqStart := time.Now()
 	streamCustomTools := customToolNameSet(req.Tools)
+	streamToolNamespaces := toolNamespaceMap(req.Tools)
 
 	for attempt := 0; attempt < maxAccountRetryAttempts; attempt++ {
 		account := h.pool.GetNextForModelExcluding(model, excluded)
@@ -521,7 +539,6 @@ func (h *Handler) handleResponsesStream(
 				}
 
 				toolUses = append(toolUses, tu)
-
 				if streamCustomTools[tu.Name] {
 					input := customToolCallInput(tu.Input)
 					ctcID := generateOutputItemID("ctc")
@@ -568,17 +585,30 @@ func (h *Handler) handleResponsesStream(
 
 				args, _ := json.Marshal(tu.Input)
 				fcID := generateOutputItemID("fc")
+				addedItem := map[string]interface{}{
+					"id":        fcID,
+					"type":      "function_call",
+					"status":    "in_progress",
+					"call_id":   tu.ToolUseID,
+					"name":      tu.Name,
+					"arguments": "",
+				}
+				doneItem := map[string]interface{}{
+					"id":        fcID,
+					"type":      "function_call",
+					"status":    "completed",
+					"call_id":   tu.ToolUseID,
+					"name":      tu.Name,
+					"arguments": string(args),
+				}
+				if ns := streamToolNamespaces[tu.Name]; ns != "" {
+					addedItem["namespace"] = ns
+					doneItem["namespace"] = ns
+				}
 				send("response.output_item.added", map[string]interface{}{
 					"type":         "response.output_item.added",
 					"output_index": outputIndex,
-					"item": map[string]interface{}{
-						"id":        fcID,
-						"type":      "function_call",
-						"status":    "in_progress",
-						"call_id":   tu.ToolUseID,
-						"name":      tu.Name,
-						"arguments": "",
-					},
+					"item":         addedItem,
 				})
 				send("response.function_call_arguments.delta", map[string]interface{}{
 					"type":         "response.function_call_arguments.delta",
@@ -589,14 +619,7 @@ func (h *Handler) handleResponsesStream(
 				send("response.output_item.done", map[string]interface{}{
 					"type":         "response.output_item.done",
 					"output_index": outputIndex,
-					"item": map[string]interface{}{
-						"id":        fcID,
-						"type":      "function_call",
-						"status":    "completed",
-						"call_id":   tu.ToolUseID,
-						"name":      tu.Name,
-						"arguments": string(args),
-					},
+					"item":         doneItem,
 				})
 				outputIndex++
 				responseStarted = true

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -31,6 +31,15 @@ func (h *Handler) handleOpenAIResponses(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Newer Codex clients stop sending the top-level "tools" field and embed
+	// every tool declaration -- including Codex's own built-in "exec"
+	// custom tool that fronts shell/file/git access -- as an
+	// "additional_tools" item inside "input" instead. Merge those in so the
+	// model actually receives them.
+	if extra := extractResponsesTools(req.Input); len(extra) > 0 {
+		req.Tools = append(req.Tools, extra...)
+	}
+
 	if strings.TrimSpace(req.Model) == "" {
 		req.Model = defaultResponsesModel
 	}
@@ -253,11 +262,36 @@ func mapResponsesCompletion(reason string) (status, incompleteReason string) {
 	}
 }
 
+// customToolNameSet returns the set of tool names declared with
+// type "custom" (e.g. Codex's freeform "exec" tool), so tool_use results for
+// them can be re-encoded as custom_tool_call output items instead of
+// function_call ones.
+func customToolNameSet(tools []OpenAITool) map[string]bool {
+	set := make(map[string]bool, len(tools))
+	for _, t := range tools {
+		if t.Type == "custom" {
+			set[t.Function.Name] = true
+		}
+	}
+	return set
+}
+
+// customToolCallInput extracts the raw string argument Kiro returned for a
+// custom tool call, per the single "input" field declared in
+// customToolInputSchema.
+func customToolCallInput(input map[string]interface{}) string {
+	if s, ok := input["input"].(string); ok {
+		return s
+	}
+	return ""
+}
+
 func buildResponsesObject(
 	id, model, content string, toolUses []KiroToolUse,
 	inputTokens, outputTokens int, req *ResponsesRequest, upstreamStopReason string,
 ) *ResponsesObject {
 	output := make([]ResponseOutputItem, 0, 1+len(toolUses))
+	customTools := customToolNameSet(req.Tools)
 
 	if strings.TrimSpace(content) != "" {
 		output = append(output, ResponseOutputItem{
@@ -273,6 +307,17 @@ func buildResponsesObject(
 	}
 
 	for _, tu := range toolUses {
+		if customTools[tu.Name] {
+			output = append(output, ResponseOutputItem{
+				ID:     generateOutputItemID("ctc"),
+				Type:   "custom_tool_call",
+				Status: "completed",
+				CallID: tu.ToolUseID,
+				Name:   tu.Name,
+				Input:  customToolCallInput(tu.Input),
+			})
+			continue
+		}
 		args, _ := json.Marshal(tu.Input)
 		output = append(output, ResponseOutputItem{
 			ID:        generateOutputItemID("fc"),
@@ -362,6 +407,7 @@ func (h *Handler) handleResponsesStream(
 	var lastErr error
 	responseStarted := false
 	reqStart := time.Now()
+	streamCustomTools := customToolNameSet(req.Tools)
 
 	for attempt := 0; attempt < maxAccountRetryAttempts; attempt++ {
 		account := h.pool.GetNextForModelExcluding(model, excluded)
@@ -475,6 +521,51 @@ func (h *Handler) handleResponsesStream(
 				}
 
 				toolUses = append(toolUses, tu)
+
+				if streamCustomTools[tu.Name] {
+					input := customToolCallInput(tu.Input)
+					ctcID := generateOutputItemID("ctc")
+					send("response.output_item.added", map[string]interface{}{
+						"type":         "response.output_item.added",
+						"output_index": outputIndex,
+						"item": map[string]interface{}{
+							"id":      ctcID,
+							"type":    "custom_tool_call",
+							"status":  "in_progress",
+							"call_id": tu.ToolUseID,
+							"name":    tu.Name,
+							"input":   "",
+						},
+					})
+					send("response.custom_tool_call_input.delta", map[string]interface{}{
+						"type":         "response.custom_tool_call_input.delta",
+						"item_id":      ctcID,
+						"output_index": outputIndex,
+						"delta":        input,
+					})
+					send("response.custom_tool_call_input.done", map[string]interface{}{
+						"type":         "response.custom_tool_call_input.done",
+						"item_id":      ctcID,
+						"output_index": outputIndex,
+						"input":        input,
+					})
+					send("response.output_item.done", map[string]interface{}{
+						"type":         "response.output_item.done",
+						"output_index": outputIndex,
+						"item": map[string]interface{}{
+							"id":      ctcID,
+							"type":    "custom_tool_call",
+							"status":  "completed",
+							"call_id": tu.ToolUseID,
+							"name":    tu.Name,
+							"input":   input,
+						},
+					})
+					outputIndex++
+					responseStarted = true
+					return
+				}
+
 				args, _ := json.Marshal(tu.Input)
 				fcID := generateOutputItemID("fc")
 				send("response.output_item.added", map[string]interface{}{

--- a/proxy/responses_handler_test.go
+++ b/proxy/responses_handler_test.go
@@ -551,6 +551,42 @@ func TestExtractResponsesToolsAdditionalTools(t *testing.T) {
 	if !ok || followup.Type != "function" {
 		t.Fatalf("expected namespace-flattened followup_task tool with its own plain name, got %+v", byName)
 	}
+	if followup.Namespace != "collaboration" {
+		t.Fatalf("expected followup_task to carry its source namespace for the response round trip, got %q", followup.Namespace)
+	}
+}
+
+// TestToolNamespaceMapAndFunctionCallOutput ensures a tool flattened out of a
+// Responses API namespace (e.g. Codex's "collaboration" spawn_agent group)
+// gets its namespace re-attached as a sibling "namespace" field on the
+// function_call output item -- Codex's FunctionCall wire format keys
+// dispatch on ToolName{name, namespace}, so a response with a bare name and
+// no namespace field never matches what Codex registered internally.
+func TestToolNamespaceMapAndFunctionCallOutput(t *testing.T) {
+	tools := []OpenAITool{{Type: "function", Namespace: "collaboration"}}
+	tools[0].Function.Name = "spawn_agent"
+
+	ns := toolNamespaceMap(tools)
+	if ns["spawn_agent"] != "collaboration" {
+		t.Fatalf("expected spawn_agent namespaced under collaboration, got %+v", ns)
+	}
+
+	req := &ResponsesRequest{Tools: tools}
+	toolUses := []KiroToolUse{{ToolUseID: "call_1", Name: "spawn_agent", Input: map[string]interface{}{"task_name": "worker", "message": "hi"}}}
+	obj := buildResponsesObject("resp_1", "gpt-5.6-terra", "", toolUses, 0, 0, req, "tool_use")
+
+	var fc *ResponseOutputItem
+	for i := range obj.Output {
+		if obj.Output[i].Type == "function_call" {
+			fc = &obj.Output[i]
+		}
+	}
+	if fc == nil {
+		t.Fatalf("expected a function_call output item, got %+v", obj.Output)
+	}
+	if fc.Namespace != "collaboration" {
+		t.Fatalf("expected function_call namespace %q, got %q", "collaboration", fc.Namespace)
+	}
 }
 
 // TestConvertOpenAIToolsCustomType ensures "custom" tools (freeform string
@@ -614,5 +650,71 @@ func TestResponsesParseCustomToolCallRoundTrip(t *testing.T) {
 	}
 	if msgs[2].Role != "tool" || msgs[2].ToolCallID != "call_1" || msgs[2].Content != "1" {
 		t.Fatalf("expected tool result message, got %+v", msgs[2])
+	}
+}
+
+// TestResponsesParseAgentMessage covers Codex's multi-agent v2 delivery of a
+// spawned sub-agent's initial task (and inter-agent messages) as an
+// "agent_message" item rather than a plain "message". Without this parsing
+// case the sub-agent silently receives no task at all -- it still runs, but
+// answers as if starting a conversation with no instructions.
+func TestResponsesParseAgentMessage(t *testing.T) {
+	raw := json.RawMessage(`[
+		{
+			"type": "agent_message",
+			"author": "/root",
+			"recipient": "/root/worker",
+			"content": [{"type": "input_text", "text": "reply with exactly: PONG"}]
+		}
+	]`)
+
+	msgs, err := parseResponsesInput(raw)
+	if err != nil {
+		t.Fatalf("parse agent_message: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d (%+v)", len(msgs), msgs)
+	}
+	if msgs[0].Role != "user" {
+		t.Fatalf("expected user role, got %q", msgs[0].Role)
+	}
+	if got, _ := msgs[0].Content.(string); got != "reply with exactly: PONG" {
+		t.Fatalf("expected task text, got %v", msgs[0].Content)
+	}
+}
+
+// TestResponsesParseAgentMessageReadsEncryptedContentField ensures the
+// "encrypted_content" part's value is read as plain text, not skipped as
+// opaque ciphertext. Codex tags multi-agent payload content this way
+// unconditionally, but against a non-ChatGPT-backend provider (no
+// encryption session exists) the field genuinely carries the task text
+// as-is -- confirmed live against a real Codex CLI session, where a spawned
+// sub-agent's "Message Type: NEW_TASK" agent_message arrived as
+// {"type":"input_text","text":"Message Type: NEW_TASK\n...\nPayload:\n"}
+// followed by {"type":"encrypted_content","encrypted_content":"<the actual
+// plaintext task>"}.
+func TestResponsesParseAgentMessageReadsEncryptedContentField(t *testing.T) {
+	raw := json.RawMessage(`[
+		{
+			"type": "agent_message",
+			"author": "/root",
+			"recipient": "/root/worker",
+			"content": [
+				{"type": "input_text", "text": "Message Type: NEW_TASK\nTask name: /root/worker\nSender: /root\nPayload:\n"},
+				{"type": "encrypted_content", "encrypted_content": "reply with exactly: PONG"}
+			]
+		}
+	]`)
+
+	msgs, err := parseResponsesInput(raw)
+	if err != nil {
+		t.Fatalf("parse agent_message: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d (%+v)", len(msgs), msgs)
+	}
+	got, _ := msgs[0].Content.(string)
+	if !strings.Contains(got, "reply with exactly: PONG") {
+		t.Fatalf("expected the task payload to be readable, got %v", got)
 	}
 }

--- a/proxy/responses_handler_test.go
+++ b/proxy/responses_handler_test.go
@@ -502,3 +502,117 @@ func TestResponsesStreamSSE(t *testing.T) {
 		t.Fatalf("expected stream content delta, got:\n%s", bodyStr)
 	}
 }
+
+// TestExtractResponsesToolsAdditionalTools covers newer Codex clients
+// (v0.146+) that stop sending the top-level "tools" field and instead embed
+// every tool -- including Codex's own built-in "exec" custom tool that
+// fronts shell/file/git access -- as a developer-role "additional_tools"
+// item inside "input". Namespace-wrapped tools (e.g. sub-agent groups) must
+// be flattened using their own plain name.
+func TestExtractResponsesToolsAdditionalTools(t *testing.T) {
+	raw := json.RawMessage(`[
+		{
+			"type": "additional_tools",
+			"role": "developer",
+			"tools": [
+				{"type": "custom", "name": "exec", "description": "Run JS"},
+				{"type": "function", "name": "wait", "description": "Wait", "parameters": {"type": "object", "properties": {"cell_id": {"type": "string"}}}},
+				{
+					"type": "namespace",
+					"name": "collaboration",
+					"description": "Sub-agents",
+					"tools": [
+						{"type": "function", "name": "followup_task", "description": "Follow up", "parameters": {"type": "object", "properties": {"target": {"type": "string"}}}}
+					]
+				}
+			]
+		},
+		{"type": "message", "role": "user", "content": "hi"}
+	]`)
+
+	tools := extractResponsesTools(raw)
+	if len(tools) != 3 {
+		t.Fatalf("expected 3 flattened tools, got %d (%+v)", len(tools), tools)
+	}
+
+	byName := map[string]OpenAITool{}
+	for _, tool := range tools {
+		byName[tool.Function.Name] = tool
+	}
+
+	exec, ok := byName["exec"]
+	if !ok || exec.Type != "custom" {
+		t.Fatalf("expected custom exec tool, got %+v", byName)
+	}
+	if _, ok := byName["wait"]; !ok {
+		t.Fatalf("expected wait function tool, got %+v", byName)
+	}
+	followup, ok := byName["followup_task"]
+	if !ok || followup.Type != "function" {
+		t.Fatalf("expected namespace-flattened followup_task tool with its own plain name, got %+v", byName)
+	}
+}
+
+// TestConvertOpenAIToolsCustomType ensures "custom" tools (freeform string
+// input, no JSON schema) get a stable single-"input"-field schema so the
+// model's tool call can be round-tripped back into a custom_tool_call output
+// item deterministically.
+func TestConvertOpenAIToolsCustomType(t *testing.T) {
+	tools := []OpenAITool{{Type: "custom"}}
+	tools[0].Function.Name = "exec"
+	tools[0].Function.Description = "Run JS"
+
+	wrapped := convertOpenAITools(tools)
+	if len(wrapped) != 1 {
+		t.Fatalf("expected 1 wrapped tool, got %d", len(wrapped))
+	}
+	schema, ok := wrapped[0].ToolSpecification.InputSchema.JSON.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map schema, got %T", wrapped[0].ToolSpecification.InputSchema.JSON)
+	}
+	props, ok := schema["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected properties map in schema, got %+v", schema)
+	}
+	if _, ok := props["input"]; !ok {
+		t.Fatalf("expected a single 'input' property, got %+v", props)
+	}
+}
+
+// TestResponsesParseCustomToolCallRoundTrip covers the reverse direction:
+// Codex re-submits a prior custom_tool_call/custom_tool_call_output pair on
+// the next turn, which must parse into the same assistant tool_calls +
+// tool-result shape as ordinary function_call items so Kiro's history
+// sanitization can handle both uniformly.
+func TestResponsesParseCustomToolCallRoundTrip(t *testing.T) {
+	raw := json.RawMessage(`[
+		{"type":"message","role":"user","content":"run something"},
+		{"type":"custom_tool_call","call_id":"call_1","name":"exec","input":"console.log(1)"},
+		{"type":"custom_tool_call_output","call_id":"call_1","output":"1"}
+	]`)
+
+	msgs, err := parseResponsesInput(raw)
+	if err != nil {
+		t.Fatalf("parse custom tool call: %v", err)
+	}
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 messages, got %d (%+v)", len(msgs), msgs)
+	}
+	if msgs[1].Role != "assistant" || len(msgs[1].ToolCalls) != 1 {
+		t.Fatalf("expected assistant tool call message, got %+v", msgs[1])
+	}
+	tc := msgs[1].ToolCalls[0]
+	if tc.Function.Name != "exec" {
+		t.Fatalf("expected exec tool call, got %q", tc.Function.Name)
+	}
+	var args map[string]string
+	if err := json.Unmarshal([]byte(tc.Function.Arguments), &args); err != nil {
+		t.Fatalf("expected JSON-wrapped arguments, got %q: %v", tc.Function.Arguments, err)
+	}
+	if args["input"] != "console.log(1)" {
+		t.Fatalf("expected wrapped raw input, got %+v", args)
+	}
+	if msgs[2].Role != "tool" || msgs[2].ToolCallID != "call_1" || msgs[2].Content != "1" {
+		t.Fatalf("expected tool result message, got %+v", msgs[2])
+	}
+}

--- a/proxy/responses_input.go
+++ b/proxy/responses_input.go
@@ -79,6 +79,20 @@ func convertResponsesInputItems(items []json.RawMessage) ([]OpenAIMessage, error
 			// separately by extractResponsesTools. Skip so it isn't
 			// misread as an empty developer message.
 
+		case typ == "agent_message":
+			// Codex's multi-agent v2 delivers a spawned sub-agent's initial
+			// task (and later inter-agent messages) as this item type
+			// instead of a plain "message" -- {"author":...,"recipient":...,
+			// "content":[{"type":"input_text","text":...}]}, or
+			// {"type":"encrypted_content",...} when Codex thinks the
+			// transport is encrypted. Without this case the content is
+			// silently dropped and a spawned sub-agent receives no task at
+			// all (it still runs, but with nothing to do).
+			flushPendingUser()
+			if text := extractAgentMessageText(obj); text != "" {
+				messages = append(messages, OpenAIMessage{Role: "user", Content: text})
+			}
+
 		case typ == "function_call_output" || typ == "tool_result" || typ == "custom_tool_call_output":
 			flushPendingUser()
 			callID, _ := obj["call_id"].(string)
@@ -218,11 +232,14 @@ func extractResponsesTools(raw json.RawMessage) []OpenAITool {
 // decodeResponsesTool decodes a single tool entry from an "additional_tools"
 // block. "namespace" entries (e.g. Codex's "collaboration" sub-agent group)
 // wrap a nested "tools" list instead of describing a callable tool
-// themselves, so they're flattened using each nested tool's own name --
-// Codex's dispatcher matches calls by that plain name, not a namespaced path.
+// themselves, so they're flattened using each nested tool's own bare name --
+// Codex's dispatcher matches calls by that plain name plus a separate
+// "namespace" field carried alongside it on the wire (see OpenAITool.Namespace),
+// not a namespace-prefixed name.
 func decodeResponsesTool(raw json.RawMessage) []OpenAITool {
 	var head struct {
 		Type  string            `json:"type"`
+		Name  string            `json:"name"`
 		Tools []json.RawMessage `json:"tools"`
 	}
 	if err := json.Unmarshal(raw, &head); err != nil {
@@ -231,7 +248,12 @@ func decodeResponsesTool(raw json.RawMessage) []OpenAITool {
 	if head.Type == "namespace" {
 		var out []OpenAITool
 		for _, nested := range head.Tools {
-			out = append(out, decodeResponsesTool(nested)...)
+			for _, tool := range decodeResponsesTool(nested) {
+				if tool.Namespace == "" {
+					tool.Namespace = head.Name
+				}
+				out = append(out, tool)
+			}
 		}
 		return out
 	}
@@ -297,6 +319,39 @@ func buildMessageFromInputItem(obj map[string]interface{}, role string) *OpenAIM
 	}
 
 	return nil
+}
+
+// extractAgentMessageText concatenates the parts of an "agent_message"
+// item's "content" array. Codex always tags multi-agent payload content as
+// "encrypted_content" -- real ciphertext only when talking to its own
+// ChatGPT-hosted backend, which negotiates the encryption. Against any other
+// provider (like this one) no such session exists, so despite the tag the
+// "encrypted_content" field is verified to carry the plain task text as-is
+// (confirmed by direct observation: e.g. {"type":"encrypted_content",
+// "encrypted_content":"reply with exactly: PONG11"}). Treating it as opaque
+// ciphertext -- as Codex's own client-side plaintext_agent_message_content
+// does -- is exactly why a spawned sub-agent previously received no task at
+// all ("Ready — no task payload was included").
+func extractAgentMessageText(obj map[string]interface{}) string {
+	content, _ := obj["content"].([]interface{})
+	var parts []string
+	for _, c := range content {
+		part, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		switch part["type"] {
+		case "input_text":
+			if text, ok := part["text"].(string); ok && text != "" {
+				parts = append(parts, text)
+			}
+		case "encrypted_content":
+			if text, ok := part["encrypted_content"].(string); ok && text != "" {
+				parts = append(parts, text)
+			}
+		}
+	}
+	return strings.Join(parts, "\n")
 }
 
 func stringifyArbitrary(v interface{}) string {

--- a/proxy/responses_input.go
+++ b/proxy/responses_input.go
@@ -74,7 +74,12 @@ func convertResponsesInputItems(items []json.RawMessage) ([]OpenAIMessage, error
 				messages = append(messages, *msg)
 			}
 
-		case typ == "function_call_output" || typ == "tool_result":
+		case typ == "additional_tools":
+			// Tool declarations, not conversational content; extracted
+			// separately by extractResponsesTools. Skip so it isn't
+			// misread as an empty developer message.
+
+		case typ == "function_call_output" || typ == "tool_result" || typ == "custom_tool_call_output":
 			flushPendingUser()
 			callID, _ := obj["call_id"].(string)
 			if callID == "" {
@@ -98,23 +103,23 @@ func convertResponsesInputItems(items []json.RawMessage) ([]OpenAIMessage, error
 			}
 			tc.Function.Name, _ = obj["name"].(string)
 			tc.Function.Arguments = stringifyArbitrary(obj["arguments"])
-			// Merge consecutive function_call items into a single assistant
-			// message so parallel tool calls stay grouped in one turn. The
-			// Responses API emits each parallel call as a separate input item;
-			// keeping them in one assistant message preserves the tool_use /
-			// tool_result pairing that Kiro requires.
-			if n := len(messages); n > 0 &&
-				messages[n-1].Role == "assistant" &&
-				len(messages[n-1].ToolCalls) > 0 &&
-				strings.TrimSpace(extractOpenAIMessageText(messages[n-1].Content)) == "" {
-				messages[n-1].ToolCalls = append(messages[n-1].ToolCalls, tc)
-			} else {
-				messages = append(messages, OpenAIMessage{
-					Role:      "assistant",
-					Content:   "",
-					ToolCalls: []ToolCall{tc},
-				})
+			messages = appendAssistantToolCall(messages, tc)
+
+		case typ == "custom_tool_call":
+			flushPendingUser()
+			tc := ToolCall{
+				ID:   stringField(obj, "call_id", "id"),
+				Type: "function",
 			}
+			tc.Function.Name, _ = obj["name"].(string)
+			// Codex's custom tools take a raw string "input" rather than a
+			// JSON "arguments" object. Wrap it under the same "input" key
+			// the outbound schema in customToolInputSchema declares, so the
+			// round trip stays consistent.
+			inputStr := stringifyArbitrary(obj["input"])
+			argsBytes, _ := json.Marshal(map[string]string{"input": inputStr})
+			tc.Function.Arguments = string(argsBytes)
+			messages = appendAssistantToolCall(messages, tc)
 
 		case typ == "input_text" || typ == "text":
 			text, _ := obj["text"].(string)
@@ -148,6 +153,94 @@ func convertResponsesInputItems(items []json.RawMessage) ([]OpenAIMessage, error
 
 	flushPendingUser()
 	return messages, nil
+}
+
+// appendAssistantToolCall merges consecutive tool-call items into a single
+// assistant message so parallel tool calls stay grouped in one turn. The
+// Responses API emits each parallel call as a separate input item; keeping
+// them in one assistant message preserves the tool_use / tool_result pairing
+// that Kiro requires.
+func appendAssistantToolCall(messages []OpenAIMessage, tc ToolCall) []OpenAIMessage {
+	if n := len(messages); n > 0 &&
+		messages[n-1].Role == "assistant" &&
+		len(messages[n-1].ToolCalls) > 0 &&
+		strings.TrimSpace(extractOpenAIMessageText(messages[n-1].Content)) == "" {
+		messages[n-1].ToolCalls = append(messages[n-1].ToolCalls, tc)
+		return messages
+	}
+	return append(messages, OpenAIMessage{
+		Role:      "assistant",
+		Content:   "",
+		ToolCalls: []ToolCall{tc},
+	})
+}
+
+// extractResponsesTools scans a Responses API "input" array for
+// "additional_tools" items and returns the tool declarations found inside
+// them. Newer Codex clients (e.g. codex-kiro / v0.146+) stop sending the
+// top-level "tools" field entirely and instead embed every tool -- including
+// its own built-in "exec" custom tool that fronts shell/file/git access --
+// as a developer-role "additional_tools" input item. Without this, the
+// model receives zero tool definitions and correctly (but confusingly)
+// reports having no tool access at all.
+func extractResponsesTools(raw json.RawMessage) []OpenAITool {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed[0] != '[' {
+		return nil
+	}
+
+	var items []json.RawMessage
+	if err := json.Unmarshal(raw, &items); err != nil {
+		return nil
+	}
+
+	var tools []OpenAITool
+	for _, item := range items {
+		var head struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal(item, &head); err != nil || head.Type != "additional_tools" {
+			continue
+		}
+		var block struct {
+			Tools []json.RawMessage `json:"tools"`
+		}
+		if err := json.Unmarshal(item, &block); err != nil {
+			continue
+		}
+		for _, t := range block.Tools {
+			tools = append(tools, decodeResponsesTool(t)...)
+		}
+	}
+	return tools
+}
+
+// decodeResponsesTool decodes a single tool entry from an "additional_tools"
+// block. "namespace" entries (e.g. Codex's "collaboration" sub-agent group)
+// wrap a nested "tools" list instead of describing a callable tool
+// themselves, so they're flattened using each nested tool's own name --
+// Codex's dispatcher matches calls by that plain name, not a namespaced path.
+func decodeResponsesTool(raw json.RawMessage) []OpenAITool {
+	var head struct {
+		Type  string            `json:"type"`
+		Tools []json.RawMessage `json:"tools"`
+	}
+	if err := json.Unmarshal(raw, &head); err != nil {
+		return nil
+	}
+	if head.Type == "namespace" {
+		var out []OpenAITool
+		for _, nested := range head.Tools {
+			out = append(out, decodeResponsesTool(nested)...)
+		}
+		return out
+	}
+
+	var tool OpenAITool
+	if err := json.Unmarshal(raw, &tool); err != nil {
+		return nil
+	}
+	return []OpenAITool{tool}
 }
 
 func buildMessageFromInputItem(obj map[string]interface{}, role string) *OpenAIMessage {

--- a/proxy/responses_types.go
+++ b/proxy/responses_types.go
@@ -43,6 +43,7 @@ type ResponseOutputItem struct {
 	CallID    string                `json:"call_id,omitempty"`
 	Name      string                `json:"name,omitempty"`
 	Arguments string                `json:"arguments,omitempty"`
+	Input     string                `json:"input,omitempty"`
 }
 
 type ResponseContentPart struct {

--- a/proxy/responses_types.go
+++ b/proxy/responses_types.go
@@ -42,6 +42,7 @@ type ResponseOutputItem struct {
 	Content   []ResponseContentPart `json:"content,omitempty"`
 	CallID    string                `json:"call_id,omitempty"`
 	Name      string                `json:"name,omitempty"`
+	Namespace string                `json:"namespace,omitempty"`
 	Arguments string                `json:"arguments,omitempty"`
 	Input     string                `json:"input,omitempty"`
 }

--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -2096,6 +2096,24 @@ func parseBase64Image(data, format string) *KiroImage {
 	}
 }
 
+// customToolInputSchema is the schema advertised to Kiro for OpenAI "custom"
+// tools (e.g. Codex's freeform "exec" tool), which take a single raw string
+// argument rather than a JSON-schema-described object. Kiro's tool_use still
+// requires a JSON object input, so we pin the argument to a single "input"
+// string field; convertOpenAIToolUseToCustomCall relies on this exact key
+// when translating the model's tool call back into a Responses API
+// custom_tool_call output item.
+var customToolInputSchema = map[string]interface{}{
+	"type": "object",
+	"properties": map[string]interface{}{
+		"input": map[string]interface{}{
+			"type":        "string",
+			"description": "Raw text input for this tool.",
+		},
+	},
+	"required": []interface{}{"input"},
+}
+
 func convertOpenAITools(tools []OpenAITool) []KiroToolWrapper {
 	if len(tools) == 0 {
 		return nil
@@ -2103,7 +2121,7 @@ func convertOpenAITools(tools []OpenAITool) []KiroToolWrapper {
 
 	result := make([]KiroToolWrapper, 0, len(tools))
 	for _, tool := range tools {
-		if tool.Type != "function" {
+		if tool.Type != "function" && tool.Type != "custom" {
 			continue
 		}
 		desc := tool.Function.Description
@@ -2118,7 +2136,11 @@ func convertOpenAITools(tools []OpenAITool) []KiroToolWrapper {
 		wrapper := KiroToolWrapper{}
 		wrapper.ToolSpecification.Name = name
 		wrapper.ToolSpecification.Description = normalizeToolDesc(desc, name)
-		wrapper.ToolSpecification.InputSchema = InputSchema{JSON: ensureObjectSchema(tool.Function.Parameters)}
+		if tool.Type == "custom" {
+			wrapper.ToolSpecification.InputSchema = InputSchema{JSON: customToolInputSchema}
+		} else {
+			wrapper.ToolSpecification.InputSchema = InputSchema{JSON: ensureObjectSchema(tool.Function.Parameters)}
+		}
 		result = append(result, wrapper)
 	}
 	return result

--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -905,6 +905,14 @@ func cloneSchemaValue(v interface{}) interface{} {
 // cleanSchema 递归清理会导致 Kiro 400 的 schema 字段。
 func cleanSchema(m map[string]interface{}) {
 	delete(m, "additionalProperties")
+	// "encrypted" is a Codex-specific, non-standard JSON Schema keyword used on
+	// multi-agent tools (spawn_agent/send_message/followup_task's "message"
+	// property) to mark that field for Codex's own client-side encrypted
+	// transport. Kiro doesn't understand it; stripping it is a safe no-op for
+	// every other client and mirrors what working third-party Codex proxies
+	// (e.g. CLIProxyAPI's optimize-multi-agent-v2) already do before forwarding
+	// these tool schemas upstream.
+	delete(m, "encrypted")
 
 	// required 必须是非空数组，否则 Kiro 会报 Improperly formed request。
 	if req, exists := m["required"]; exists {
@@ -1107,6 +1115,19 @@ type OpenAITool struct {
 		Description string      `json:"description"`
 		Parameters  interface{} `json:"parameters"`
 	} `json:"function"`
+	// Namespace is set programmatically (not parsed from JSON) when a tool is
+	// flattened out of a Responses API "namespace" wrapper (e.g. Codex's
+	// "collaboration" sub-agent group). Codex's own FunctionCall wire format
+	// carries the namespace as a sibling "namespace" field alongside the bare
+	// "name" (confirmed in codex-rs/protocol/src/models.rs tests, e.g.
+	// {"type":"function_call","name":"spawn_agent","namespace":"collaboration",...}) --
+	// it is NOT concatenated into the name. Omitting it here is exactly why a
+	// bare "spawn_agent" call round-tripped through this proxy fails with
+	// Codex's local "unsupported call: spawn_agent" router error: Codex
+	// registers the handler under ToolName{name, namespace: Some(ns)} and a
+	// response with no namespace field parses back as namespace: None, which
+	// never matches.
+	Namespace string `json:"-"`
 }
 
 // UnmarshalJSON accepts both the Chat Completions tool shape, where the tool


### PR DESCRIPTION
## Summary

Fixes #151.

Newer Codex CLI builds (confirmed on `v0.146.0`, model `gpt-5.6-terra`) stop sending tool declarations in the top-level `"tools"` field of a `/v1/responses` request. Instead, every tool — including Codex's own built-in `"exec"` custom tool, which fronts shell/file/git access and MCP tool namespaces — is embedded as a `developer`-role `"additional_tools"` item inside `"input"`. Kiro-Go only read the top-level field, so the model silently received zero tool definitions and correctly (but confusingly) reported having no tool access at all, even though the request succeeded and streamed normally.

新版 Codex CLI（在 `v0.146.0`、模型 `gpt-5.6-terra` 上确认）不再把工具声明放进 `/v1/responses` 请求顶层的 `"tools"` 字段，而是把包括 Codex 内置的、承载 shell/文件/git 访问能力及 MCP 工具命名空间的万能工具 `"exec"` 在内的所有工具，都作为 `input` 中一个 `role` 为 `developer` 的 `"additional_tools"` 条目嵌入。Kiro-Go 之前只读取顶层字段，导致模型静默收到零个工具定义，如实但令人困惑地回答自己完全没有工具访问权限——尽管请求本身成功并正常流式返回。

**Update:** this PR now also makes Codex's `spawn_agent`/Multi-Agent V2 collaboration tools (`spawn_agent`, `send_message`, `followup_task`, `wait_agent`, `list_agents`, `interrupt_agent`) fully functional through a non-ChatGPT-backend provider — not just visible, but able to actually spawn a working sub-agent, deliver its task, and retrieve its real answer. Verified end-to-end live against Codex CLI `v0.146.0`.

## What changed

- **`proxy/responses_input.go`**
  - `extractResponsesTools` / `decodeResponsesTool`: scan `input` for `"additional_tools"` items and pull out their tool declarations, flattening `"namespace"`-wrapped groups (e.g. Codex's `collaboration` sub-agent tools) by each nested tool's own plain name, while recording the source namespace on `OpenAITool.Namespace` so it can be re-attached on the response side (see below) — Codex's dispatcher matches namespaced calls on `{name, namespace}`, not a namespace-prefixed name.
  - Parse `custom_tool_call` / `custom_tool_call_output` input items (Codex re-submitting a prior turn's custom tool call) the same way `function_call` / `function_call_output` are handled, wrapping the raw string argument under the `"input"` key the outbound schema declares.
  - Parse `agent_message` input items — how a spawned sub-agent's actual task (and later inter-agent messages) arrives, as `{author, recipient, content}` rather than a plain `"message"`. Previously unhandled and silently dropped, leaving a spawned sub-agent with no task at all. Content parts tagged `"input_text"` or `"encrypted_content"` are both read as text: the latter is genuinely plaintext when talking to any non-ChatGPT-backend provider (confirmed live: `{"type":"encrypted_content","encrypted_content":"reply with exactly: PONG"}`), since no real encryption session exists to negotiate it.
  - Extracted the `function_call` / `custom_tool_call` "merge into previous assistant message" logic into a shared `appendAssistantToolCall` helper (previously duplicated).
- **`proxy/translator.go`**
  - `convertOpenAITools` now accepts OpenAI `"custom"`-type tools (freeform string input, no JSON schema) by pinning them to a fixed single-`"input"`-string-field schema (`customToolInputSchema`), so there's a stable key to extract the model's raw string argument from on the way back.
  - `cleanSchema` now also strips the non-standard `"encrypted"` JSON Schema keyword Codex marks the `spawn_agent`/`send_message`/`followup_task` `"message"` property with for its own client-side transport — Kiro doesn't understand it, and other working third-party Codex proxies (e.g. CLIProxyAPI's `optimize-multi-agent-v2`) strip it the same way.
- **`proxy/responses_handler.go`**
  - Merge tools extracted via `extractResponsesTools` into `req.Tools` right after parsing the request, so both the outbound Kiro payload and the output-building code see the full tool set.
  - `customToolNameSet` / `customToolCallInput`: track which tool names were declared `"custom"` so `tool_use` results for them are re-encoded as `custom_tool_call` output items (with an `"input"` string) instead of `function_call` (with `"arguments"` JSON) — both in `buildResponsesObject` (non-streaming) and the SSE stream path (`response.custom_tool_call_input.delta` / `.done` events alongside `response.output_item.added` / `.done`).
  - `toolNamespaceMap`: re-attaches a namespaced tool's source namespace as a sibling `"namespace"` field on `function_call` output items (confirmed in `codex-rs/protocol/src/models.rs` tests, e.g. `{"name":"spawn_agent","namespace":"collaboration",...}` — it is *not* concatenated into the name). Without this, Codex's own registry (keyed on `ToolName{name, namespace}`) never matches the response and rejects the call locally with `unsupported call: spawn_agent`, before any network round-trip — this was the main blocker for `spawn_agent` and the rest of the collaboration tool group.
- **`proxy/responses_types.go`**: added `Input` field to `ResponseOutputItem` for `custom_tool_call` items, and `Namespace` for namespaced `function_call` items.
- **`proxy/responses_handler_test.go`**: added coverage for `additional_tools` extraction (including namespace tracking), the `"custom"` tool schema, the `custom_tool_call`/`custom_tool_call_output` round trip, `agent_message` parsing (including the `encrypted_content` field), and namespace re-attachment on `function_call` output.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages pass, including new tests)
- [x] Manually verified against a real Codex CLI `v0.146.0` session (`codex --profile kiro-go`, `wire_api = "responses"`): before the fix the model reported no tool access whatsoever; after the fix it correctly reads/writes files, runs shell commands, and uses git through Codex's `exec` tool.
- [x] Manually verified `spawn_agent` end-to-end: `codex --profile kiro-go exec "Use spawn_agent to spawn a sub-agent named 'x' with the message 'reply with exactly: PONG'. Wait for it and report its final answer verbatim."` → the sub-agent is created, receives its task, and the parent correctly reports back the sub-agent's real answer (`PONG`) via `wait_agent`.

🤖 Generated with the help of [Claude Code](https://claude.com/claude-code)
