### PR TITLE
fix(refresh): skip Builder ID accounts in background refresh loops

### DIFF
--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -336,27 +336,34 @@ func (h *Handler) refreshAllAccounts() {
 			continue
 		}
 
-		// API Key accounts skip OAuth refresh; still sync usage/subscription.
-		if !config.IsAPIKeyAccount(account) {
-			// 检查 token 是否需要刷新
-			if account.ExpiresAt > 0 && time.Now().Unix() > account.ExpiresAt-tokenRefreshSkewSeconds {
-				if _, err := h.refreshAccountToken(account, false); err != nil {
-					logger.Warnf("[BackgroundRefresh] Token refresh failed for %s: %v", account.Email, err)
-					h.handleAccountFailure(account, err)
-					continue
+		// Builder ID accounts (no profileArn) cannot resolve a profile ARN
+		// upstream; refreshing them serially (potentially thousands of
+		// accounts) just burns time, spams the log with "no available Kiro
+		// profile", and hammers the AWS endpoint. Only refresh accounts that
+		// can actually resolve a profile (API Key / SSO with profileArn).
+		if config.IsAPIKeyAccount(account) || account.ProfileArn != "" {
+			// API Key accounts skip OAuth refresh; still sync usage/subscription.
+			if !config.IsAPIKeyAccount(account) {
+				// 检查 token 是否需要刷新
+				if account.ExpiresAt > 0 && time.Now().Unix() > account.ExpiresAt-tokenRefreshSkewSeconds {
+					if _, err := h.refreshAccountToken(account, false); err != nil {
+						logger.Warnf("[BackgroundRefresh] Token refresh failed for %s: %v", account.Email, err)
+						h.handleAccountFailure(account, err)
+						continue
+					}
 				}
 			}
-		}
 
-		// 刷新账户信息
-		info, err := RefreshAccountInfo(account)
-		if err != nil {
-			logger.Warnf("[BackgroundRefresh] Failed to refresh %s: %v", account.Email, err)
-			continue
-		}
+			// 刷新账户信息
+			info, err := RefreshAccountInfo(account)
+			if err != nil {
+				logger.Warnf("[BackgroundRefresh] Failed to refresh %s: %v", account.Email, err)
+				continue
+			}
 
-		config.UpdateAccountInfo(account.ID, *info)
-		logger.Infof("[BackgroundRefresh] Refreshed %s: %s %.1f/%.1f", account.Email, info.SubscriptionType, info.UsageCurrent, info.UsageLimit)
+			config.UpdateAccountInfo(account.ID, *info)
+			logger.Infof("[BackgroundRefresh] Refreshed %s: %s %.1f/%.1f", account.Email, info.SubscriptionType, info.UsageCurrent, info.UsageLimit)
+		}
 	}
 	h.pool.Reload()
 }
@@ -626,6 +633,14 @@ func (h *Handler) refreshModelsCache() {
 	aggregated := make([]ModelInfo, 0)
 	for i := range accounts {
 		account := &accounts[i]
+		// Builder ID accounts cannot resolve a profile upstream (403 on
+		// ListAvailableModels). Skipping them keeps background refresh fast
+		// and avoids hammering upstream / spamming the log with per-account
+		// failures. They still route optimistically (GetNextForModel falls
+		// back to the full pool when no account has a cached model list).
+		if !config.IsAPIKeyAccount(account) && account.ProfileArn == "" {
+			continue
+		}
 		if err := h.ensureValidToken(account); err != nil {
 			logger.Warnf("[ModelsCache] Skip %s token refresh failed: %v", account.Email, err)
 			h.handleAccountFailure(account, err)


### PR DESCRIPTION
## Summary
Skip Builder ID accounts (no \profileArn\) in the two background refresh loops:

- \efreshAllAccounts\: only refresh API Key / SSO accounts that can resolve a profile ARN.
- \efreshModelsCache\: skip Builder ID accounts too.

## Why
Builder ID accounts cannot resolve a profile ARN upstream (\
o available Kiro profile\ / 403 on \ListAvailableProfiles\). With a large pool (e.g. 1000 Builder ID accounts) the background refresh:

- serially iterates every account and fails on each one,
- spams the log with \[BackgroundRefresh] Failed to refresh ... no available Kiro profile\,
- hammers the AWS endpoint every 30 minutes,
- and delays requests while the serial refresh is running.

## Behavior preserved
- Builder ID accounts still route normally: \GetNextForModel\ falls back to the full pool when no account has a cached model list (optimistic routing).
- Per-request profile ARN resolution is untouched (covered by #117).
- API Key / SSO accounts with a resolvable profile are refreshed exactly as before.

## Related
- #117 fixed per-request profile lookup suppression; this PR addresses the background refresh loops that still serially touch every Builder ID account.