### PR TITLE
fix(stream): treat meteringEvent as normal terminal signal

### DIFF
--- a/proxy/kiro.go
+++ b/proxy/kiro.go
@@ -669,6 +669,13 @@ func parseEventStreamTracked(body io.Reader, callback *KiroStreamCallback) (emit
 			if usage, ok := event["usage"].(float64); ok {
 				totalCredits += usage
 			}
+			// Builder ID / Q CLI accounts close the stream with a metering
+			// event instead of a metadataEvent carrying stopReason. Treat
+			// metering as the normal terminal signal so those streams are
+			// not misclassified as truncated.
+			if callback.OnStopReason != nil {
+				callback.OnStopReason("end_turn")
+			}
 		case "contextUsageEvent":
 			if pct, ok := event["contextUsagePercentage"].(float64); ok {
 				contextUsagePercentages = append(contextUsagePercentages, pct)


### PR DESCRIPTION
## Summary
Builder ID / Q CLI accounts close the upstream stream with a \meteringEvent\ instead of a \metadataEvent\ carrying a \stopReason\. Without a stop reason the stream is classified as truncated by \classifyStreamIntegrity\ (see #146), so every successful Builder ID turn ends with an error instead of a normal completion.

This PR treats the metering event as the terminal signal (\end_turn\) so those streams are not misclassified.

## Why
- With Builder ID account pools (no profileArn), streams terminate via \meteringEvent\ with no stopReason.
- \parseEventStreamTracked\ records usage on \meteringEvent\ but never signals a stop reason.
- \classifyStreamIntegrity\ then returns \errUpstreamTruncatedResponse\, triggering retries and eventually an error event to the client — even though the turn completed normally.

## Test
- \go build ./...\ ✅
- \go test ./proxy/ -run 'TestStream|TestParse|TestClassify'\ ✅

## Related
- #146 introduced the stream integrity classification this fixes.