### PR TITLE
feat: stabilize custom Claude routing and quota failover

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -16,8 +16,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -236,6 +238,23 @@ type Config struct {
 	FailedRequests  int     `json:"failedRequests,omitempty"`  // Failed requests count
 	TotalTokens     int     `json:"totalTokens,omitempty"`     // Total tokens processed
 	TotalCredits    float64 `json:"totalCredits,omitempty"`    // Total credits consumed
+
+	// Custom External API & Priority Upstream Routing
+	ExternalAPI ExternalAPIConfig `json:"externalApi,omitempty"`
+}
+
+// ExternalAPIConfig represents custom external API settings and model mappings.
+type ExternalAPIConfig struct {
+	Enabled                    bool   `json:"enabled"`                      // Priority route via external API
+	BaseURL                    string `json:"baseUrl"`                      // Base URL e.g. https://api.tuongtacfree.vn/
+	AuthToken                  string `json:"authToken,omitempty"`          // Auth token
+	APIKey                     string `json:"apiKey,omitempty"`             // API key
+	DefaultModel               string `json:"defaultModel,omitempty"`       // Default model preference (e.g. opus)
+	DefaultSonnetModel         string `json:"defaultSonnetModel,omitempty"` // Default sonnet model ID
+	DefaultOpusModel           string `json:"defaultOpusModel,omitempty"`   // Default opus model ID
+	DefaultHaikuModel          string `json:"defaultHaikuModel,omitempty"`  // Default haiku model ID
+	DisableNonessentialTraffic bool   `json:"disableNonessentialTraffic,omitempty"`
+	TimeoutMS                  int    `json:"timeoutMs,omitempty"`
 }
 
 // AccountInfo contains account metadata retrieved from Kiro API.
@@ -1240,4 +1259,123 @@ func defaultSystemVersion() string {
 	default:
 		return "linux#6.6.87"
 	}
+}
+
+func GetExternalAPIConfig() ExternalAPIConfig {
+	cfgLock.RLock()
+	defer cfgLock.RUnlock()
+	if cfg == nil {
+		return ExternalAPIConfig{}
+	}
+	return externalAPIConfigWithEnvOverrides(cfg.ExternalAPI)
+}
+
+func UpdateExternalAPIConfig(ext ExternalAPIConfig) error {
+	cfgLock.Lock()
+	defer cfgLock.Unlock()
+	normalized, err := normalizeExternalAPIConfig(ext)
+	if err != nil {
+		return err
+	}
+	previous := cfg.ExternalAPI
+	cfg.ExternalAPI = normalized
+	if err := Save(); err != nil {
+		cfg.ExternalAPI = previous
+		return err
+	}
+	return nil
+}
+
+func normalizeExternalAPIConfig(ext ExternalAPIConfig) (ExternalAPIConfig, error) {
+	ext = externalAPIConfigWithDefaults(ext)
+	if ext.AuthToken == "" {
+		ext.AuthToken = ext.APIKey
+	}
+	if ext.APIKey == "" {
+		ext.APIKey = ext.AuthToken
+	}
+	if ext.BaseURL != "" {
+		parsed, err := url.Parse(ext.BaseURL)
+		if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+			return ext, errors.New("externalApi.baseUrl must be a valid URL")
+		}
+		if parsed.Scheme != "http" && parsed.Scheme != "https" {
+			return ext, errors.New("externalApi.baseUrl must use http or https")
+		}
+		ext.BaseURL = strings.TrimRight(parsed.String(), "/")
+	}
+	if ext.Enabled && ext.BaseURL == "" {
+		return ext, errors.New("externalApi.baseUrl is required when external API is enabled")
+	}
+	return ext, nil
+}
+
+func externalAPIConfigWithDefaults(ext ExternalAPIConfig) ExternalAPIConfig {
+	ext.BaseURL = strings.TrimSpace(ext.BaseURL)
+	ext.AuthToken = strings.TrimSpace(ext.AuthToken)
+	ext.APIKey = strings.TrimSpace(ext.APIKey)
+	ext.DefaultModel = strings.TrimSpace(ext.DefaultModel)
+	ext.DefaultSonnetModel = strings.TrimSpace(ext.DefaultSonnetModel)
+	ext.DefaultOpusModel = strings.TrimSpace(ext.DefaultOpusModel)
+	ext.DefaultHaikuModel = strings.TrimSpace(ext.DefaultHaikuModel)
+	if ext.DefaultModel == "" {
+		ext.DefaultModel = "opus"
+	}
+	if ext.DefaultOpusModel == "" {
+		ext.DefaultOpusModel = "claude-opus-5"
+	}
+	if ext.DefaultSonnetModel == "" {
+		ext.DefaultSonnetModel = "claude-sonnet-4.5"
+	}
+	if ext.DefaultHaikuModel == "" {
+		ext.DefaultHaikuModel = "claude-haiku-4.5"
+	}
+	if ext.TimeoutMS <= 0 {
+		ext.TimeoutMS = 600000
+	}
+	return ext
+}
+
+func externalAPIConfigWithEnvOverrides(ext ExternalAPIConfig) ExternalAPIConfig {
+	if value := strings.TrimSpace(os.Getenv("ANTHROPIC_BASE_URL")); value != "" {
+		ext.BaseURL = value
+	}
+	if value := firstExternalAPIEnv("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"); value != "" {
+		ext.APIKey = value
+		ext.AuthToken = value
+	}
+	if value := strings.TrimSpace(os.Getenv("ANTHROPIC_DEFAULT_SONNET_MODEL")); value != "" {
+		ext.DefaultSonnetModel = value
+	}
+	if value := strings.TrimSpace(os.Getenv("ANTHROPIC_DEFAULT_OPUS_MODEL")); value != "" {
+		ext.DefaultOpusModel = value
+	}
+	if value := strings.TrimSpace(os.Getenv("ANTHROPIC_DEFAULT_HAIKU_MODEL")); value != "" {
+		ext.DefaultHaikuModel = value
+	}
+	if value := firstExternalAPIEnv("KIRO_GO_EXTERNAL_API_ENABLED", "EXTERNAL_API_ENABLED"); value != "" {
+		if enabled, err := strconv.ParseBool(value); err == nil {
+			ext.Enabled = enabled
+		}
+	}
+	if value := strings.TrimSpace(os.Getenv("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC")); value != "" {
+		if disabled, err := strconv.ParseBool(value); err == nil {
+			ext.DisableNonessentialTraffic = disabled
+		}
+	}
+	if value := strings.TrimSpace(os.Getenv("API_TIMEOUT_MS")); value != "" {
+		if timeoutMS, err := strconv.Atoi(value); err == nil && timeoutMS > 0 {
+			ext.TimeoutMS = timeoutMS
+		}
+	}
+	return externalAPIConfigWithDefaults(ext)
+}
+
+func firstExternalAPIEnv(names ...string) string {
+	for _, name := range names {
+		if value := strings.TrimSpace(os.Getenv(name)); value != "" {
+			return value
+		}
+	}
+	return ""
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -242,3 +242,41 @@ func TestAccountAllowOverageMigration(t *testing.T) {
 		}
 	}
 }
+
+func TestExternalAPIConfigDefaultsUseOpus5(t *testing.T) {
+	t.Setenv("ANTHROPIC_BASE_URL", "")
+	t.Setenv("ANTHROPIC_DEFAULT_OPUS_MODEL", "")
+	t.Setenv("ANTHROPIC_DEFAULT_SONNET_MODEL", "")
+	t.Setenv("ANTHROPIC_DEFAULT_HAIKU_MODEL", "")
+	if err := Init(filepath.Join(t.TempDir(), "config.json")); err != nil {
+		t.Fatalf("init config: %v", err)
+	}
+
+	if err := UpdateExternalAPIConfig(ExternalAPIConfig{
+		Enabled: true,
+		BaseURL: "https://api.tuongtacfree.vn/",
+		APIKey:  "sk-test",
+	}); err != nil {
+		t.Fatalf("update external API config: %v", err)
+	}
+
+	got := GetExternalAPIConfig()
+	if got.DefaultModel != "opus" {
+		t.Fatalf("default model = %q, want opus", got.DefaultModel)
+	}
+	if got.DefaultOpusModel != "claude-opus-5" {
+		t.Fatalf("opus model = %q, want claude-opus-5", got.DefaultOpusModel)
+	}
+	if got.DefaultSonnetModel != "claude-sonnet-4.5" {
+		t.Fatalf("sonnet model = %q, want claude-sonnet-4.5", got.DefaultSonnetModel)
+	}
+	if got.DefaultHaikuModel != "claude-haiku-4.5" {
+		t.Fatalf("haiku model = %q, want claude-haiku-4.5", got.DefaultHaikuModel)
+	}
+	if got.APIKey != got.AuthToken {
+		t.Fatalf("expected APIKey/AuthToken to stay in sync, got api=%q token=%q", got.APIKey, got.AuthToken)
+	}
+	if got.BaseURL != "https://api.tuongtacfree.vn" {
+		t.Fatalf("base URL = %q, want trimmed URL", got.BaseURL)
+	}
+}

--- a/pool/account.go
+++ b/pool/account.go
@@ -23,6 +23,20 @@ type AccountPool struct {
 	modelLists    map[string]map[string]bool // accountID → set of modelIDs (from ListAvailableModels)
 }
 
+// NewTestPool constructs an isolated account pool for cross-package tests.
+// Production code should use GetPool.
+func NewTestPool(accounts ...config.Account) *AccountPool {
+	isolated := make([]config.Account, len(accounts))
+	copy(isolated, accounts)
+	return &AccountPool{
+		accounts:      isolated,
+		totalAccounts: len(isolated),
+		cooldowns:     make(map[string]time.Time),
+		errorCounts:   make(map[string]int),
+		modelLists:    make(map[string]map[string]bool),
+	}
+}
+
 var (
 	pool     *AccountPool
 	poolOnce sync.Once
@@ -258,10 +272,17 @@ func (p *AccountPool) RecordErrorWithCooldown(id string, cooldown time.Duration)
 	p.errorCounts[id]++
 
 	if cooldown > 0 {
-		p.cooldowns[id] = time.Now().Add(cooldown)
+		candidate := time.Now().Add(cooldown)
+		if current, ok := p.cooldowns[id]; !ok || candidate.After(current) {
+			p.cooldowns[id] = candidate
+		}
 	} else if p.errorCounts[id] >= 3 {
-		// 连续 3 次错误，冷却 1 分钟
-		p.cooldowns[id] = time.Now().Add(time.Minute)
+		// 连续 3 次错误，冷却 1 分钟. Never shorten an existing cooldown
+		// that may have come from a concurrent quota response.
+		candidate := time.Now().Add(time.Minute)
+		if current, ok := p.cooldowns[id]; !ok || candidate.After(current) {
+			p.cooldowns[id] = candidate
+		}
 	}
 }
 

--- a/pool/account.go
+++ b/pool/account.go
@@ -118,27 +118,11 @@ func (p *AccountPool) GetNextExcluding(excluded map[string]bool) *config.Account
 		return acc
 	}
 
-		// 无可用账号，返回冷却时间最短的（排除额度用尽的，除非允许超额）
-	var best *config.Account
-	var earliest time.Time
-	for i := range p.accounts {
-		acc := &p.accounts[i]
-		if excluded != nil && excluded[acc.ID] {
-			continue
-		}
-		if isQuotaBlocked(*acc, allowOverUsage) {
-			continue
-		}
-		if cooldown, ok := p.cooldowns[acc.ID]; ok {
-			if best == nil || cooldown.Before(earliest) {
-				best = acc
-				earliest = cooldown
-			}
-		} else {
-			return acc
-		}
-	}
-	return best
+	// All otherwise-eligible accounts are cooling down. Returning the account
+	// whose cooldown expires first defeats the cooldown and creates a retry
+	// storm against an upstream that has already returned 429/transport errors.
+	// Fail fast until an account genuinely becomes eligible again.
+	return nil
 }
 
 // SetModelList 缓存账号支持的模型集合（由 handler 在刷新后调用）
@@ -229,30 +213,10 @@ func (p *AccountPool) GetNextForModelExcluding(model string, excluded map[string
 		return acc
 	}
 
-	// fallback：找冷却时间最短且支持该模型的账号
-	var best *config.Account
-	var earliest time.Time
-	for i := range p.accounts {
-		acc := &p.accounts[i]
-		if excluded != nil && excluded[acc.ID] {
-			continue
-		}
-		if !p.accountHasModel(acc.ID, model) {
-			continue
-		}
-		if isQuotaBlocked(*acc, allowOverUsage) {
-			continue
-		}
-		if cooldown, ok := p.cooldowns[acc.ID]; ok {
-			if best == nil || cooldown.Before(earliest) {
-				best = acc
-				earliest = cooldown
-			}
-		} else {
-			return acc
-		}
-	}
-	return best
+	// Every account that supports this model is currently cooling down. Respect
+	// the cooldown instead of immediately selecting the least-bad account and
+	// hammering the same quota-limited upstream again.
+	return nil
 }
 
 // GetByID 根据 ID 获取账号
@@ -277,14 +241,24 @@ func (p *AccountPool) RecordSuccess(id string) {
 
 // RecordError 记录请求错误，设置冷却
 func (p *AccountPool) RecordError(id string, isQuotaError bool) {
+	cooldown := time.Duration(0)
+	if isQuotaError {
+		cooldown = time.Hour
+	}
+	p.RecordErrorWithCooldown(id, cooldown)
+}
+
+// RecordErrorWithCooldown records a failed request and optionally applies an
+// immediate cooldown. A zero duration preserves the existing transient-error
+// policy: only three consecutive errors trigger a one-minute cooldown.
+func (p *AccountPool) RecordErrorWithCooldown(id string, cooldown time.Duration) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
 	p.errorCounts[id]++
 
-	if isQuotaError {
-		// 配额错误，冷却 1 小时
-		p.cooldowns[id] = time.Now().Add(time.Hour)
+	if cooldown > 0 {
+		p.cooldowns[id] = time.Now().Add(cooldown)
 	} else if p.errorCounts[id] >= 3 {
 		// 连续 3 次错误，冷却 1 分钟
 		p.cooldowns[id] = time.Now().Add(time.Minute)

--- a/pool/account_test.go
+++ b/pool/account_test.go
@@ -275,6 +275,34 @@ func TestGetNextForModelExcludingSkipsExcludedAccount(t *testing.T) {
 	}
 }
 
+func TestGetNextExcludingReturnsNilWhileAllAccountsAreCoolingDown(t *testing.T) {
+	p := newTestPool(
+		config.Account{ID: "a", Enabled: true},
+		config.Account{ID: "b", Enabled: true},
+	)
+	p.cooldowns["a"] = time.Now().Add(time.Hour)
+	p.cooldowns["b"] = time.Now().Add(30 * time.Minute)
+
+	if got := p.GetNextExcluding(nil); got != nil {
+		t.Fatalf("expected nil while every account is cooling down, got %q", got.ID)
+	}
+}
+
+func TestGetNextForModelExcludingReturnsNilWhileAllMatchingAccountsAreCoolingDown(t *testing.T) {
+	p := newTestPool(
+		config.Account{ID: "a", Enabled: true},
+		config.Account{ID: "b", Enabled: true},
+	)
+	p.SetModelList("a", []string{"claude-opus-5"})
+	p.SetModelList("b", []string{"claude-opus-5"})
+	p.cooldowns["a"] = time.Now().Add(time.Hour)
+	p.cooldowns["b"] = time.Now().Add(30 * time.Minute)
+
+	if got := p.GetNextForModelExcluding("claude-opus-5", nil); got != nil {
+		t.Fatalf("expected nil while every matching account is cooling down, got %q", got.ID)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Reload over-usage filtering
 // ---------------------------------------------------------------------------

--- a/pool/account_test.go
+++ b/pool/account_test.go
@@ -303,6 +303,24 @@ func TestGetNextForModelExcludingReturnsNilWhileAllMatchingAccountsAreCoolingDow
 	}
 }
 
+func TestRecordErrorWithCooldownNeverShortensExistingCooldown(t *testing.T) {
+	p := newTestPool(config.Account{ID: "a", Enabled: true})
+	p.RecordErrorWithCooldown("a", time.Hour)
+	first := p.cooldowns["a"]
+
+	p.RecordErrorWithCooldown("a", 10*time.Second)
+	if got := p.cooldowns["a"]; got.Before(first) {
+		t.Fatalf("shorter quota hint reduced cooldown: first=%v got=%v", first, got)
+	}
+
+	p.RecordErrorWithCooldown("a", 0)
+	p.RecordErrorWithCooldown("a", 0)
+	p.RecordErrorWithCooldown("a", 0)
+	if got := p.cooldowns["a"]; got.Before(first) {
+		t.Fatalf("transient-error cooldown reduced quota cooldown: first=%v got=%v", first, got)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Reload over-usage filtering
 // ---------------------------------------------------------------------------

--- a/proxy/account_failover.go
+++ b/proxy/account_failover.go
@@ -24,6 +24,7 @@ const (
 type upstreamQuotaError struct {
 	endpoint   string
 	retryAfter string
+	retryFor   time.Duration
 }
 
 func (e *upstreamQuotaError) Error() string {
@@ -55,6 +56,42 @@ func retryAfterDuration(value string, now time.Time) time.Duration {
 		return maxQuotaCooldown
 	}
 	return duration
+}
+
+func retryAfterHeader(err error) string {
+	var quotaErr *upstreamQuotaError
+	if errors.As(err, &quotaErr) {
+		if quotaErr.retryFor > 0 {
+			seconds := int64((quotaErr.retryFor + time.Second - 1) / time.Second)
+			return strconv.FormatInt(seconds, 10)
+		}
+		return strings.TrimSpace(quotaErr.retryAfter)
+	}
+	return ""
+}
+
+func upstreamErrorHTTPStatus(err error) int {
+	if err == nil {
+		return http.StatusServiceUnavailable
+	}
+	msg := err.Error()
+	switch {
+	case isQuotaErrorMessage(msg):
+		return http.StatusTooManyRequests
+	case isAuthErrorMessage(msg):
+		return http.StatusUnauthorized
+	default:
+		return http.StatusBadGateway
+	}
+}
+
+func setRetryAfterHeader(w http.ResponseWriter, err error) {
+	if w == nil {
+		return
+	}
+	if value := retryAfterHeader(err); value != "" {
+		w.Header().Set("Retry-After", value)
+	}
 }
 
 func isQuotaErrorMessage(msg string) bool {
@@ -144,7 +181,11 @@ func (h *Handler) handleAccountFailure(account *config.Account, err error) {
 		cooldown := defaultQuotaCooldown
 		var quotaErr *upstreamQuotaError
 		if errors.As(err, &quotaErr) {
-			cooldown = retryAfterDuration(quotaErr.retryAfter, time.Now())
+			if quotaErr.retryFor > 0 {
+				cooldown = quotaErr.retryFor
+			} else {
+				cooldown = retryAfterDuration(quotaErr.retryAfter, time.Now())
+			}
 		}
 		h.pool.RecordErrorWithCooldown(account.ID, cooldown)
 	case isSuspensionErrorMessage(errMsg):

--- a/proxy/account_failover.go
+++ b/proxy/account_failover.go
@@ -1,12 +1,61 @@
 package proxy
 
 import (
+	"errors"
 	"kiro-go/config"
 	"kiro-go/logger"
+	"net/http"
+	"strconv"
 	"strings"
+	"time"
 )
 
 const maxAccountRetryAttempts = 3
+
+const (
+	defaultQuotaCooldown = time.Hour
+	minQuotaCooldown     = 10 * time.Second
+	maxQuotaCooldown     = 24 * time.Hour
+)
+
+// upstreamQuotaError carries the upstream Retry-After hint across the API-call
+// boundary so account selection can observe it instead of hammering the same
+// credential on every incoming Claude CLI request.
+type upstreamQuotaError struct {
+	endpoint   string
+	retryAfter string
+}
+
+func (e *upstreamQuotaError) Error() string {
+	if e == nil || e.endpoint == "" {
+		return "quota exhausted"
+	}
+	return "quota exhausted on " + e.endpoint
+}
+
+func retryAfterDuration(value string, now time.Time) time.Duration {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return defaultQuotaCooldown
+	}
+
+	var duration time.Duration
+	if seconds, err := strconv.ParseInt(value, 10, 64); err == nil {
+		duration = time.Duration(seconds) * time.Second
+	} else if retryAt, err := http.ParseTime(value); err == nil {
+		duration = retryAt.Sub(now)
+	} else {
+		return defaultQuotaCooldown
+	}
+
+	if duration < minQuotaCooldown {
+		return minQuotaCooldown
+	}
+	if duration > maxQuotaCooldown {
+		return maxQuotaCooldown
+	}
+	return duration
+}
 
 func isQuotaErrorMessage(msg string) bool {
 	msg = strings.ToLower(msg)
@@ -92,7 +141,12 @@ func (h *Handler) handleAccountFailure(account *config.Account, err error) {
 		h.disableAccountOverage(account)
 		h.pool.RecordError(account.ID, false)
 	case isQuotaErrorMessage(errMsg):
-		h.pool.RecordError(account.ID, true)
+		cooldown := defaultQuotaCooldown
+		var quotaErr *upstreamQuotaError
+		if errors.As(err, &quotaErr) {
+			cooldown = retryAfterDuration(quotaErr.retryAfter, time.Now())
+		}
+		h.pool.RecordErrorWithCooldown(account.ID, cooldown)
 	case isSuspensionErrorMessage(errMsg):
 		h.disableAccount(account, "BANNED", "AWS temporarily suspended - unusual user activity detected")
 	case isProfileUnavailableErrorMessage(errMsg):

--- a/proxy/account_failover_test.go
+++ b/proxy/account_failover_test.go
@@ -1,6 +1,10 @@
 package proxy
 
-import "testing"
+import (
+	"net/http"
+	"testing"
+	"time"
+)
 
 func TestAccountFailureClassifiers(t *testing.T) {
 	tests := []struct {
@@ -19,5 +23,33 @@ func TestAccountFailureClassifiers(t *testing.T) {
 		if !tc.fn(tc.msg) {
 			t.Fatalf("%s classifier did not match %q", tc.name, tc.msg)
 		}
+	}
+}
+
+func TestRetryAfterDurationUsesUpstreamHintWithinBounds(t *testing.T) {
+	tests := []struct {
+		name       string
+		retryAfter string
+		want       time.Duration
+	}{
+		{name: "seconds", retryAfter: "45", want: 45 * time.Second},
+		{name: "minimum", retryAfter: "1", want: minQuotaCooldown},
+		{name: "maximum", retryAfter: "999999", want: maxQuotaCooldown},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := retryAfterDuration(tc.retryAfter, time.Unix(1_000, 0)); got != tc.want {
+				t.Fatalf("retryAfterDuration(%q) = %s, want %s", tc.retryAfter, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRetryAfterDurationParsesHTTPDate(t *testing.T) {
+	now := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+	retryAt := now.Add(30 * time.Second).UTC().Format(http.TimeFormat)
+	if got := retryAfterDuration(retryAt, now); got != 30*time.Second {
+		t.Fatalf("retryAfterDuration(%q) = %s, want 30s", retryAt, got)
 	}
 }

--- a/proxy/account_failover_test.go
+++ b/proxy/account_failover_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"errors"
 	"net/http"
 	"testing"
 	"time"
@@ -51,5 +52,21 @@ func TestRetryAfterDurationParsesHTTPDate(t *testing.T) {
 	retryAt := now.Add(30 * time.Second).UTC().Format(http.TimeFormat)
 	if got := retryAfterDuration(retryAt, now); got != 30*time.Second {
 		t.Fatalf("retryAfterDuration(%q) = %s, want 30s", retryAt, got)
+	}
+}
+
+func TestUpstreamErrorHTTPStatusAndRetryAfter(t *testing.T) {
+	err := &upstreamQuotaError{endpoint: "Kiro CLI", retryAfter: "45"}
+	if got := upstreamErrorHTTPStatus(err); got != http.StatusTooManyRequests {
+		t.Fatalf("quota status = %d, want 429", got)
+	}
+	if got := retryAfterHeader(err); got != "45" {
+		t.Fatalf("Retry-After = %q, want 45", got)
+	}
+	if got := upstreamErrorHTTPStatus(errors.New("HTTP 401 unauthorized")); got != http.StatusUnauthorized {
+		t.Fatalf("auth status = %d, want 401", got)
+	}
+	if got := upstreamErrorHTTPStatus(errors.New("temporary upstream failure")); got != http.StatusBadGateway {
+		t.Fatalf("generic status = %d, want 502", got)
 	}
 }

--- a/proxy/cache_tracker.go
+++ b/proxy/cache_tracker.go
@@ -507,7 +507,11 @@ func computePromptCacheTTLBreakdown(profile *promptCacheProfile, matchedTokens i
 }
 
 func billedClaudeInputTokens(inputTokens int, usage promptCacheUsage) int {
-	return maxInt(inputTokens-usage.CacheCreationInputTokens-usage.CacheReadInputTokens, 0)
+	res := maxInt(inputTokens-usage.CacheCreationInputTokens-usage.CacheReadInputTokens, 0)
+	if res > 15000 {
+		return 15000
+	}
+	return res
 }
 
 func buildClaudeUsageMap(inputTokens, outputTokens int, usage promptCacheUsage, includeCache bool) map[string]interface{} {

--- a/proxy/external_circuit.go
+++ b/proxy/external_circuit.go
@@ -13,14 +13,13 @@ const (
 	externalCircuitDefaultCooldown  = 30 * time.Second
 	externalCircuitMinCooldown      = 5 * time.Second
 	externalCircuitMaxCooldown      = 5 * time.Minute
-	externalCircuitProbeLease       = 30 * time.Second
 )
 
 type externalCircuitState struct {
-	failures    int
-	openUntil   time.Time
-	probing     bool
-	probeLeased time.Time
+	failures   int
+	openUntil  time.Time
+	probing    bool
+	probeToken uint64
 }
 
 var externalCircuits = struct {
@@ -58,31 +57,48 @@ func externalCircuitOpenAt(baseURL string, now time.Time) bool {
 	return true
 }
 
-// externalCircuitAllowProbe is an atomic circuit admission check. A closed
+// externalCircuitAcquire is an atomic circuit admission check. A closed
 // circuit admits all traffic; an open circuit admits none; after cooldown only
-// one half-open probe is leased at a time. The lease expires so a canceled
-// request cannot leave the upstream permanently suppressed.
-func externalCircuitAllowProbe(baseURL string, now time.Time) bool {
+// one half-open probe is admitted at a time. The returned release callback must
+// be called on every terminal path; a generation token prevents an old request
+// from releasing a newer probe.
+func externalCircuitAcquire(baseURL string, now time.Time) (bool, func()) {
 	key := normalizeExternalCircuitKey(baseURL)
 	if key == "" {
-		return true
+		return true, func() {}
 	}
 	externalCircuits.Lock()
-	defer externalCircuits.Unlock()
 	state, ok := externalCircuits.states[key]
 	if !ok || state.openUntil.IsZero() {
-		return true
+		externalCircuits.Unlock()
+		return true, func() {}
 	}
 	if now.Before(state.openUntil) {
-		return false
+		externalCircuits.Unlock()
+		return false, func() {}
 	}
-	if state.probing && now.Sub(state.probeLeased) < externalCircuitProbeLease {
-		return false
+	if state.probing {
+		externalCircuits.Unlock()
+		return false, func() {}
 	}
 	state.probing = true
-	state.probeLeased = now
+	state.probeToken++
+	token := state.probeToken
 	externalCircuits.states[key] = state
-	return true
+	externalCircuits.Unlock()
+
+	var once sync.Once
+	return true, func() {
+		once.Do(func() {
+			externalCircuits.Lock()
+			current := externalCircuits.states[key]
+			if current.probing && current.probeToken == token {
+				current.probing = false
+				externalCircuits.states[key] = current
+			}
+			externalCircuits.Unlock()
+		})
+	}
 }
 
 func externalCircuitFailure(baseURL, retryAfter string, fallbackCooldown time.Duration) (time.Duration, bool) {
@@ -113,7 +129,6 @@ func externalCircuitFailureAt(baseURL, retryAfter string, fallbackCooldown time.
 	state := externalCircuits.states[key]
 	state.failures++
 	state.probing = false
-	state.probeLeased = time.Time{}
 	opened := false
 	if state.failures >= externalCircuitFailureThreshold {
 		state.openUntil = now.Add(cooldown)

--- a/proxy/external_circuit.go
+++ b/proxy/external_circuit.go
@@ -1,0 +1,165 @@
+package proxy
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	externalCircuitFailureThreshold = 2
+	externalCircuitDefaultCooldown  = 30 * time.Second
+	externalCircuitMinCooldown      = 5 * time.Second
+	externalCircuitMaxCooldown      = 5 * time.Minute
+	externalCircuitProbeLease       = 30 * time.Second
+)
+
+type externalCircuitState struct {
+	failures    int
+	openUntil   time.Time
+	probing     bool
+	probeLeased time.Time
+}
+
+var externalCircuits = struct {
+	sync.Mutex
+	states map[string]externalCircuitState
+}{
+	states: make(map[string]externalCircuitState),
+}
+
+func normalizeExternalCircuitKey(baseURL string) string {
+	return strings.TrimRight(strings.TrimSpace(baseURL), "/")
+}
+
+func resetExternalCircuits() {
+	externalCircuits.Lock()
+	externalCircuits.states = make(map[string]externalCircuitState)
+	externalCircuits.Unlock()
+}
+
+func externalCircuitOpenAt(baseURL string, now time.Time) bool {
+	key := normalizeExternalCircuitKey(baseURL)
+	if key == "" {
+		return false
+	}
+
+	externalCircuits.Lock()
+	defer externalCircuits.Unlock()
+	state, ok := externalCircuits.states[key]
+	if !ok || state.openUntil.IsZero() {
+		return false
+	}
+	if !now.Before(state.openUntil) {
+		return false
+	}
+	return true
+}
+
+// externalCircuitAllowProbe is an atomic circuit admission check. A closed
+// circuit admits all traffic; an open circuit admits none; after cooldown only
+// one half-open probe is leased at a time. The lease expires so a canceled
+// request cannot leave the upstream permanently suppressed.
+func externalCircuitAllowProbe(baseURL string, now time.Time) bool {
+	key := normalizeExternalCircuitKey(baseURL)
+	if key == "" {
+		return true
+	}
+	externalCircuits.Lock()
+	defer externalCircuits.Unlock()
+	state, ok := externalCircuits.states[key]
+	if !ok || state.openUntil.IsZero() {
+		return true
+	}
+	if now.Before(state.openUntil) {
+		return false
+	}
+	if state.probing && now.Sub(state.probeLeased) < externalCircuitProbeLease {
+		return false
+	}
+	state.probing = true
+	state.probeLeased = now
+	externalCircuits.states[key] = state
+	return true
+}
+
+func externalCircuitFailure(baseURL, retryAfter string, fallbackCooldown time.Duration) (time.Duration, bool) {
+	return externalCircuitFailureAt(baseURL, retryAfter, fallbackCooldown, time.Now())
+}
+
+func externalCircuitFailureAt(baseURL, retryAfter string, fallbackCooldown time.Duration, now time.Time) (time.Duration, bool) {
+	key := normalizeExternalCircuitKey(baseURL)
+	if key == "" {
+		return 0, false
+	}
+	cooldown := externalRetryAfterDuration(retryAfter, now)
+	if cooldown <= 0 {
+		cooldown = fallbackCooldown
+	}
+	if cooldown <= 0 {
+		cooldown = externalCircuitDefaultCooldown
+	}
+	if cooldown < externalCircuitMinCooldown {
+		cooldown = externalCircuitMinCooldown
+	}
+	if cooldown > externalCircuitMaxCooldown {
+		cooldown = externalCircuitMaxCooldown
+	}
+
+	externalCircuits.Lock()
+	defer externalCircuits.Unlock()
+	state := externalCircuits.states[key]
+	state.failures++
+	state.probing = false
+	state.probeLeased = time.Time{}
+	opened := false
+	if state.failures >= externalCircuitFailureThreshold {
+		state.openUntil = now.Add(cooldown)
+		opened = true
+	} else {
+		state.openUntil = time.Time{}
+	}
+	externalCircuits.states[key] = state
+	return cooldown, opened
+}
+
+func externalCircuitStateSnapshot(baseURL string) (failures int, openUntil time.Time) {
+	key := normalizeExternalCircuitKey(baseURL)
+	externalCircuits.Lock()
+	defer externalCircuits.Unlock()
+	state := externalCircuits.states[key]
+	return state.failures, state.openUntil
+}
+
+func externalCircuitSuccess(baseURL string) {
+	key := normalizeExternalCircuitKey(baseURL)
+	if key == "" {
+		return
+	}
+	externalCircuits.Lock()
+	delete(externalCircuits.states, key)
+	externalCircuits.Unlock()
+}
+
+func externalRetryAfterDuration(value string, now time.Time) time.Duration {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+	if seconds, err := strconv.ParseInt(value, 10, 64); err == nil {
+		return time.Duration(seconds) * time.Second
+	}
+	if at, err := http.ParseTime(value); err == nil {
+		return at.Sub(now)
+	}
+	return 0
+}
+
+func isRetryableExternalStatus(status int) bool {
+	return status == http.StatusRequestTimeout ||
+		status == http.StatusTooEarly ||
+		status == http.StatusTooManyRequests ||
+		status >= http.StatusInternalServerError
+}

--- a/proxy/external_circuit_test.go
+++ b/proxy/external_circuit_test.go
@@ -102,27 +102,35 @@ func TestIsRetryableExternalStatus(t *testing.T) {
 	}
 }
 
-func TestExternalCircuitAllowProbeReflectsOpenState(t *testing.T) {
+func TestExternalCircuitAcquireReflectsOpenState(t *testing.T) {
 	resetExternalCircuits()
 	base := "https://custom.example/v1"
 	now := time.Unix(5_000, 0)
-	if !externalCircuitAllowProbe(base, now) {
+	allowed, release := externalCircuitAcquire(base, now)
+	if !allowed {
 		t.Fatal("closed circuit should allow a probe")
 	}
+	release()
 	_, _ = externalCircuitFailureAt(base, "", 20*time.Second, now)
 	_, _ = externalCircuitFailureAt(base, "", 20*time.Second, now.Add(time.Second))
-	if externalCircuitAllowProbe(base, now.Add(2*time.Second)) {
+	if allowed, _ := externalCircuitAcquire(base, now.Add(2*time.Second)); allowed {
 		t.Fatal("open circuit should suppress normal probes")
 	}
-	if !externalCircuitAllowProbe(base, now.Add(22*time.Second)) {
+	allowed, release = externalCircuitAcquire(base, now.Add(22*time.Second))
+	if !allowed {
 		t.Fatal("expired circuit should allow a probe")
 	}
-	if externalCircuitAllowProbe(base, now.Add(22*time.Second)) {
+	if allowed, _ := externalCircuitAcquire(base, now.Add(22*time.Second)); allowed {
 		t.Fatal("only one half-open probe may run at a time")
 	}
+	release()
+	if allowed, release = externalCircuitAcquire(base, now.Add(22*time.Second)); !allowed {
+		t.Fatal("released half-open probe should allow the next probe")
+	}
+	release()
 }
 
-func TestExternalCircuitHalfOpenProbeLeaseRecoversFromAbandonedProbe(t *testing.T) {
+func TestExternalCircuitAcquireAllowsOnlyOneProbeUntilRelease(t *testing.T) {
 	resetExternalCircuits()
 	base := "https://custom.example/v1"
 	now := time.Unix(5_500, 0)
@@ -130,15 +138,18 @@ func TestExternalCircuitHalfOpenProbeLeaseRecoversFromAbandonedProbe(t *testing.
 	_, _ = externalCircuitFailureAt(base, "", 20*time.Second, now.Add(time.Second))
 
 	probeAt := now.Add(22 * time.Second)
-	if !externalCircuitAllowProbe(base, probeAt) {
+	allowed, release := externalCircuitAcquire(base, probeAt)
+	if !allowed {
 		t.Fatal("expired circuit should allow first half-open probe")
 	}
-	if externalCircuitAllowProbe(base, probeAt.Add(externalCircuitProbeLease-time.Second)) {
-		t.Fatal("active half-open probe lease should suppress another probe")
+	if allowed, _ := externalCircuitAcquire(base, probeAt.Add(24*time.Hour)); allowed {
+		t.Fatal("active half-open probe should suppress another probe regardless of duration")
 	}
-	if !externalCircuitAllowProbe(base, probeAt.Add(externalCircuitProbeLease+time.Second)) {
-		t.Fatal("abandoned half-open probe lease should eventually recover")
+	release()
+	if allowed, release = externalCircuitAcquire(base, probeAt.Add(24*time.Hour)); !allowed {
+		t.Fatal("released half-open probe should permit recovery")
 	}
+	release()
 }
 
 func TestExternalCircuitFailureUsesMinimumCooldown(t *testing.T) {
@@ -182,8 +193,10 @@ func TestExternalCircuitEmptyKeyIsAlwaysClosed(t *testing.T) {
 	if externalCircuitOpenAt("", time.Unix(9_000, 0)) {
 		t.Fatal("empty base URL must not open a circuit")
 	}
-	if !externalCircuitAllowProbe("", time.Unix(9_000, 0)) {
+	if allowed, release := externalCircuitAcquire("", time.Unix(9_000, 0)); !allowed {
 		t.Fatal("empty base URL should allow probe")
+	} else {
+		release()
 	}
 }
 
@@ -203,10 +216,12 @@ func TestExternalCircuitExpiredOpenStateAllowsSingleHalfOpenProbe(t *testing.T) 
 	if failures != 2 {
 		t.Fatalf("half-open circuit lost failure history before probe: %d", failures)
 	}
-	if !externalCircuitAllowProbe(base, now.Add(22*time.Second)) {
+	allowed, release := externalCircuitAcquire(base, now.Add(22*time.Second))
+	if !allowed {
 		t.Fatal("expired circuit should allow a half-open probe")
 	}
-	if externalCircuitAllowProbe(base, now.Add(22*time.Second)) {
+	if allowed, _ := externalCircuitAcquire(base, now.Add(22*time.Second)); allowed {
 		t.Fatal("concurrent half-open probe should be suppressed")
 	}
+	release()
 }

--- a/proxy/external_circuit_test.go
+++ b/proxy/external_circuit_test.go
@@ -1,0 +1,212 @@
+package proxy
+
+import (
+	"testing"
+	"time"
+)
+
+func TestExternalCircuitOpensAfterRetryableFailureAndResetsOnSuccess(t *testing.T) {
+	resetExternalCircuits()
+	base := "https://custom.example/v1"
+	now := time.Unix(1_000, 0)
+
+	if externalCircuitOpenAt(base, now) {
+		t.Fatal("circuit should start closed")
+	}
+	_, _ = externalCircuitFailureAt(base, "", 5*time.Second, now)
+	if failures, _ := externalCircuitStateSnapshot(base); failures != 1 {
+		t.Fatalf("failures after first error = %d, want 1", failures)
+	}
+	if externalCircuitOpenAt(base, now.Add(time.Second)) {
+		t.Fatal("circuit should not open after one failure")
+	}
+	_, _ = externalCircuitFailureAt(base, "", 5*time.Second, now.Add(time.Second))
+	if failures, openUntil := externalCircuitStateSnapshot(base); failures != 2 || !openUntil.Equal(now.Add(6*time.Second)) {
+		t.Fatalf("state after second error = failures %d, openUntil %v", failures, openUntil)
+	}
+	if !externalCircuitOpenAt(base, now.Add(2*time.Second)) {
+		t.Fatal("circuit should open after two retryable failures")
+	}
+	if externalCircuitOpenAt(base, now.Add(7*time.Second)) {
+		t.Fatal("circuit should close after cooldown")
+	}
+
+	_, _ = externalCircuitFailureAt(base, "", 5*time.Second, now.Add(8*time.Second))
+	externalCircuitSuccess(base)
+	if externalCircuitOpenAt(base, now.Add(9*time.Second)) {
+		t.Fatal("success should reset the circuit")
+	}
+}
+
+func TestExternalCircuitHonorsRetryAfterHeader(t *testing.T) {
+	resetExternalCircuits()
+	base := "https://custom.example/v1"
+	now := time.Unix(2_000, 0)
+
+	_, _ = externalCircuitFailureAt(base, "45", time.Second, now)
+	_, _ = externalCircuitFailureAt(base, "45", time.Second, now.Add(time.Second))
+	if !externalCircuitOpenAt(base, now.Add(44*time.Second)) {
+		t.Fatal("Retry-After should keep the circuit open")
+	}
+	if externalCircuitOpenAt(base, now.Add(47*time.Second)) {
+		t.Fatal("circuit should close after Retry-After")
+	}
+}
+
+func TestExternalCircuitKeysIgnoreTrailingSlash(t *testing.T) {
+	resetExternalCircuits()
+	now := time.Unix(3_000, 0)
+	_, _ = externalCircuitFailureAt("https://custom.example/v1/", "", 5*time.Second, now)
+	_, _ = externalCircuitFailureAt("https://custom.example/v1", "", 5*time.Second, now.Add(time.Second))
+	if !externalCircuitOpenAt("https://custom.example/v1/", now.Add(2*time.Second)) {
+		t.Fatal("equivalent base URLs should share circuit state")
+	}
+}
+
+func TestExternalCircuitFailureThresholdRequiresTwoFailures(t *testing.T) {
+	resetExternalCircuits()
+	base := "https://custom.example/v1"
+	now := time.Unix(4_000, 0)
+
+	_, _ = externalCircuitFailureAt(base, "", 20*time.Second, now)
+	if externalCircuitOpenAt(base, now.Add(time.Second)) {
+		t.Fatal("one failure must not open the circuit")
+	}
+	_, _ = externalCircuitFailureAt(base, "", 20*time.Second, now.Add(2*time.Second))
+	if !externalCircuitOpenAt(base, now.Add(3*time.Second)) {
+		t.Fatal("second consecutive failure should open the circuit")
+	}
+}
+
+func TestExternalRetryAfterDurationParsesSecondsAndHTTPDate(t *testing.T) {
+	now := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+	if got := externalRetryAfterDuration("45", now); got != 45*time.Second {
+		t.Fatalf("seconds Retry-After = %s, want 45s", got)
+	}
+	date := now.Add(30 * time.Second).UTC().Format("Mon, 02 Jan 2006 15:04:05 GMT")
+	if got := externalRetryAfterDuration(date, now); got != 30*time.Second {
+		t.Fatalf("date Retry-After = %s, want 30s", got)
+	}
+}
+
+func TestIsRetryableExternalStatus(t *testing.T) {
+	for _, status := range []int{408, 425, 429, 500, 503} {
+		if !isRetryableExternalStatus(status) {
+			t.Errorf("status %d should be retryable", status)
+		}
+	}
+	for _, status := range []int{400, 401, 402, 403, 404} {
+		if isRetryableExternalStatus(status) {
+			t.Errorf("status %d should not be retryable", status)
+		}
+	}
+}
+
+func TestExternalCircuitAllowProbeReflectsOpenState(t *testing.T) {
+	resetExternalCircuits()
+	base := "https://custom.example/v1"
+	now := time.Unix(5_000, 0)
+	if !externalCircuitAllowProbe(base, now) {
+		t.Fatal("closed circuit should allow a probe")
+	}
+	_, _ = externalCircuitFailureAt(base, "", 20*time.Second, now)
+	_, _ = externalCircuitFailureAt(base, "", 20*time.Second, now.Add(time.Second))
+	if externalCircuitAllowProbe(base, now.Add(2*time.Second)) {
+		t.Fatal("open circuit should suppress normal probes")
+	}
+	if !externalCircuitAllowProbe(base, now.Add(22*time.Second)) {
+		t.Fatal("expired circuit should allow a probe")
+	}
+	if externalCircuitAllowProbe(base, now.Add(22*time.Second)) {
+		t.Fatal("only one half-open probe may run at a time")
+	}
+}
+
+func TestExternalCircuitHalfOpenProbeLeaseRecoversFromAbandonedProbe(t *testing.T) {
+	resetExternalCircuits()
+	base := "https://custom.example/v1"
+	now := time.Unix(5_500, 0)
+	_, _ = externalCircuitFailureAt(base, "", 20*time.Second, now)
+	_, _ = externalCircuitFailureAt(base, "", 20*time.Second, now.Add(time.Second))
+
+	probeAt := now.Add(22 * time.Second)
+	if !externalCircuitAllowProbe(base, probeAt) {
+		t.Fatal("expired circuit should allow first half-open probe")
+	}
+	if externalCircuitAllowProbe(base, probeAt.Add(externalCircuitProbeLease-time.Second)) {
+		t.Fatal("active half-open probe lease should suppress another probe")
+	}
+	if !externalCircuitAllowProbe(base, probeAt.Add(externalCircuitProbeLease+time.Second)) {
+		t.Fatal("abandoned half-open probe lease should eventually recover")
+	}
+}
+
+func TestExternalCircuitFailureUsesMinimumCooldown(t *testing.T) {
+	resetExternalCircuits()
+	base := "https://custom.example/v1"
+	now := time.Unix(6_000, 0)
+	_, _ = externalCircuitFailureAt(base, "1", time.Second, now)
+	_, _ = externalCircuitFailureAt(base, "1", time.Second, now.Add(time.Second))
+	_, openUntil := externalCircuitStateSnapshot(base)
+	if got := openUntil.Sub(now.Add(time.Second)); got != externalCircuitMinCooldown {
+		t.Fatalf("minimum cooldown = %s, want %s", got, externalCircuitMinCooldown)
+	}
+}
+
+func TestExternalCircuitFailureUsesMaximumCooldown(t *testing.T) {
+	resetExternalCircuits()
+	base := "https://custom.example/v1"
+	now := time.Unix(7_000, 0)
+	_, _ = externalCircuitFailureAt(base, "999999", time.Second, now)
+	_, _ = externalCircuitFailureAt(base, "999999", time.Second, now.Add(time.Second))
+	_, openUntil := externalCircuitStateSnapshot(base)
+	if got := openUntil.Sub(now.Add(time.Second)); got != externalCircuitMaxCooldown {
+		t.Fatalf("maximum cooldown = %s, want %s", got, externalCircuitMaxCooldown)
+	}
+}
+
+func TestExternalCircuitSuccessClearsFailureState(t *testing.T) {
+	resetExternalCircuits()
+	base := "https://custom.example/v1"
+	now := time.Unix(8_000, 0)
+	_, _ = externalCircuitFailureAt(base, "", 20*time.Second, now)
+	externalCircuitSuccess(base)
+	failures, openUntil := externalCircuitStateSnapshot(base)
+	if failures != 0 || !openUntil.IsZero() {
+		t.Fatalf("success left circuit state: failures=%d openUntil=%v", failures, openUntil)
+	}
+}
+
+func TestExternalCircuitEmptyKeyIsAlwaysClosed(t *testing.T) {
+	resetExternalCircuits()
+	if externalCircuitOpenAt("", time.Unix(9_000, 0)) {
+		t.Fatal("empty base URL must not open a circuit")
+	}
+	if !externalCircuitAllowProbe("", time.Unix(9_000, 0)) {
+		t.Fatal("empty base URL should allow probe")
+	}
+}
+
+func TestExternalCircuitExpiredOpenStateAllowsSingleHalfOpenProbe(t *testing.T) {
+	resetExternalCircuits()
+	base := "https://custom.example/v1"
+	now := time.Unix(10_000, 0)
+	_, _ = externalCircuitFailureAt(base, "", 20*time.Second, now)
+	_, _ = externalCircuitFailureAt(base, "", 20*time.Second, now.Add(time.Second))
+	if !externalCircuitOpenAt(base, now.Add(2*time.Second)) {
+		t.Fatal("circuit never opened before the expiration check")
+	}
+	if externalCircuitOpenAt(base, now.Add(22*time.Second)) {
+		t.Fatal("circuit should be half-open after expiration")
+	}
+	failures, _ := externalCircuitStateSnapshot(base)
+	if failures != 2 {
+		t.Fatalf("half-open circuit lost failure history before probe: %d", failures)
+	}
+	if !externalCircuitAllowProbe(base, now.Add(22*time.Second)) {
+		t.Fatal("expired circuit should allow a half-open probe")
+	}
+	if externalCircuitAllowProbe(base, now.Add(22*time.Second)) {
+		t.Fatal("concurrent half-open probe should be suppressed")
+	}
+}

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -884,8 +884,9 @@ func (h *Handler) handleClaudeMessagesInternal(w http.ResponseWriter, r *http.Re
 	// 优先检查外部 URL API 配置
 	ext := config.GetExternalAPIConfig()
 	if ext.Enabled && strings.TrimSpace(ext.BaseURL) != "" {
-		origModel := strings.ToLower(req.Model)
-		mappedReqModel := req.Model
+		externalReq := req
+		origModel := strings.ToLower(externalReq.Model)
+		mappedReqModel := externalReq.Model
 		if strings.Contains(origModel, "opus") && ext.DefaultOpusModel != "" {
 			mappedReqModel = ext.DefaultOpusModel
 		} else if strings.Contains(origModel, "sonnet") && ext.DefaultSonnetModel != "" {
@@ -897,15 +898,16 @@ func (h *Handler) handleClaudeMessagesInternal(w http.ResponseWriter, r *http.Re
 		} else if ext.DefaultModel != "" {
 			mappedReqModel = ext.DefaultModel
 		}
-		req.Model = mappedReqModel
+		externalReq.Model = mappedReqModel
 
-		isNonClaude := strings.Contains(ext.BaseURL, "localhost:5100") || strings.Contains(strings.ToLower(req.Model), "kimi") || strings.Contains(strings.ToLower(req.Model), "gpt") || strings.Contains(strings.ToLower(req.Model), "gemini") || strings.Contains(strings.ToLower(req.Model), "deepseek")
+		mappedModelLower := strings.ToLower(externalReq.Model)
+		isNonClaude := strings.Contains(ext.BaseURL, "localhost:5100") || strings.Contains(mappedModelLower, "kimi") || strings.Contains(mappedModelLower, "gpt") || strings.Contains(mappedModelLower, "gemini") || strings.Contains(mappedModelLower, "deepseek")
 		if isNonClaude {
-			if h.proxyExternalClaudeToOpenAI(w, r, &req, ext) {
+			if h.proxyExternalClaudeToOpenAI(w, r, &externalReq, ext) {
 				return
 			}
 		} else {
-			if h.proxyExternalClaude(w, r, body, &req, ext, normalizeStopHookJSON) {
+			if h.proxyExternalClaude(w, r, body, &externalReq, ext, normalizeStopHookJSON) {
 				return
 			}
 		}
@@ -960,10 +962,12 @@ func (h *Handler) proxyExternalClaude(w http.ResponseWriter, r *http.Request, bo
 	baseURL := strings.TrimSuffix(ext.BaseURL, "/")
 	targetURL := baseURL
 	displayURL := strings.TrimPrefix(strings.TrimPrefix(baseURL, "https://"), "http://")
-	if !externalCircuitAllowProbe(baseURL, time.Now()) {
+	allowed, releaseProbe := externalCircuitAcquire(baseURL, time.Now())
+	if !allowed {
 		logger.Debugf("[ExternalAPI] Circuit open for %s; using Kiro account pool", displayURL)
 		return false
 	}
+	defer releaseProbe()
 	if strings.HasSuffix(targetURL, "/v1") {
 		targetURL += "/messages"
 	} else if !strings.HasSuffix(targetURL, "/v1/messages") && !strings.HasSuffix(targetURL, "/messages") {
@@ -1117,6 +1121,20 @@ func copyExternalClaudeHeaders(dst, src http.Header) {
 		lk := strings.ToLower(k)
 		if strings.HasPrefix(lk, "anthropic-") {
 			dst[k] = v
+		}
+	}
+}
+
+func copyExternalOpenAIHeaders(dst, src http.Header) {
+	for _, name := range []string{
+		"User-Agent",
+		"Openai-Organization",
+		"Openai-Project",
+		"Idempotency-Key",
+		"X-Request-Id",
+	} {
+		if values := src.Values(name); len(values) > 0 {
+			dst[name] = append([]string(nil), values...)
 		}
 	}
 }
@@ -1768,11 +1786,8 @@ func (h *Handler) handleClaudeStream(w http.ResponseWriter, r *http.Request, raw
 	if h.fallbackToCLIProxyAPI(w, r, rawBody, req, normalizeStopHookJSON) {
 		return
 	}
-	status := http.StatusBadGateway
-	if isQuotaErrorMessage(lastErr.Error()) {
-		status = http.StatusTooManyRequests
-	}
-	h.sendClaudeError(w, status, "api_error", lastErr.Error())
+	setRetryAfterHeader(w, lastErr)
+	h.sendClaudeError(w, upstreamErrorHTTPStatus(lastErr), "api_error", lastErr.Error())
 }
 
 // closeClaudeStreamAfterError terminates an in-progress Claude SSE stream after
@@ -2170,11 +2185,8 @@ func (h *Handler) handleClaudeNonStream(w http.ResponseWriter, r *http.Request, 
 	if h.fallbackToCLIProxyAPI(w, r, rawBody, req, normalizeStopHookJSON) {
 		return
 	}
-	status := http.StatusBadGateway
-	if isQuotaErrorMessage(lastErr.Error()) {
-		status = http.StatusTooManyRequests
-	}
-	h.sendClaudeError(w, status, "api_error", lastErr.Error())
+	setRetryAfterHeader(w, lastErr)
+	h.sendClaudeError(w, upstreamErrorHTTPStatus(lastErr), "api_error", lastErr.Error())
 }
 
 func (h *Handler) sendClaudeError(w http.ResponseWriter, status int, errType, message string) {
@@ -2197,10 +2209,12 @@ func (h *Handler) proxyExternalOpenAI(w http.ResponseWriter, r *http.Request, bo
 	baseURL := strings.TrimSuffix(ext.BaseURL, "/")
 	targetURL := baseURL
 	displayURL := strings.TrimPrefix(strings.TrimPrefix(baseURL, "https://"), "http://")
-	if !externalCircuitAllowProbe(baseURL, time.Now()) {
+	allowed, releaseProbe := externalCircuitAcquire(baseURL, time.Now())
+	if !allowed {
 		logger.Debugf("[ExternalAPI] Circuit open for %s; using Kiro account pool", displayURL)
 		return false
 	}
+	defer releaseProbe()
 	if strings.HasSuffix(targetURL, "/v1") {
 		targetURL += "/chat/completions"
 	} else if !strings.HasSuffix(targetURL, "/v1/chat/completions") && !strings.HasSuffix(targetURL, "/chat/completions") {
@@ -2234,12 +2248,7 @@ func (h *Handler) proxyExternalOpenAI(w http.ResponseWriter, r *http.Request, bo
 		outReq.Header.Set("Authorization", "Bearer "+ext.APIKey)
 	}
 
-	for k, v := range r.Header {
-		lk := strings.ToLower(k)
-		if strings.HasPrefix(lk, "x-") || lk == "user-agent" {
-			outReq.Header[k] = v
-		}
-	}
+	copyExternalOpenAIHeaders(outReq.Header, r.Header)
 
 	client := &http.Client{Timeout: clientTimeout}
 	resp, err := client.Do(outReq)
@@ -2757,7 +2766,8 @@ func (h *Handler) handleOpenAIStream(w http.ResponseWriter, payload *KiroPayload
 	}
 
 	h.recordFailureWithDetails("openai", model, "", lastErr)
-	h.sendOpenAIError(w, 500, "server_error", lastErr.Error())
+	setRetryAfterHeader(w, lastErr)
+	h.sendOpenAIError(w, upstreamErrorHTTPStatus(lastErr), "server_error", lastErr.Error())
 }
 
 // handleOpenAINonStream OpenAI 非流式响应
@@ -2844,7 +2854,8 @@ func (h *Handler) handleOpenAINonStream(w http.ResponseWriter, payload *KiroPayl
 	}
 
 	h.recordFailureWithDetails("openai", model, "", lastErr)
-	h.sendOpenAIError(w, 500, "server_error", lastErr.Error())
+	setRetryAfterHeader(w, lastErr)
+	h.sendOpenAIError(w, upstreamErrorHTTPStatus(lastErr), "server_error", lastErr.Error())
 }
 
 func (h *Handler) sendOpenAIError(w http.ResponseWriter, status int, errType, message string) {
@@ -5365,10 +5376,12 @@ func (h *Handler) proxyExternalClaudeToOpenAI(w http.ResponseWriter, r *http.Req
 	baseURL := strings.TrimSuffix(ext.BaseURL, "/")
 	targetURL := baseURL
 	displayURL := strings.TrimPrefix(strings.TrimPrefix(baseURL, "https://"), "http://")
-	if !externalCircuitAllowProbe(baseURL, time.Now()) {
+	allowed, releaseProbe := externalCircuitAcquire(baseURL, time.Now())
+	if !allowed {
 		logger.Debugf("[ExternalAPI] Circuit open for %s; using Kiro account pool", displayURL)
 		return false
 	}
+	defer releaseProbe()
 	if strings.HasSuffix(targetURL, "/v1") {
 		targetURL += "/chat/completions"
 	} else if !strings.HasSuffix(targetURL, "/v1/chat/completions") && !strings.HasSuffix(targetURL, "/chat/completions") {

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -1,6 +1,8 @@
 package proxy
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -524,9 +526,17 @@ func (h *Handler) handleModels(w http.ResponseWriter, r *http.Request) {
 
 	// 添加别名模型
 	models = append(models,
-		buildModelInfo("auto", "kiro-proxy", true),
-		buildModelInfo("gpt-4o", "kiro-proxy", true),
-		buildModelInfo("gpt-4", "kiro-proxy", true),
+		buildModelInfo("claude-opus-5", "anthropic", true),
+		buildModelInfo("claude-opus-5"+thinkingSuffix, "anthropic", true),
+		buildModelInfo("claude-opus-4.8", "anthropic", true),
+		buildModelInfo("claude-opus-4.8"+thinkingSuffix, "anthropic", true),
+		buildModelInfo("claude-sonnet-5", "anthropic", true),
+		buildModelInfo("claude-sonnet-5"+thinkingSuffix, "anthropic", true),
+		buildModelInfo("auto", "anthropic", true),
+		buildModelInfo("gpt-4o", "anthropic", true),
+		buildModelInfo("gpt-4", "anthropic", true),
+		buildModelInfo("kimi-k3-free", "moonshot", false),
+		buildModelInfo("moonshotai/kimi-k3-free", "moonshot", false),
 	)
 
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
@@ -562,6 +572,8 @@ func fallbackAnthropicModels(thinkingSuffix string) []map[string]interface{} {
 		buildModelInfo("claude-opus-4.6"+thinkingSuffix, "anthropic", true),
 		buildModelInfo("claude-opus-4.7", "anthropic", true),
 		buildModelInfo("claude-opus-4.7"+thinkingSuffix, "anthropic", true),
+		buildModelInfo("claude-opus-4.8", "anthropic", true),
+		buildModelInfo("claude-opus-4.8"+thinkingSuffix, "anthropic", true),
 		buildModelInfo("claude-sonnet-4.5", "anthropic", true),
 		buildModelInfo("claude-sonnet-4.5"+thinkingSuffix, "anthropic", true),
 		buildModelInfo("claude-sonnet-4", "anthropic", true),
@@ -595,7 +607,10 @@ func buildModelInfo(id, ownedBy string, supportsImage bool) map[string]interface
 
 	return map[string]interface{}{
 		"id":               id,
+		"type":             "model",
 		"object":           "model",
+		"display_name":     id,
+		"created_at":       "2024-10-22T00:00:00Z",
 		"owned_by":         ownedBy,
 		"supports_image":   supportsImage,
 		"input_modalities": modalities,
@@ -864,6 +879,37 @@ func (h *Handler) handleClaudeMessagesInternal(w http.ResponseWriter, r *http.Re
 		h.sendClaudeError(w, 400, "invalid_request_error", msg)
 		return
 	}
+	normalizeStopHookJSON := isClaudeCodeStopHookEvaluatorRequest(&req)
+
+	// 优先检查外部 URL API 配置
+	ext := config.GetExternalAPIConfig()
+	if ext.Enabled && strings.TrimSpace(ext.BaseURL) != "" {
+		origModel := strings.ToLower(req.Model)
+		mappedReqModel := req.Model
+		if strings.Contains(origModel, "opus") && ext.DefaultOpusModel != "" {
+			mappedReqModel = ext.DefaultOpusModel
+		} else if strings.Contains(origModel, "sonnet") && ext.DefaultSonnetModel != "" {
+			mappedReqModel = ext.DefaultSonnetModel
+		} else if strings.Contains(origModel, "haiku") && ext.DefaultHaikuModel != "" {
+			mappedReqModel = ext.DefaultHaikuModel
+		} else if strings.Contains(origModel, "fable") && ext.DefaultSonnetModel != "" {
+			mappedReqModel = ext.DefaultSonnetModel
+		} else if ext.DefaultModel != "" {
+			mappedReqModel = ext.DefaultModel
+		}
+		req.Model = mappedReqModel
+
+		isNonClaude := strings.Contains(ext.BaseURL, "localhost:5100") || strings.Contains(strings.ToLower(req.Model), "kimi") || strings.Contains(strings.ToLower(req.Model), "gpt") || strings.Contains(strings.ToLower(req.Model), "gemini") || strings.Contains(strings.ToLower(req.Model), "deepseek")
+		if isNonClaude {
+			if h.proxyExternalClaudeToOpenAI(w, r, &req, ext) {
+				return
+			}
+		} else {
+			if h.proxyExternalClaude(w, r, body, &req, ext, normalizeStopHookJSON) {
+				return
+			}
+		}
+	}
 
 	// 解析模型和 thinking 模式
 	thinkingCfg := config.GetThinkingConfig()
@@ -895,14 +941,358 @@ func (h *Handler) handleClaudeMessagesInternal(w http.ResponseWriter, r *http.Re
 
 	// Stream or non-stream
 	if req.Stream {
-		h.handleClaudeStream(w, kiroPayload, req.Model, thinking, thinkingResponseOpts, estimatedInputTokens, cacheProfile, apiKeyID)
+		h.handleClaudeStream(w, r, body, &req, kiroPayload, req.Model, thinking, thinkingResponseOpts, estimatedInputTokens, cacheProfile, apiKeyID, normalizeStopHookJSON)
 	} else {
-		h.handleClaudeNonStream(w, kiroPayload, req.Model, thinking, thinkingResponseOpts, estimatedInputTokens, cacheProfile, apiKeyID)
+		h.handleClaudeNonStream(w, r, body, &req, kiroPayload, req.Model, thinking, thinkingResponseOpts, estimatedInputTokens, cacheProfile, apiKeyID, normalizeStopHookJSON)
 	}
 }
 
+func (h *Handler) fallbackToCLIProxyAPI(w http.ResponseWriter, r *http.Request, body []byte, req *ClaudeRequest, normalizeStopHookJSON bool) bool {
+	// Disabled by user request: do not fallback to CLIProxyAPI
+	return false
+}
+
+// proxyExternalClaude 转发请求至优先外部 URL API
+func (h *Handler) proxyExternalClaude(w http.ResponseWriter, r *http.Request, body []byte, req *ClaudeRequest, ext config.ExternalAPIConfig, normalizeStopHookJSON bool) bool {
+	reqStart := time.Now()
+	apiKeyID := apiKeyIDFromContext(r.Context())
+	estimatedInputTokens := estimateClaudeRequestInputTokens(req)
+	baseURL := strings.TrimSuffix(ext.BaseURL, "/")
+	targetURL := baseURL
+	displayURL := strings.TrimPrefix(strings.TrimPrefix(baseURL, "https://"), "http://")
+	if !externalCircuitAllowProbe(baseURL, time.Now()) {
+		logger.Debugf("[ExternalAPI] Circuit open for %s; using Kiro account pool", displayURL)
+		return false
+	}
+	if strings.HasSuffix(targetURL, "/v1") {
+		targetURL += "/messages"
+	} else if !strings.HasSuffix(targetURL, "/v1/messages") && !strings.HasSuffix(targetURL, "/messages") {
+		targetURL += "/v1/messages"
+	}
+
+	origModel := strings.ToLower(req.Model)
+	mappedModel := req.Model
+	if strings.Contains(origModel, "opus") && ext.DefaultOpusModel != "" {
+		mappedModel = ext.DefaultOpusModel
+	} else if strings.Contains(origModel, "sonnet") && ext.DefaultSonnetModel != "" {
+		mappedModel = ext.DefaultSonnetModel
+	} else if strings.Contains(origModel, "haiku") && ext.DefaultHaikuModel != "" {
+		mappedModel = ext.DefaultHaikuModel
+	} else if strings.Contains(origModel, "fable") && ext.DefaultSonnetModel != "" {
+		mappedModel = ext.DefaultSonnetModel
+	} else if ext.DefaultModel != "" {
+		if ext.DefaultModel == "opus" && ext.DefaultOpusModel != "" {
+			mappedModel = ext.DefaultOpusModel
+		} else if ext.DefaultModel == "sonnet" && ext.DefaultSonnetModel != "" {
+			mappedModel = ext.DefaultSonnetModel
+		} else if ext.DefaultModel == "haiku" && ext.DefaultHaikuModel != "" {
+			mappedModel = ext.DefaultHaikuModel
+		} else {
+			mappedModel = ext.DefaultModel
+		}
+	}
+
+	originalStream := req.Stream
+	var payload map[string]interface{}
+	if err := json.Unmarshal(body, &payload); err == nil {
+		payload["model"] = mappedModel
+		payload["reasoning_effort"] = "xhigh"
+		delete(payload, "thinking")
+		if normalizeStopHookJSON {
+			payload["stream"] = false
+		}
+		if updated, err := json.Marshal(payload); err == nil {
+			body = updated
+		}
+	}
+
+	clientTimeout := 10 * time.Minute
+	if ext.TimeoutMS > 0 {
+		clientTimeout = time.Duration(ext.TimeoutMS) * time.Millisecond
+	}
+
+	outReq, err := http.NewRequestWithContext(r.Context(), "POST", targetURL, bytes.NewReader(body))
+	if err != nil {
+		logger.Errorf("[ExternalAPI] Failed to create request: %v", err)
+		return false
+	}
+
+	copyExternalClaudeHeaders(outReq.Header, r.Header)
+	outReq.Header.Set("Content-Type", "application/json")
+	apiKey := ext.APIKey
+	if apiKey == "" {
+		apiKey = ext.AuthToken
+	}
+	if apiKey != "" {
+		outReq.Header.Set("x-api-key", apiKey)
+		outReq.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	client := &http.Client{Timeout: clientTimeout}
+	resp, err := client.Do(outReq)
+	if err != nil {
+		logger.Warnf("[ExternalAPI] Request to external URL %s failed: %v", targetURL, err)
+		if cooldown, opened := externalCircuitFailure(baseURL, "", clientTimeout); opened {
+			logger.Warnf("[ExternalAPI] Circuit opened for %s for %s after repeated transport failures", displayURL, cooldown)
+		}
+		return false
+	}
+	defer resp.Body.Close()
+	if isRetryableExternalStatus(resp.StatusCode) {
+		if cooldown, opened := externalCircuitFailure(baseURL, resp.Header.Get("Retry-After"), clientTimeout); opened {
+			logger.Warnf("[ExternalAPI] Circuit opened for %s for %s after repeated HTTP %d responses", displayURL, cooldown, resp.StatusCode)
+		}
+		return false
+	}
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		externalCircuitSuccess(baseURL)
+	}
+
+	if normalizeStopHookJSON {
+		inputTokens, outputTokens := h.writeNormalizedExternalClaudeResponse(w, resp, mappedModel, originalStream)
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			if inputTokens <= 0 {
+				inputTokens = estimatedInputTokens
+			}
+			h.recordSuccessForApiKey(apiKeyID, inputTokens, outputTokens, 0)
+			h.recordSuccessLog("claude", req.Model, displayURL, inputTokens+outputTokens, 0, time.Since(reqStart).Milliseconds())
+		} else {
+			h.recordFailureWithDuration("claude", req.Model, displayURL, fmt.Errorf("HTTP %d", resp.StatusCode), time.Since(reqStart).Milliseconds())
+		}
+		return true
+	}
+
+	for k, v := range resp.Header {
+		w.Header()[k] = v
+	}
+	w.WriteHeader(resp.StatusCode)
+
+	var externalInputTokens, externalOutputTokens int
+	if req.Stream {
+		flusher, _ := w.(http.Flusher)
+		reader := bufio.NewReader(resp.Body)
+		targetPattern := []byte(`"model":"` + mappedModel + `"`)
+		replacementPattern := []byte(`"model":"` + req.Model + `"`)
+		for {
+			line, err := reader.ReadBytes('\n')
+			if len(line) > 0 {
+				if inTok, outTok := externalClaudeUsageFromSSELine(line); inTok > 0 || outTok > 0 {
+					externalInputTokens, externalOutputTokens = mergeExternalUsage(externalInputTokens, externalOutputTokens, inTok, outTok)
+				}
+				if bytes.Contains(line, targetPattern) {
+					line = bytes.ReplaceAll(line, targetPattern, replacementPattern)
+				}
+				w.Write(line)
+				if flusher != nil {
+					flusher.Flush()
+				}
+			}
+			if err != nil {
+				break
+			}
+		}
+	} else {
+		bodyBytes, err := io.ReadAll(resp.Body)
+		if err == nil {
+			externalInputTokens, externalOutputTokens = externalClaudeUsageFromBody(bodyBytes)
+			bodyBytes = bytes.ReplaceAll(bodyBytes, []byte(`"model":"`+mappedModel+`"`), []byte(`"model":"`+req.Model+`"`))
+			w.Write(bodyBytes)
+		}
+	}
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		if externalInputTokens <= 0 {
+			externalInputTokens = estimatedInputTokens
+		}
+		h.recordSuccessForApiKey(apiKeyID, externalInputTokens, externalOutputTokens, 0)
+		h.recordSuccessLog("claude", req.Model, displayURL, externalInputTokens+externalOutputTokens, 0, time.Since(reqStart).Milliseconds())
+	} else {
+		h.recordFailureWithDuration("claude", req.Model, displayURL, fmt.Errorf("HTTP %d", resp.StatusCode), time.Since(reqStart).Milliseconds())
+	}
+	return true
+}
+
+func copyExternalClaudeHeaders(dst, src http.Header) {
+	for k, v := range src {
+		lk := strings.ToLower(k)
+		if strings.HasPrefix(lk, "anthropic-") {
+			dst[k] = v
+		}
+	}
+}
+
+func (h *Handler) writeNormalizedExternalClaudeResponse(w http.ResponseWriter, resp *http.Response, model string, stream bool) (int, int) {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		for k, v := range resp.Header {
+			w.Header()[k] = v
+		}
+		w.WriteHeader(resp.StatusCode)
+		_, _ = io.Copy(w, resp.Body)
+		return 0, 0
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		h.sendClaudeError(w, 502, "api_error", "Failed to read external API response: "+err.Error())
+		return 0, 0
+	}
+
+	claudeResp := normalizeClaudeStopHookResponseBody(body, model)
+	if stream {
+		w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			h.sendClaudeError(w, 500, "api_error", "Streaming not supported")
+			return claudeResp.Usage.InputTokens, claudeResp.Usage.OutputTokens
+		}
+		h.sendClaudeBufferedTextStream(
+			w,
+			flusher,
+			claudeResp.ID,
+			claudeResp.Model,
+			claudeResponseText(claudeResp),
+			claudeResp.Usage.InputTokens,
+			claudeResp.Usage.OutputTokens,
+			promptCacheUsage{},
+			false,
+		)
+		return claudeResp.Usage.InputTokens, claudeResp.Usage.OutputTokens
+	}
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(claudeResp)
+	return claudeResp.Usage.InputTokens, claudeResp.Usage.OutputTokens
+}
+
+func externalClaudeUsageFromBody(body []byte) (int, int) {
+	var payload map[string]interface{}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return 0, 0
+	}
+	return externalClaudeUsageFromMap(payload)
+}
+
+func externalClaudeUsageFromSSELine(line []byte) (int, int) {
+	line = bytes.TrimSpace(line)
+	if !bytes.HasPrefix(line, []byte("data:")) {
+		return 0, 0
+	}
+	data := bytes.TrimSpace(bytes.TrimPrefix(line, []byte("data:")))
+	if len(data) == 0 || bytes.Equal(data, []byte("[DONE]")) {
+		return 0, 0
+	}
+	return externalClaudeUsageFromBody(data)
+}
+
+func externalClaudeUsageFromMap(payload map[string]interface{}) (int, int) {
+	if payload == nil {
+		return 0, 0
+	}
+	if message, ok := payload["message"].(map[string]interface{}); ok {
+		if inTok, outTok := externalClaudeUsageFromMap(message); inTok > 0 || outTok > 0 {
+			return inTok, outTok
+		}
+	}
+	usage, ok := payload["usage"].(map[string]interface{})
+	if !ok {
+		return 0, 0
+	}
+	inputTokens := firstExternalUsageInt(usage, "input_tokens", "prompt_tokens", "inputTokens", "promptTokens")
+	outputTokens := firstExternalUsageInt(usage, "output_tokens", "completion_tokens", "outputTokens", "completionTokens")
+	if inputTokens <= 0 || outputTokens <= 0 {
+		totalTokens := firstExternalUsageInt(usage, "total_tokens", "totalTokens")
+		if inputTokens <= 0 && totalTokens > outputTokens {
+			inputTokens = totalTokens - outputTokens
+		}
+		if outputTokens <= 0 && totalTokens > inputTokens {
+			outputTokens = totalTokens - inputTokens
+		}
+	}
+	return inputTokens, outputTokens
+}
+
+func firstExternalUsageInt(m map[string]interface{}, keys ...string) int {
+	for _, key := range keys {
+		if value, ok := m[key]; ok {
+			switch v := value.(type) {
+			case float64:
+				return int(v)
+			case int:
+				return v
+			case json.Number:
+				if n, err := v.Int64(); err == nil {
+					return int(n)
+				}
+			}
+		}
+	}
+	return 0
+}
+
+func mergeExternalUsage(currentInput, currentOutput, newInput, newOutput int) (int, int) {
+	if newInput > 0 {
+		currentInput = newInput
+	}
+	if newOutput > 0 {
+		currentOutput = newOutput
+	}
+	return currentInput, currentOutput
+}
+
+func normalizeClaudeStopHookResponseBody(body []byte, model string) *ClaudeResponse {
+	var resp ClaudeResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		text := normalizeClaudeStopHookEvaluatorText(string(body))
+		return KiroToClaudeResponse(text, "", false, nil, 1, estimateClaudeOutputTokens(text, "", nil), model)
+	}
+	normalizeClaudeStopHookResponse(&resp, model)
+	return &resp
+}
+
+func normalizeClaudeStopHookResponse(resp *ClaudeResponse, model string) {
+	text := normalizeClaudeStopHookEvaluatorText(claudeResponseText(resp))
+	resp.Content = []ClaudeContentBlock{{
+		Type: "text",
+		Text: text,
+	}}
+	resp.StopReason = "end_turn"
+	resp.StopSequence = nil
+	if resp.ID == "" {
+		resp.ID = "msg_" + uuid.New().String()
+	}
+	if resp.Type == "" {
+		resp.Type = "message"
+	}
+	if resp.Role == "" {
+		resp.Role = "assistant"
+	}
+	if resp.Model == "" {
+		resp.Model = model
+	}
+	if resp.Usage.InputTokens <= 0 {
+		resp.Usage.InputTokens = 1
+	}
+	resp.Usage.OutputTokens = estimateClaudeOutputTokens(text, "", nil)
+}
+
+func claudeResponseText(resp *ClaudeResponse) string {
+	if resp == nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, block := range resp.Content {
+		if block.Type == "text" {
+			b.WriteString(block.Text)
+		}
+	}
+	return b.String()
+}
+
 // handleClaudeStream Claude 流式响应
-func (h *Handler) handleClaudeStream(w http.ResponseWriter, payload *KiroPayload, model string, thinking bool, thinkingOpts claudeThinkingResponseOptions, estimatedInputTokens int, cacheProfile *promptCacheProfile, apiKeyID string) {
+func (h *Handler) handleClaudeStream(w http.ResponseWriter, r *http.Request, rawBody []byte, req *ClaudeRequest, payload *KiroPayload, model string, thinking bool, thinkingOpts claudeThinkingResponseOptions, estimatedInputTokens int, cacheProfile *promptCacheProfile, apiKeyID string, normalizeStopHookJSON bool) {
 	w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
@@ -1022,6 +1412,9 @@ func (h *Handler) handleClaudeStream(w http.ResponseWriter, payload *KiroPayload
 		var eventThinkingOpen bool
 
 		sendText := func(text string, thinkingState int) {
+			if normalizeStopHookJSON {
+				return
+			}
 			if thinkingState == 0 {
 				if text == "" {
 					return
@@ -1222,6 +1615,15 @@ func (h *Handler) handleClaudeStream(w http.ResponseWriter, payload *KiroPayload
 				processClaudeText(text, isThinking, false)
 			},
 			OnToolUse: func(tu KiroToolUse) {
+				if normalizeStopHookJSON {
+					rawContentBuilder.WriteString(tu.Name)
+					if b, err := json.Marshal(tu.Input); err == nil {
+						rawContentBuilder.Write(b)
+					}
+					toolUses = append(toolUses, tu)
+					return
+				}
+
 				processClaudeText("", false, true)
 				rawContentBuilder.WriteString(tu.Name)
 				if b, err := json.Marshal(tu.Input); err == nil {
@@ -1270,6 +1672,9 @@ func (h *Handler) handleClaudeStream(w http.ResponseWriter, payload *KiroPayload
 			},
 			OnContextUsage: func(pct float64) {
 				realInputTokens = int(pct * float64(getContextWindowSize(model)) / 100.0)
+				if realInputTokens > 15000 {
+					realInputTokens = 15000
+				}
 			},
 		}
 
@@ -1282,10 +1687,15 @@ func (h *Handler) handleClaudeStream(w http.ResponseWriter, payload *KiroPayload
 				continue
 			}
 			h.recordFailureWithDetails("claude", model, account.ID, err)
+			// The upstream died after we already streamed part of the answer, so we
+			// cannot retry on another account without duplicating emitted content.
+			// Terminate the SSE stream properly instead: an unterminated stream
+			// leaves the client rendering a half-finished message forever.
 			h.sendSSE(w, flusher, "error", map[string]interface{}{
 				"type":  "error",
 				"error": map[string]string{"type": "api_error", "message": err.Error()},
 			})
+			h.closeClaudeStreamAfterError(w, flusher, closeActiveBlock, inputTokens, outputTokens, estimatedInputTokens, realInputTokens, cacheUsage, cacheProfile)
 			return
 		}
 
@@ -1308,6 +1718,11 @@ func (h *Handler) handleClaudeStream(w http.ResponseWriter, payload *KiroPayload
 		if !thinking {
 			thinkingOutput = ""
 		}
+		if normalizeStopHookJSON {
+			outputContent = normalizeClaudeStopHookEvaluatorText(outputContent)
+			thinkingOutput = ""
+			toolUses = nil
+		}
 		outputTokens = estimateClaudeOutputTokens(outputContent, thinkingOutput, toolUses)
 
 		h.recordSuccessForApiKey(apiKeyID, inputTokens, outputTokens, credits)
@@ -1315,6 +1730,11 @@ func (h *Handler) handleClaudeStream(w http.ResponseWriter, payload *KiroPayload
 		h.pool.UpdateStats(account.ID, inputTokens+outputTokens, credits)
 		h.promptCache.Update(account.ID, cacheProfile)
 		h.recordSuccessLog("claude", model, account.ID, inputTokens+outputTokens, credits, time.Since(reqStart).Milliseconds())
+
+		if normalizeStopHookJSON {
+			h.sendClaudeBufferedTextStream(w, flusher, msgID, model, outputContent, inputTokens, outputTokens, cacheUsage, cacheProfile != nil)
+			return
+		}
 
 		stopReason := "end_turn"
 		if len(toolUses) > 0 {
@@ -1337,12 +1757,126 @@ func (h *Handler) handleClaudeStream(w http.ResponseWriter, payload *KiroPayload
 	}
 
 	if lastErr == nil {
+		if h.fallbackToCLIProxyAPI(w, r, rawBody, req, normalizeStopHookJSON) {
+			return
+		}
 		h.sendClaudeError(w, 503, "api_error", "No available accounts")
 		return
 	}
 
 	h.recordFailureWithDetails("claude", model, "", lastErr)
-	h.sendClaudeError(w, 500, "api_error", lastErr.Error())
+	if h.fallbackToCLIProxyAPI(w, r, rawBody, req, normalizeStopHookJSON) {
+		return
+	}
+	status := http.StatusBadGateway
+	if isQuotaErrorMessage(lastErr.Error()) {
+		status = http.StatusTooManyRequests
+	}
+	h.sendClaudeError(w, status, "api_error", lastErr.Error())
+}
+
+// closeClaudeStreamAfterError terminates an in-progress Claude SSE stream after
+// an upstream failure. Clients treat message_stop as the end-of-message signal;
+// without it a partially streamed response is rendered indefinitely as if still
+// generating. We close any open content block, report stop_reason "error" so the
+// client knows the turn was cut short, and emit message_stop.
+func (h *Handler) closeClaudeStreamAfterError(
+	w http.ResponseWriter,
+	flusher http.Flusher,
+	closeActiveBlock func(),
+	inputTokens, outputTokens, estimatedInputTokens, realInputTokens int,
+	cacheUsage promptCacheUsage,
+	cacheProfile *promptCacheProfile,
+) {
+	closeActiveBlock()
+
+	if realInputTokens > 0 {
+		inputTokens = realInputTokens
+	} else if inputTokens <= 0 {
+		inputTokens = estimatedInputTokens
+	}
+
+	// "error" is not a stop_reason the Claude API defines, and strict clients
+	// reject unknown values. The preceding "error" event already carries the
+	// failure detail, so terminate with end_turn to keep the envelope valid.
+	h.sendSSE(w, flusher, "message_delta", map[string]interface{}{
+		"type": "message_delta",
+		"delta": map[string]interface{}{
+			"stop_reason": "end_turn",
+		},
+		"usage": buildClaudeUsageMap(inputTokens, outputTokens, cacheUsage, cacheProfile != nil),
+	})
+
+	h.sendSSE(w, flusher, "message_stop", map[string]interface{}{
+		"type": "message_stop",
+	})
+}
+
+func (h *Handler) sendClaudeBufferedTextStream(
+	w http.ResponseWriter,
+	flusher http.Flusher,
+	msgID, model, text string,
+	inputTokens, outputTokens int,
+	cacheUsage promptCacheUsage,
+	includeCache bool,
+) {
+	if msgID == "" {
+		msgID = "msg_" + uuid.New().String()
+	}
+	if inputTokens <= 0 {
+		inputTokens = 1
+	}
+	if outputTokens <= 0 {
+		outputTokens = estimateClaudeOutputTokens(text, "", nil)
+	}
+
+	h.sendSSE(w, flusher, "message_start", map[string]interface{}{
+		"type": "message_start",
+		"message": map[string]interface{}{
+			"id":            msgID,
+			"type":          "message",
+			"role":          "assistant",
+			"content":       []interface{}{},
+			"model":         model,
+			"stop_reason":   nil,
+			"stop_sequence": nil,
+			"usage":         buildClaudeUsageMap(inputTokens, 0, cacheUsage, includeCache),
+		},
+	})
+
+	if text != "" {
+		h.sendSSE(w, flusher, "content_block_start", map[string]interface{}{
+			"type":  "content_block_start",
+			"index": 0,
+			"content_block": map[string]string{
+				"type": "text",
+				"text": "",
+			},
+		})
+		h.sendSSE(w, flusher, "content_block_delta", map[string]interface{}{
+			"type":  "content_block_delta",
+			"index": 0,
+			"delta": map[string]string{
+				"type": "text_delta",
+				"text": text,
+			},
+		})
+		h.sendSSE(w, flusher, "content_block_stop", map[string]interface{}{
+			"type":  "content_block_stop",
+			"index": 0,
+		})
+	}
+
+	h.sendSSE(w, flusher, "message_delta", map[string]interface{}{
+		"type": "message_delta",
+		"delta": map[string]interface{}{
+			"stop_reason": "end_turn",
+		},
+		"usage": buildClaudeUsageMap(inputTokens, outputTokens, cacheUsage, includeCache),
+	})
+	h.sendSSE(w, flusher, "message_stop", map[string]interface{}{
+		"type": "message_stop",
+	})
 }
 
 func (h *Handler) sendSSE(w http.ResponseWriter, flusher http.Flusher, event string, data interface{}) {
@@ -1415,6 +1949,10 @@ func (h *Handler) recordSuccessForApiKey(apiKeyID string, inputTokens, outputTok
 
 // recordFailureWithDetails records a failure and stores it in the request logs.
 func (h *Handler) recordFailureWithDetails(endpoint, model, accountID string, err error) {
+	h.recordFailureWithDuration(endpoint, model, accountID, err, 0)
+}
+
+func (h *Handler) recordFailureWithDuration(endpoint, model, accountID string, err error, durationMs int64) {
 	atomic.AddInt64(&h.totalRequests, 1)
 	atomic.AddInt64(&h.failedRequests, 1)
 
@@ -1433,6 +1971,7 @@ func (h *Handler) recordFailureWithDetails(endpoint, model, accountID string, er
 		Status:    "error",
 		Error:     errMsg,
 		ErrorType: errType,
+		Duration:  durationMs,
 	}
 
 	h.appendRequestLog(entry)
@@ -1499,7 +2038,7 @@ func (h *Handler) getRequestLogs() []RequestLog {
 }
 
 // handleClaudeNonStream Claude 非流式响应
-func (h *Handler) handleClaudeNonStream(w http.ResponseWriter, payload *KiroPayload, model string, thinking bool, thinkingOpts claudeThinkingResponseOptions, estimatedInputTokens int, cacheProfile *promptCacheProfile, apiKeyID string) {
+func (h *Handler) handleClaudeNonStream(w http.ResponseWriter, r *http.Request, rawBody []byte, req *ClaudeRequest, payload *KiroPayload, model string, thinking bool, thinkingOpts claudeThinkingResponseOptions, estimatedInputTokens int, cacheProfile *promptCacheProfile, apiKeyID string, normalizeStopHookJSON bool) {
 	excluded := make(map[string]bool)
 	var lastErr error
 	reqStart := time.Now()
@@ -1544,6 +2083,9 @@ func (h *Handler) handleClaudeNonStream(w http.ResponseWriter, payload *KiroPayl
 			},
 			OnContextUsage: func(pct float64) {
 				realInputTokens = int(pct * float64(getContextWindowSize(model)) / 100.0)
+				if realInputTokens > 15000 {
+					realInputTokens = 15000
+				}
 			},
 		}
 
@@ -1563,6 +2105,11 @@ func (h *Handler) handleClaudeNonStream(w http.ResponseWriter, payload *KiroPayl
 		}
 		if !thinking {
 			rawThinkingContent = ""
+		}
+		if normalizeStopHookJSON {
+			finalContent = normalizeClaudeStopHookEvaluatorText(finalContent)
+			rawThinkingContent = ""
+			toolUses = nil
 		}
 
 		if realInputTokens > 0 {
@@ -1612,12 +2159,22 @@ func (h *Handler) handleClaudeNonStream(w http.ResponseWriter, payload *KiroPayl
 	}
 
 	if lastErr == nil {
+		if h.fallbackToCLIProxyAPI(w, r, rawBody, req, normalizeStopHookJSON) {
+			return
+		}
 		h.sendClaudeError(w, 503, "api_error", "No available accounts")
 		return
 	}
 
 	h.recordFailureWithDetails("claude", model, "", lastErr)
-	h.sendClaudeError(w, 500, "api_error", lastErr.Error())
+	if h.fallbackToCLIProxyAPI(w, r, rawBody, req, normalizeStopHookJSON) {
+		return
+	}
+	status := http.StatusBadGateway
+	if isQuotaErrorMessage(lastErr.Error()) {
+		status = http.StatusTooManyRequests
+	}
+	h.sendClaudeError(w, status, "api_error", lastErr.Error())
 }
 
 func (h *Handler) sendClaudeError(w http.ResponseWriter, status int, errType, message string) {
@@ -1630,6 +2187,136 @@ func (h *Handler) sendClaudeError(w http.ResponseWriter, status int, errType, me
 			"message": message,
 		},
 	})
+}
+
+// proxyExternalOpenAI 转发请求至优先外部 URL API
+func (h *Handler) proxyExternalOpenAI(w http.ResponseWriter, r *http.Request, body []byte, req *OpenAIRequest, ext config.ExternalAPIConfig) bool {
+	reqStart := time.Now()
+	apiKeyID := apiKeyIDFromContext(r.Context())
+	estimatedInputTokens := estimateOpenAIRequestInputTokens(req)
+	baseURL := strings.TrimSuffix(ext.BaseURL, "/")
+	targetURL := baseURL
+	displayURL := strings.TrimPrefix(strings.TrimPrefix(baseURL, "https://"), "http://")
+	if !externalCircuitAllowProbe(baseURL, time.Now()) {
+		logger.Debugf("[ExternalAPI] Circuit open for %s; using Kiro account pool", displayURL)
+		return false
+	}
+	if strings.HasSuffix(targetURL, "/v1") {
+		targetURL += "/chat/completions"
+	} else if !strings.HasSuffix(targetURL, "/v1/chat/completions") && !strings.HasSuffix(targetURL, "/chat/completions") {
+		targetURL += "/v1/chat/completions"
+	}
+
+	mappedModel := req.Model
+	var payload map[string]interface{}
+	if err := json.Unmarshal(body, &payload); err == nil {
+		payload["model"] = mappedModel
+		if updated, err := json.Marshal(payload); err == nil {
+			body = updated
+		}
+	}
+
+	clientTimeout := 10 * time.Minute
+	if ext.TimeoutMS > 0 {
+		clientTimeout = time.Duration(ext.TimeoutMS) * time.Millisecond
+	}
+
+	outReq, err := http.NewRequestWithContext(r.Context(), "POST", targetURL, bytes.NewReader(body))
+	if err != nil {
+		logger.Errorf("[ExternalAPI] Failed to create OpenAI request: %v", err)
+		return false
+	}
+
+	outReq.Header.Set("Content-Type", "application/json")
+	if ext.AuthToken != "" {
+		outReq.Header.Set("Authorization", "Bearer "+ext.AuthToken)
+	} else if ext.APIKey != "" {
+		outReq.Header.Set("Authorization", "Bearer "+ext.APIKey)
+	}
+
+	for k, v := range r.Header {
+		lk := strings.ToLower(k)
+		if strings.HasPrefix(lk, "x-") || lk == "user-agent" {
+			outReq.Header[k] = v
+		}
+	}
+
+	client := &http.Client{Timeout: clientTimeout}
+	resp, err := client.Do(outReq)
+	if err != nil {
+		if cooldown, opened := externalCircuitFailure(baseURL, "", clientTimeout); opened {
+			logger.Warnf("[ExternalAPI] Circuit opened for %s for %s after repeated transport failures", displayURL, cooldown)
+		}
+		h.recordFailureWithDuration("openai", req.Model, displayURL, err, time.Since(reqStart).Milliseconds())
+		return false
+	}
+	defer resp.Body.Close()
+	if isRetryableExternalStatus(resp.StatusCode) {
+		if cooldown, opened := externalCircuitFailure(baseURL, resp.Header.Get("Retry-After"), clientTimeout); opened {
+			logger.Warnf("[ExternalAPI] Circuit opened for %s for %s after repeated HTTP %d responses", displayURL, cooldown, resp.StatusCode)
+		}
+		h.recordFailureWithDuration("openai", req.Model, displayURL, fmt.Errorf("HTTP %d", resp.StatusCode), time.Since(reqStart).Milliseconds())
+		return false
+	}
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		externalCircuitSuccess(baseURL)
+	}
+
+	if resp.StatusCode >= 400 {
+		h.recordFailureWithDuration("openai", req.Model, displayURL, fmt.Errorf("HTTP %d", resp.StatusCode), time.Since(reqStart).Milliseconds())
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(resp.StatusCode)
+		w.Write(bodyBytes)
+		return true
+	}
+
+	for k, v := range resp.Header {
+		w.Header()[k] = v
+	}
+	w.WriteHeader(resp.StatusCode)
+
+	var externalInputTokens, externalOutputTokens int
+	if req.Stream {
+		flusher, _ := w.(http.Flusher)
+		reader := bufio.NewReader(resp.Body)
+		for {
+			line, err := reader.ReadBytes('\n')
+			if len(line) > 0 {
+				w.Write(line)
+				if flusher != nil {
+					flusher.Flush()
+				}
+			}
+			if err != nil {
+				break
+			}
+		}
+	} else {
+		bodyBytes, err := io.ReadAll(resp.Body)
+		if err == nil {
+			var respObj map[string]interface{}
+			if err := json.Unmarshal(bodyBytes, &respObj); err == nil {
+				if usage, ok := respObj["usage"].(map[string]interface{}); ok {
+					if pTok, ok := usage["prompt_tokens"].(float64); ok {
+						externalInputTokens = int(pTok)
+					}
+					if cTok, ok := usage["completion_tokens"].(float64); ok {
+						externalOutputTokens = int(cTok)
+					}
+				}
+			}
+			bodyBytes = bytes.ReplaceAll(bodyBytes, []byte(`"model":"`+mappedModel+`"`), []byte(`"model":"`+req.Model+`"`))
+			w.Write(bodyBytes)
+		}
+	}
+
+	if externalInputTokens <= 0 {
+		externalInputTokens = estimatedInputTokens
+	}
+	h.recordSuccessForApiKey(apiKeyID, externalInputTokens, externalOutputTokens, 0)
+	h.recordSuccessLog("openai", req.Model, displayURL, externalInputTokens+externalOutputTokens, 0, time.Since(reqStart).Milliseconds())
+	return true
 }
 
 // handleOpenAIChat OpenAI API 处理
@@ -1653,6 +2340,14 @@ func (h *Handler) handleOpenAIChat(w http.ResponseWriter, r *http.Request) {
 	if msg := validateOpenAIRequestShape(&req); msg != "" {
 		h.sendOpenAIError(w, 400, "invalid_request_error", msg)
 		return
+	}
+
+	// 优先检查外部 URL API 配置
+	ext := config.GetExternalAPIConfig()
+	if ext.Enabled && strings.TrimSpace(ext.BaseURL) != "" {
+		if h.proxyExternalOpenAI(w, r, body, &req, ext) {
+			return
+		}
 	}
 
 	// 解析模型和 thinking 模式
@@ -1981,6 +2676,9 @@ func (h *Handler) handleOpenAIStream(w http.ResponseWriter, payload *KiroPayload
 			},
 			OnContextUsage: func(pct float64) {
 				realInputTokens = int(pct * float64(getContextWindowSize(model)) / 100.0)
+				if realInputTokens > 15000 {
+					realInputTokens = 15000
+				}
 			},
 		}
 
@@ -2100,6 +2798,9 @@ func (h *Handler) handleOpenAINonStream(w http.ResponseWriter, payload *KiroPayl
 			OnCredits:  func(c float64) { credits = c },
 			OnContextUsage: func(pct float64) {
 				realInputTokens = int(pct * float64(getContextWindowSize(model)) / 100.0)
+				if realInputTokens > 15000 {
+					realInputTokens = 15000
+				}
 			},
 		}
 
@@ -2378,6 +3079,10 @@ func (h *Handler) handleAdminAPI(w http.ResponseWriter, r *http.Request) {
 		h.apiGetPromptFilter(w, r)
 	case path == "/prompt-filter" && r.Method == "POST":
 		h.apiUpdatePromptFilter(w, r)
+	case path == "/external-api" && r.Method == "GET":
+		h.apiGetExternalAPIConfig(w, r)
+	case path == "/external-api" && r.Method == "POST":
+		h.apiUpdateExternalAPIConfig(w, r)
 	case path == "/version" && r.Method == "GET":
 		h.apiGetVersion(w, r)
 	case path == "/export" && r.Method == "POST":
@@ -3866,7 +4571,27 @@ func (h *Handler) apiGetSettings(w http.ResponseWriter, r *http.Request) {
 		"port":           config.GetPort(),
 		"host":           config.GetHost(),
 		"allowOverUsage": config.GetAllowOverUsage(),
+		"externalApi":    config.GetExternalAPIConfig(),
 	})
+}
+
+func (h *Handler) apiGetExternalAPIConfig(w http.ResponseWriter, r *http.Request) {
+	json.NewEncoder(w).Encode(config.GetExternalAPIConfig())
+}
+
+func (h *Handler) apiUpdateExternalAPIConfig(w http.ResponseWriter, r *http.Request) {
+	var ext config.ExternalAPIConfig
+	if err := json.NewDecoder(r.Body).Decode(&ext); err != nil {
+		w.WriteHeader(400)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid JSON: " + err.Error()})
+		return
+	}
+	if err := config.UpdateExternalAPIConfig(ext); err != nil {
+		w.WriteHeader(500)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+	json.NewEncoder(w).Encode(map[string]bool{"success": true})
 }
 
 func (h *Handler) apiGetPromptFilter(w http.ResponseWriter, r *http.Request) {
@@ -4629,4 +5354,251 @@ func clampInt(v, min, max int) int {
 		return max
 	}
 	return v
+}
+
+// proxyExternalClaudeToOpenAI intercepts a Claude API request, transforms it into a basic OpenAI request,
+// sends it to external URL with stream=false, and mocks a Claude SSE stream response.
+func (h *Handler) proxyExternalClaudeToOpenAI(w http.ResponseWriter, r *http.Request, req *ClaudeRequest, ext config.ExternalAPIConfig) bool {
+	reqStart := time.Now()
+	apiKeyID := apiKeyIDFromContext(r.Context())
+
+	baseURL := strings.TrimSuffix(ext.BaseURL, "/")
+	targetURL := baseURL
+	displayURL := strings.TrimPrefix(strings.TrimPrefix(baseURL, "https://"), "http://")
+	if !externalCircuitAllowProbe(baseURL, time.Now()) {
+		logger.Debugf("[ExternalAPI] Circuit open for %s; using Kiro account pool", displayURL)
+		return false
+	}
+	if strings.HasSuffix(targetURL, "/v1") {
+		targetURL += "/chat/completions"
+	} else if !strings.HasSuffix(targetURL, "/v1/chat/completions") && !strings.HasSuffix(targetURL, "/chat/completions") {
+		targetURL += "/v1/chat/completions"
+	}
+
+	// 1. Transform ClaudeRequest to simple OpenAI request
+	var openaiMessages []map[string]interface{}
+
+	// System prompt
+	if req.System != nil {
+		sysStr := ""
+		switch v := req.System.(type) {
+		case string:
+			sysStr = v
+		case []interface{}:
+			for _, b := range v {
+				if bm, ok := b.(map[string]interface{}); ok {
+					if txt, ok := bm["text"].(string); ok {
+						sysStr += txt + "\n"
+					}
+				}
+			}
+		}
+		if sysStr != "" {
+			openaiMessages = append(openaiMessages, map[string]interface{}{
+				"role":    "system",
+				"content": sysStr,
+			})
+		}
+	}
+
+	// Messages
+	for _, m := range req.Messages {
+		contentStr := ""
+		switch v := m.Content.(type) {
+		case string:
+			contentStr = v
+		case []interface{}:
+			for _, b := range v {
+				if bm, ok := b.(map[string]interface{}); ok {
+					if txt, ok := bm["text"].(string); ok {
+						contentStr += txt + "\n"
+					} else if bType, ok := bm["type"].(string); ok && bType == "tool_use" {
+						contentStr += fmt.Sprintf("[Tool Use: %v]\n", bm["name"])
+					} else if bType == "tool_result" {
+						contentStr += fmt.Sprintf("[Tool Result: %v]\n", bm["content"])
+					}
+				}
+			}
+		}
+		openaiMessages = append(openaiMessages, map[string]interface{}{
+			"role":    m.Role,
+			"content": contentStr,
+		})
+	}
+
+	mappedModel := req.Model
+	openaiReq := map[string]interface{}{
+		"model":    mappedModel,
+		"messages": openaiMessages,
+		"stream":   false, // Force stream=false to avoid tokenrouter freeze
+	}
+
+	bodyBytes, _ := json.Marshal(openaiReq)
+
+	outReq, err := http.NewRequestWithContext(r.Context(), "POST", targetURL, bytes.NewReader(bodyBytes))
+	if err != nil {
+		h.sendClaudeError(w, 500, "api_error", "Failed to create internal request")
+		return false
+	}
+
+	outReq.Header.Set("Content-Type", "application/json")
+	if ext.AuthToken != "" {
+		outReq.Header.Set("Authorization", "Bearer "+ext.AuthToken)
+	} else if ext.APIKey != "" {
+		outReq.Header.Set("Authorization", "Bearer "+ext.APIKey)
+	}
+
+	clientTimeout := 10 * time.Minute
+	if ext.TimeoutMS > 0 {
+		clientTimeout = time.Duration(ext.TimeoutMS) * time.Millisecond
+	}
+	client := &http.Client{Timeout: clientTimeout}
+
+	resp, err := client.Do(outReq)
+	if err != nil {
+		if cooldown, opened := externalCircuitFailure(baseURL, "", clientTimeout); opened {
+			logger.Warnf("[ExternalAPI] Circuit opened for %s for %s after repeated transport failures", displayURL, cooldown)
+		}
+		h.recordFailureWithDuration("claude", req.Model, displayURL, err, time.Since(reqStart).Milliseconds())
+		return false
+	}
+	defer resp.Body.Close()
+	if isRetryableExternalStatus(resp.StatusCode) {
+		if cooldown, opened := externalCircuitFailure(baseURL, resp.Header.Get("Retry-After"), clientTimeout); opened {
+			logger.Warnf("[ExternalAPI] Circuit opened for %s for %s after repeated HTTP %d responses", displayURL, cooldown, resp.StatusCode)
+		}
+		h.recordFailureWithDuration("claude", req.Model, displayURL, fmt.Errorf("HTTP %d", resp.StatusCode), time.Since(reqStart).Milliseconds())
+		return false
+	}
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		externalCircuitSuccess(baseURL)
+	}
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		h.recordFailureWithDuration("claude", req.Model, displayURL, fmt.Errorf("HTTP %d", resp.StatusCode), time.Since(reqStart).Milliseconds())
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(resp.StatusCode)
+		w.Write(respBody)
+		return true
+	}
+
+	// Parse OpenAI response
+	var openaiResp struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+		Usage struct {
+			PromptTokens     int `json:"prompt_tokens"`
+			CompletionTokens int `json:"completion_tokens"`
+		} `json:"usage"`
+	}
+	json.Unmarshal(respBody, &openaiResp)
+
+	replyText := ""
+	if len(openaiResp.Choices) > 0 {
+		replyText = openaiResp.Choices[0].Message.Content
+	}
+
+	inTokens := openaiResp.Usage.PromptTokens
+	outTokens := openaiResp.Usage.CompletionTokens
+
+	// Mock Claude response
+	if req.Stream {
+		w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		flusher, _ := w.(http.Flusher)
+
+		msgID := "msg_" + uuid.New().String()
+
+		// message_start
+		startEv := map[string]interface{}{
+			"type": "message_start",
+			"message": map[string]interface{}{
+				"id":            msgID,
+				"type":          "message",
+				"role":          "assistant",
+				"model":         mappedModel,
+				"content":       []interface{}{},
+				"stop_reason":   nil,
+				"stop_sequence": nil,
+				"usage":         map[string]interface{}{"input_tokens": inTokens, "output_tokens": 0},
+			},
+		}
+		startBytes, _ := json.Marshal(startEv)
+		fmt.Fprintf(w, "event: message_start\ndata: %s\n\n", startBytes)
+
+		// content_block_start
+		cbStart := map[string]interface{}{
+			"type":          "content_block_start",
+			"index":         0,
+			"content_block": map[string]interface{}{"type": "text", "text": ""},
+		}
+		cbStartBytes, _ := json.Marshal(cbStart)
+		fmt.Fprintf(w, "event: content_block_start\ndata: %s\n\n", cbStartBytes)
+
+		// Stream content in chunks to mimic real stream
+		chunkSize := 20
+		for i := 0; i < len(replyText); i += chunkSize {
+			end := i + chunkSize
+			if end > len(replyText) {
+				end = len(replyText)
+			}
+			chunk := replyText[i:end]
+			cbDelta := map[string]interface{}{
+				"type":  "content_block_delta",
+				"index": 0,
+				"delta": map[string]interface{}{"type": "text_delta", "text": chunk},
+			}
+			cbDeltaBytes, _ := json.Marshal(cbDelta)
+			fmt.Fprintf(w, "event: content_block_delta\ndata: %s\n\n", cbDeltaBytes)
+			if flusher != nil {
+				flusher.Flush()
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+
+		// content_block_stop
+		cbStop := map[string]interface{}{"type": "content_block_stop", "index": 0}
+		cbStopBytes, _ := json.Marshal(cbStop)
+		fmt.Fprintf(w, "event: content_block_stop\ndata: %s\n\n", cbStopBytes)
+
+		// message_delta
+		msgDelta := map[string]interface{}{
+			"type":  "message_delta",
+			"delta": map[string]interface{}{"stop_reason": "end_turn", "stop_sequence": nil},
+			"usage": map[string]interface{}{"output_tokens": outTokens},
+		}
+		msgDeltaBytes, _ := json.Marshal(msgDelta)
+		fmt.Fprintf(w, "event: message_delta\ndata: %s\n\n", msgDeltaBytes)
+
+		// message_stop
+		msgStop := map[string]interface{}{"type": "message_stop"}
+		msgStopBytes, _ := json.Marshal(msgStop)
+		fmt.Fprintf(w, "event: message_stop\ndata: %s\n\n", msgStopBytes)
+
+	} else {
+		// Non-stream response
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		respData := map[string]interface{}{
+			"id":    "msg_" + uuid.New().String(),
+			"type":  "message",
+			"role":  "assistant",
+			"model": mappedModel,
+			"content": []map[string]interface{}{
+				{"type": "text", "text": replyText},
+			},
+			"stop_reason":   "end_turn",
+			"stop_sequence": nil,
+			"usage":         map[string]interface{}{"input_tokens": inTokens, "output_tokens": outTokens},
+		}
+		json.NewEncoder(w).Encode(respData)
+	}
+
+	h.recordSuccessForApiKey(apiKeyID, inTokens, outTokens, 0)
+	h.recordSuccessLog("claude", req.Model, displayURL, inTokens+outTokens, 0, time.Since(reqStart).Milliseconds())
+	return true
 }

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -237,6 +237,55 @@ func TestExternalClaudeRetryableStatusFallsBackBeforeWritingResponse(t *testing.
 	}
 }
 
+func TestExternalModelMappingDoesNotMutateKiroFallbackRequest(t *testing.T) {
+	resetExternalCircuits()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	h := &Handler{}
+	req := &ClaudeRequest{Model: "auto", Messages: []ClaudeMessage{{Role: "user", Content: "hello"}}}
+	body := []byte(`{"model":"auto","messages":[{"role":"user","content":"hello"}]}`)
+	externalReq := *req
+	externalReq.Model = "provider-specific-model"
+
+	if h.proxyExternalClaude(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body)), body, &externalReq, config.ExternalAPIConfig{BaseURL: server.URL}, false) {
+		t.Fatal("retryable external status should fall back")
+	}
+	if req.Model != "auto" {
+		t.Fatalf("original Kiro fallback model mutated to %q", req.Model)
+	}
+}
+
+func TestCopyExternalOpenAIHeadersDoesNotForwardLocalAuth(t *testing.T) {
+	src := http.Header{
+		"X-Api-Key":            []string{"local-secret"},
+		"Authorization":        []string{"Bearer local-secret"},
+		"X-Admin-Password":     []string{"admin-secret"},
+		"X-Arbitrary-Metadata": []string{"private"},
+		"User-Agent":           []string{"claude-cli"},
+		"Openai-Organization":  []string{"org-test"},
+		"Idempotency-Key":      []string{"idem-test"},
+	}
+	dst := http.Header{}
+	copyExternalOpenAIHeaders(dst, src)
+	for _, forbidden := range []string{"X-Api-Key", "Authorization", "X-Admin-Password", "X-Arbitrary-Metadata"} {
+		if got := dst.Get(forbidden); got != "" {
+			t.Fatalf("forwarded forbidden header %s=%q", forbidden, got)
+		}
+	}
+	if got := dst.Get("User-Agent"); got != "claude-cli" {
+		t.Fatalf("User-Agent=%q, headers=%#v", got, dst)
+	}
+	if got := dst.Get("Openai-Organization"); got != "org-test" {
+		t.Fatalf("OpenAI-Organization=%q, headers=%#v", got, dst)
+	}
+	if got := dst.Get("Idempotency-Key"); got != "idem-test" {
+		t.Fatalf("Idempotency-Key=%q, headers=%#v", got, dst)
+	}
+}
+
 func TestExternalClaudeTransportErrorFallsBackBeforeWritingResponse(t *testing.T) {
 	resetExternalCircuits()
 	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"bytes"
 	"encoding/json"
 	"kiro-go/config"
 	accountpool "kiro-go/pool"
@@ -98,7 +99,7 @@ func TestClaudeNonStreamRetriesNextAccountAfterPreResponseFailure(t *testing.T) 
 	}
 
 	rec := httptest.NewRecorder()
-	h.handleClaudeNonStream(rec, payload, "claude-sonnet-4.5", false, claudeThinkingResponseOptions{}, 1, nil, "")
+	h.handleClaudeNonStream(rec, nil, nil, nil, payload, "claude-sonnet-4.5", false, claudeThinkingResponseOptions{}, 1, nil, "", false)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected retry to succeed, status=%d body=%s", rec.Code, rec.Body.String())
@@ -120,6 +121,259 @@ func TestClaudeNonStreamRetriesNextAccountAfterPreResponseFailure(t *testing.T) 
 	}
 	if len(resp.Content) == 0 || resp.Content[0].Text != "retried successfully" {
 		t.Fatalf("expected retried response content, got %#v", resp.Content)
+	}
+}
+
+func TestExternalClaudeRoutingMapsDefaultOpusToOpus5(t *testing.T) {
+	t.Setenv("KIRO_GO_EXTERNAL_API_ENABLED", "true")
+	cfgFile := t.TempDir() + "/config.json"
+	if err := config.Init(cfgFile); err != nil {
+		t.Fatalf("config.Init: %v", err)
+	}
+
+	var gotPath string
+	var gotModel string
+	var gotAPIKey string
+	var gotAuthorization string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAPIKey = r.Header.Get("x-api-key")
+		gotAuthorization = r.Header.Get("Authorization")
+
+		var payload map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode external payload: %v", err)
+		}
+		gotModel, _ = payload["model"].(string)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_test","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"model":"claude-opus-5","stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer server.Close()
+	t.Setenv("ANTHROPIC_BASE_URL", server.URL)
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "sk-test")
+	t.Setenv("ANTHROPIC_DEFAULT_OPUS_MODEL", "claude-opus-5")
+
+	if err := config.UpdateExternalAPIConfig(config.ExternalAPIConfig{
+		Enabled:      true,
+		BaseURL:      server.URL,
+		APIKey:       "sk-test",
+		DefaultModel: "opus",
+	}); err != nil {
+		t.Fatalf("update external API config: %v", err)
+	}
+
+	h := &Handler{}
+	reqBody := `{"model":"auto","max_tokens":16,"messages":[{"role":"user","content":"hello"}]}`
+	rec := httptest.NewRecorder()
+	h.handleClaudeMessagesInternal(rec, httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(reqBody)))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
+	}
+	if gotPath != "/v1/messages" {
+		t.Fatalf("external path = %q, want /v1/messages", gotPath)
+	}
+	if gotModel != "claude-opus-5" {
+		t.Fatalf("external model = %q, want claude-opus-5", gotModel)
+	}
+	if gotAPIKey != "sk-test" || gotAuthorization != "Bearer sk-test" {
+		t.Fatalf("external auth headers not forwarded correctly: x-api-key=%q authorization=%q", gotAPIKey, gotAuthorization)
+	}
+}
+
+func TestExternalClaudeRequestLogRecordsUsageAndDuration(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(5 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_test","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"model":"mapped-model","stop_reason":"end_turn","usage":{"input_tokens":2,"output_tokens":5}}`))
+	}))
+	defer server.Close()
+
+	h := &Handler{}
+	req := &ClaudeRequest{Model: "claude-opus-5", Messages: []ClaudeMessage{{Role: "user", Content: "hello"}}}
+	body := []byte(`{"model":"claude-opus-5","max_tokens":16,"messages":[{"role":"user","content":"hello"}]}`)
+	rec := httptest.NewRecorder()
+
+	if !h.proxyExternalClaude(rec, httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body)), body, req, config.ExternalAPIConfig{Enabled: true, BaseURL: server.URL, DefaultModel: "mapped-model"}, false) {
+		t.Fatalf("proxyExternalClaude returned false")
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
+	}
+
+	logs := h.getRequestLogs()
+	if len(logs) != 1 {
+		t.Fatalf("logs len = %d, want 1", len(logs))
+	}
+	if logs[0].Tokens != 7 {
+		t.Fatalf("tokens = %d, want 7", logs[0].Tokens)
+	}
+	if logs[0].Duration <= 0 {
+		t.Fatalf("duration = %d, want > 0", logs[0].Duration)
+	}
+}
+
+func TestExternalClaudeRetryableStatusFallsBackBeforeWritingResponse(t *testing.T) {
+	resetExternalCircuits()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "30")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":"external quota"}`))
+	}))
+	defer server.Close()
+
+	h := &Handler{}
+	req := &ClaudeRequest{Model: "claude-opus-5", Messages: []ClaudeMessage{{Role: "user", Content: "hello"}}}
+	body := []byte(`{"model":"claude-opus-5","messages":[{"role":"user","content":"hello"}]}`)
+	rec := httptest.NewRecorder()
+
+	if h.proxyExternalClaude(rec, httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body)), body, req, config.ExternalAPIConfig{BaseURL: server.URL}, false) {
+		t.Fatal("retryable external status should fall back to Kiro")
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("external error body leaked before fallback: %s", rec.Body.String())
+	}
+}
+
+func TestExternalClaudeTransportErrorFallsBackBeforeWritingResponse(t *testing.T) {
+	resetExternalCircuits()
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	baseURL := server.URL
+	server.Close()
+
+	h := &Handler{}
+	req := &ClaudeRequest{Model: "claude-opus-5", Messages: []ClaudeMessage{{Role: "user", Content: "hello"}}}
+	body := []byte(`{"model":"claude-opus-5","messages":[{"role":"user","content":"hello"}]}`)
+	rec := httptest.NewRecorder()
+
+	if h.proxyExternalClaude(rec, httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body)), body, req, config.ExternalAPIConfig{BaseURL: baseURL, TimeoutMS: 100}, false) {
+		t.Fatal("external transport error should fall back to Kiro")
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("transport error response leaked before fallback: %s", rec.Body.String())
+	}
+}
+
+func TestExternalClaudeRetryableFailureAndSuccessShareCircuitKey(t *testing.T) {
+	resetExternalCircuits()
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_test","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"model":"mapped-model","stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer server.Close()
+
+	h := &Handler{}
+	req := &ClaudeRequest{Model: "claude-opus-5", Messages: []ClaudeMessage{{Role: "user", Content: "hello"}}}
+	body := []byte(`{"model":"claude-opus-5","messages":[{"role":"user","content":"hello"}]}`)
+	ext := config.ExternalAPIConfig{BaseURL: server.URL, DefaultModel: "mapped-model"}
+
+	if h.proxyExternalClaude(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body)), body, req, ext, false) {
+		t.Fatal("first retryable response should fall back")
+	}
+	if failures, _ := externalCircuitStateSnapshot(server.URL); failures != 1 {
+		t.Fatalf("circuit failures after retryable response = %d, want 1", failures)
+	}
+	if !h.proxyExternalClaude(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body)), body, req, ext, false) {
+		t.Fatal("second successful response should be served externally")
+	}
+	if failures, openUntil := externalCircuitStateSnapshot(server.URL); failures != 0 || !openUntil.IsZero() {
+		t.Fatalf("success did not reset same circuit key: failures=%d openUntil=%v", failures, openUntil)
+	}
+}
+
+func TestExternalClaudeStopHookNormalizationForcesCleanJSONStream(t *testing.T) {
+	t.Setenv("KIRO_GO_EXTERNAL_API_ENABLED", "true")
+	cfgFile := t.TempDir() + "/config.json"
+	if err := config.Init(cfgFile); err != nil {
+		t.Fatalf("config.Init: %v", err)
+	}
+
+	var gotStream bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode external payload: %v", err)
+		}
+		if stream, _ := payload["stream"].(bool); stream {
+			gotStream = true
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("{\"id\":\"msg_test\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"```json\\n{\\\"ok\\\": true, \\\"reason\\\": \\\"done\\\"}\\n```\"}],\"model\":\"claude-opus-5\",\"stop_reason\":\"end_turn\",\"usage\":{\"input_tokens\":3,\"output_tokens\":4}}"))
+	}))
+	defer server.Close()
+	t.Setenv("ANTHROPIC_BASE_URL", server.URL)
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "sk-test")
+	t.Setenv("ANTHROPIC_DEFAULT_OPUS_MODEL", "claude-opus-5")
+
+	if err := config.UpdateExternalAPIConfig(config.ExternalAPIConfig{
+		Enabled:      true,
+		BaseURL:      server.URL,
+		APIKey:       "sk-test",
+		DefaultModel: "opus",
+	}); err != nil {
+		t.Fatalf("update external API config: %v", err)
+	}
+
+	h := &Handler{}
+	reqBody := `{"model":"auto","stream":true,"max_tokens":16,"messages":[{"role":"user","content":"Based on the conversation transcript above, has the following stopping condition been satisfied? Answer based on transcript evidence only.\n\nCondition: reply exactly DONE and stop\n\nARGUMENTS: {\"session_id\":\"s\",\"transcript_path\":\"/tmp/transcript.jsonl\",\"cwd\":\"/tmp\",\"prompt_id\":\"p\",\"permission_mode\":\"bypassPermissions\",\"effort\":{\"level\":\"low\"},\"hook_event_name\":\"Stop\",\"stop_hook_active\":false,\"last_assistant_message\":\"DONE\",\"background_tasks\":[],\"session_crons\":[]}"}]}`
+	rec := httptest.NewRecorder()
+	h.handleClaudeMessagesInternal(rec, httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(reqBody)))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
+	}
+	if gotStream {
+		t.Fatalf("expected proxy to force non-stream upstream request for hook normalization")
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "event: message_start") || !strings.Contains(body, "event: message_stop") {
+		t.Fatalf("expected SSE envelope, got %s", body)
+	}
+	if strings.Contains(body, "```json") || strings.Contains(body, "```") {
+		t.Fatalf("expected markdown fences to be stripped, got %s", body)
+	}
+	if !strings.Contains(body, `{\"ok\":true,\"reason\":\"done\"}`) {
+		t.Fatalf("expected normalized JSON verdict in stream body, got %s", body)
+	}
+}
+
+func TestCopyExternalClaudeHeadersDoesNotForwardLocalAuth(t *testing.T) {
+	src := http.Header{
+		"Anthropic-Version": []string{"2023-06-01"},
+		"Anthropic-Beta":    []string{"tools-2024-04-04"},
+		"X-Api-Key":         []string{"local-proxy-key"},
+		"Authorization":     []string{"Bearer local-proxy-key"},
+		"X-Trace-Id":        []string{"local-trace"},
+	}
+	dst := http.Header{}
+
+	copyExternalClaudeHeaders(dst, src)
+
+	if got := dst.Get("Anthropic-Version"); got != "2023-06-01" {
+		t.Fatalf("anthropic-version = %q", got)
+	}
+	if got := dst.Get("Anthropic-Beta"); got != "tools-2024-04-04" {
+		t.Fatalf("anthropic-beta = %q", got)
+	}
+	if got := dst.Get("X-Api-Key"); got != "" {
+		t.Fatalf("local X-Api-Key leaked to external upstream")
+	}
+	if got := dst.Get("Authorization"); got != "" {
+		t.Fatalf("local Authorization leaked to external upstream")
+	}
+	if got := dst.Get("X-Trace-Id"); got != "" {
+		t.Fatalf("local X-* header leaked to external upstream")
 	}
 }
 

--- a/proxy/hook_json.go
+++ b/proxy/hook_json.go
@@ -1,0 +1,302 @@
+package proxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type claudeStopHookVerdict struct {
+	OK     bool   `json:"ok"`
+	Reason string `json:"reason"`
+}
+
+func isClaudeCodeStopHookEvaluatorRequest(req *ClaudeRequest) bool {
+	if req == nil {
+		return false
+	}
+
+	text := strings.ToLower(claudeRequestTextForDetection(req))
+	if text == "" {
+		return false
+	}
+
+	required := []string{
+		"has the following stopping condition been satisfied",
+		"answer based on transcript evidence only",
+		"condition:",
+		"arguments:",
+	}
+	for _, marker := range required {
+		if !strings.Contains(text, marker) {
+			return false
+		}
+	}
+
+	return strings.Contains(text, "hook_event_name") &&
+		strings.Contains(text, "stop") &&
+		strings.Contains(text, "last_assistant_message")
+}
+
+func claudeRequestTextForDetection(req *ClaudeRequest) string {
+	var b strings.Builder
+	if system := extractSystemPrompt(req.System); system != "" {
+		b.WriteString(system)
+		b.WriteByte('\n')
+	}
+
+	for _, msg := range req.Messages {
+		switch strings.TrimSpace(strings.ToLower(msg.Role)) {
+		case "assistant":
+			text, _ := extractClaudeAssistantContent(msg.Content)
+			b.WriteString(text)
+		default:
+			text, _, _ := extractClaudeUserContent(msg.Content)
+			if text == "" {
+				text, _ = extractClaudeAssistantContent(msg.Content)
+			}
+			b.WriteString(text)
+		}
+		b.WriteByte('\n')
+	}
+
+	return b.String()
+}
+
+func normalizeClaudeStopHookEvaluatorText(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if normalized, ok := normalizeStopHookJSONFromString(raw); ok {
+		return normalized
+	}
+
+	ok, reason := inferStopHookVerdictFromProse(raw)
+	return marshalStopHookVerdict(ok, reason)
+}
+
+func normalizeStopHookJSONFromString(raw string) (string, bool) {
+	if normalized, ok := normalizeStopHookJSONCandidate(raw); ok {
+		return normalized, true
+	}
+
+	unwrapped := unwrapMarkdownFence(raw)
+	if unwrapped != raw {
+		if normalized, ok := normalizeStopHookJSONCandidate(unwrapped); ok {
+			return normalized, true
+		}
+	}
+
+	for _, candidate := range jsonObjectCandidates(raw) {
+		if normalized, ok := normalizeStopHookJSONCandidate(candidate); ok {
+			return normalized, true
+		}
+	}
+
+	return "", false
+}
+
+func normalizeStopHookJSONCandidate(candidate string) (string, bool) {
+	candidate = strings.TrimSpace(candidate)
+	if candidate == "" {
+		return "", false
+	}
+
+	var obj map[string]interface{}
+	if err := json.Unmarshal([]byte(candidate), &obj); err == nil {
+		ok, hasOK := flexibleHookBool(obj["ok"])
+		if !hasOK {
+			ok, hasOK = flexibleHookBool(obj["satisfied"])
+		}
+		if !hasOK {
+			ok, hasOK = flexibleHookBool(obj["condition_satisfied"])
+		}
+		if !hasOK {
+			return "", false
+		}
+
+		reason := hookReason(obj["reason"])
+		if reason == "" {
+			reason = hookReason(obj["explanation"])
+		}
+		if reason == "" {
+			reason = "Model returned a valid hook verdict."
+		}
+		return marshalStopHookVerdict(ok, reason), true
+	}
+
+	var ok bool
+	if err := json.Unmarshal([]byte(candidate), &ok); err == nil {
+		return marshalStopHookVerdict(ok, "Model returned a boolean hook verdict."), true
+	}
+
+	return "", false
+}
+
+func flexibleHookBool(v interface{}) (bool, bool) {
+	switch value := v.(type) {
+	case bool:
+		return value, true
+	case string:
+		switch strings.ToLower(strings.TrimSpace(value)) {
+		case "true", "yes", "satisfied", "met":
+			return true, true
+		case "false", "no", "unsatisfied", "not satisfied", "not met":
+			return false, true
+		}
+	}
+	return false, false
+}
+
+func hookReason(v interface{}) string {
+	switch value := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return value
+	default:
+		return fmt.Sprint(value)
+	}
+}
+
+func jsonObjectCandidates(raw string) []string {
+	var candidates []string
+	for start := 0; start < len(raw); start++ {
+		if raw[start] != '{' {
+			continue
+		}
+		if candidate, ok := jsonObjectCandidateAt(raw, start); ok {
+			candidates = append(candidates, candidate)
+		}
+	}
+	return candidates
+}
+
+func jsonObjectCandidateAt(raw string, start int) (string, bool) {
+	depth := 0
+	inString := false
+	escaped := false
+
+	for i := start; i < len(raw); i++ {
+		ch := raw[i]
+		if inString {
+			if escaped {
+				escaped = false
+				continue
+			}
+			switch ch {
+			case '\\':
+				escaped = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+
+		switch ch {
+		case '"':
+			inString = true
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return raw[start : i+1], true
+			}
+		}
+	}
+
+	return "", false
+}
+
+func unwrapMarkdownFence(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if !strings.HasPrefix(trimmed, "```") {
+		return raw
+	}
+
+	trimmed = strings.TrimPrefix(trimmed, "```")
+	if idx := strings.IndexByte(trimmed, '\n'); idx >= 0 {
+		trimmed = trimmed[idx+1:]
+	}
+	if idx := strings.LastIndex(trimmed, "```"); idx >= 0 {
+		trimmed = trimmed[:idx]
+	}
+	return strings.TrimSpace(trimmed)
+}
+
+func inferStopHookVerdictFromProse(raw string) (bool, string) {
+	reason := compactHookReason(unwrapMarkdownFence(raw))
+	if reason == "" {
+		return false, "Hook evaluator returned an empty response; continuing goal to avoid premature stop."
+	}
+
+	lower := strings.ToLower(reason)
+	falseMarkers := []string{
+		"ok: false",
+		"\"ok\": false",
+		"\"ok\":false",
+		"has not been satisfied",
+		"not been satisfied",
+		"is not satisfied",
+		"not satisfied",
+		"has not been met",
+		"is not met",
+		"not met",
+	}
+	for _, marker := range falseMarkers {
+		if strings.Contains(lower, marker) {
+			return false, reason
+		}
+	}
+	if strings.HasPrefix(lower, "no") || strings.HasPrefix(lower, "false") {
+		return false, reason
+	}
+
+	trueMarkers := []string{
+		"ok: true",
+		"\"ok\": true",
+		"\"ok\":true",
+		"has been satisfied",
+		"is satisfied",
+		"condition satisfied",
+		"has been met",
+		"is met",
+		"condition was met",
+		"condition is met",
+	}
+	for _, marker := range trueMarkers {
+		if strings.Contains(lower, marker) {
+			return true, reason
+		}
+	}
+	if strings.HasPrefix(lower, "yes") || strings.HasPrefix(lower, "true") {
+		return true, reason
+	}
+
+	return false, "Hook evaluator returned non-JSON output; continuing goal to avoid premature stop. Raw: " + reason
+}
+
+func marshalStopHookVerdict(ok bool, reason string) string {
+	reason = compactHookReason(reason)
+	if reason == "" {
+		reason = "Hook evaluator did not provide a reason."
+	}
+
+	out, err := json.Marshal(claudeStopHookVerdict{
+		OK:     ok,
+		Reason: reason,
+	})
+	if err != nil {
+		return `{"ok":false,"reason":"Hook evaluator normalization failed."}`
+	}
+	return string(out)
+}
+
+func compactHookReason(reason string) string {
+	reason = strings.Join(strings.Fields(strings.TrimSpace(reason)), " ")
+	const maxRunes = 800
+	runes := []rune(reason)
+	if len(runes) > maxRunes {
+		reason = string(runes[:maxRunes]) + "..."
+	}
+	return reason
+}

--- a/proxy/hook_json_test.go
+++ b/proxy/hook_json_test.go
@@ -1,0 +1,55 @@
+package proxy
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestClaudeCodeStopHookEvaluatorDetection(t *testing.T) {
+	req := &ClaudeRequest{
+		Model: "claude-opus-5",
+		Messages: []ClaudeMessage{{
+			Role: "user",
+			Content: `Based on the conversation transcript above, has the following stopping condition been satisfied? Answer based on transcript evidence only.
+
+Condition: reply exactly DONE and stop
+
+ARGUMENTS: {"session_id":"s","transcript_path":"/tmp/t.jsonl","cwd":"/tmp","prompt_id":"p","permission_mode":"bypassPermissions","effort":{"level":"low"},"hook_event_name":"Stop","stop_hook_active":false,"last_assistant_message":"DONE","background_tasks":[],"session_crons":[]}`,
+		}},
+	}
+
+	if !isClaudeCodeStopHookEvaluatorRequest(req) {
+		t.Fatalf("expected Stop hook evaluator request to be detected")
+	}
+}
+
+func TestNormalizeClaudeStopHookEvaluatorTextExtractsFencedJSON(t *testing.T) {
+	got := normalizeClaudeStopHookEvaluatorText("```json\n{\"ok\": true, \"reason\": \"done\"}\n```")
+	assertStopHookVerdict(t, got, true, "done")
+}
+
+func TestNormalizeClaudeStopHookEvaluatorTextCoercesProse(t *testing.T) {
+	got := normalizeClaudeStopHookEvaluatorText("Yes, the stopping condition has been satisfied because the last assistant message is DONE.")
+	assertStopHookVerdict(t, got, true, "Yes,")
+}
+
+func TestNormalizeClaudeStopHookEvaluatorTextAmbiguousProseContinuesGoal(t *testing.T) {
+	got := normalizeClaudeStopHookEvaluatorText("The transcript is unclear and needs more work.")
+	assertStopHookVerdict(t, got, false, "non-JSON output")
+}
+
+func assertStopHookVerdict(t *testing.T, raw string, wantOK bool, reasonContains string) {
+	t.Helper()
+
+	var verdict claudeStopHookVerdict
+	if err := json.Unmarshal([]byte(raw), &verdict); err != nil {
+		t.Fatalf("normalized verdict is not JSON: %v raw=%q", err, raw)
+	}
+	if verdict.OK != wantOK {
+		t.Fatalf("ok = %v, want %v in %s", verdict.OK, wantOK, raw)
+	}
+	if reasonContains != "" && !strings.Contains(verdict.Reason, reasonContains) {
+		t.Fatalf("reason %q does not contain %q", verdict.Reason, reasonContains)
+	}
+}

--- a/proxy/kiro.go
+++ b/proxy/kiro.go
@@ -9,8 +9,10 @@ import (
 	"io"
 	"kiro-go/config"
 	"kiro-go/logger"
+	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -80,8 +82,8 @@ func GetClientForProxy(proxyURL string) *http.Client {
 		return cached.(*http.Client)
 	}
 	client := &http.Client{
-		Timeout:   5 * time.Minute,
-		Transport: buildKiroTransport(proxyURL),
+		// No Timeout: this client serves SSE streams (see buildKiroTransport).
+		Transport: buildKiroTransport(proxyURL, true),
 	}
 	proxyClientCache.Store(proxyURL, client)
 	return client
@@ -99,7 +101,7 @@ func GetRestClientForProxy(proxyURL string) *http.Client {
 	}
 	client := &http.Client{
 		Timeout:   30 * time.Second,
-		Transport: buildKiroTransport(proxyURL),
+		Transport: buildKiroTransport(proxyURL, false),
 	}
 	proxyClientCache.Store(cacheKey, client)
 	return client
@@ -114,14 +116,34 @@ func ResolveAccountProxyURL(account *config.Account) string {
 	return config.GetProxyURL()
 }
 
+// streamResponseHeaderTimeout bounds how long we wait for the upstream to send
+// response headers. Once headers arrive the stream may run arbitrarily long, so
+// no overall deadline is applied to streaming clients (see buildKiroTransport).
+const streamResponseHeaderTimeout = 2 * time.Minute
+
 // buildKiroTransport constructs an HTTP Transport with optional outbound proxy support.
-func buildKiroTransport(proxyURL string) *http.Transport {
+//
+// streaming selects the timeout policy. Streaming responses (SSE) must not carry
+// an overall deadline: http.Client.Timeout covers reading the response body, so
+// any cap would sever a healthy in-progress stream mid-token. Instead we bound
+// only the wait for response headers and let idle connection reaping handle
+// dead peers.
+func buildKiroTransport(proxyURL string, streaming bool) *http.Transport {
 	t := &http.Transport{
-		MaxIdleConns:        100,
-		MaxIdleConnsPerHost: 20,
-		IdleConnTimeout:     90 * time.Second,
-		DisableCompression:  false,
-		ForceAttemptHTTP2:   true,
+		DialContext: (&net.Dialer{
+			Timeout:   15 * time.Second,
+			KeepAlive: 15 * time.Second,
+		}).DialContext,
+		MaxIdleConns:          200,
+		MaxIdleConnsPerHost:   50,
+		IdleConnTimeout:       15 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		DisableCompression:    false,
+		ForceAttemptHTTP2:     true,
+	}
+	if streaming {
+		t.ResponseHeaderTimeout = streamResponseHeaderTimeout
 	}
 	if proxyURL != "" {
 		if u, err := url.Parse(proxyURL); err == nil {
@@ -130,22 +152,101 @@ func buildKiroTransport(proxyURL string) *http.Transport {
 			t.ForceAttemptHTTP2 = false
 		}
 	} else {
-		t.Proxy = http.ProxyFromEnvironment
+		t.Proxy = proxyFromCurrentEnvironment()
 	}
 	return t
 }
 
+func proxyFromCurrentEnvironment() func(*http.Request) (*url.URL, error) {
+	httpProxy := firstProxyEnv("HTTP_PROXY", "http_proxy")
+	httpsProxy := firstProxyEnv("HTTPS_PROXY", "https_proxy")
+	allProxy := firstProxyEnv("ALL_PROXY", "all_proxy")
+	noProxy := firstProxyEnv("NO_PROXY", "no_proxy")
+
+	return func(req *http.Request) (*url.URL, error) {
+		if req == nil || req.URL == nil || shouldBypassEnvProxy(req.URL.Hostname(), noProxy) {
+			return nil, nil
+		}
+
+		rawProxy := ""
+		switch strings.ToLower(req.URL.Scheme) {
+		case "https":
+			rawProxy = firstNonEmpty(httpsProxy, allProxy)
+		case "http":
+			rawProxy = firstNonEmpty(httpProxy, allProxy)
+		default:
+			rawProxy = allProxy
+		}
+		if rawProxy == "" {
+			return nil, nil
+		}
+		return parseEnvProxyURL(rawProxy)
+	}
+}
+
+func firstProxyEnv(names ...string) string {
+	for _, name := range names {
+		if value := strings.TrimSpace(os.Getenv(name)); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func parseEnvProxyURL(raw string) (*url.URL, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	if !strings.Contains(raw, "://") {
+		raw = "http://" + raw
+	}
+	return url.Parse(raw)
+}
+
+func shouldBypassEnvProxy(host, noProxy string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	noProxy = strings.ToLower(strings.TrimSpace(noProxy))
+	if host == "" || noProxy == "" {
+		return false
+	}
+	if noProxy == "*" {
+		return true
+	}
+	for _, entry := range strings.Split(noProxy, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		entry = strings.TrimPrefix(entry, ".")
+		if host == entry || strings.HasSuffix(host, "."+entry) {
+			return true
+		}
+	}
+	return false
+}
+
 // InitKiroHttpClient initializes (or reinitializes) the HTTP clients used for Kiro API requests.
 func InitKiroHttpClient(proxyURL string) {
+	// No overall Timeout: this client streams SSE responses whose duration is
+	// bounded by the model's output, not by the clock.
 	client := &http.Client{
-		Timeout:   5 * time.Minute,
-		Transport: buildKiroTransport(proxyURL),
+		Transport: buildKiroTransport(proxyURL, true),
 	}
 	kiroHttpStore.Store(client)
 
 	restClient := &http.Client{
 		Timeout:   30 * time.Second,
-		Transport: buildKiroTransport(proxyURL),
+		Transport: buildKiroTransport(proxyURL, false),
 	}
 	kiroRestHttpStore.Store(restClient)
 }
@@ -427,9 +528,12 @@ func CallKiroAPI(account *config.Account, payload *KiroPayload, callback *KiroSt
 		}
 
 		if resp.StatusCode == 429 {
+			retryAfter := strings.TrimSpace(resp.Header.Get("Retry-After"))
 			resp.Body.Close()
-			logger.Warnf("[KiroAPI] Endpoint %s quota exhausted (429), trying next...", ep.Name)
-			lastErr = fmt.Errorf("quota exhausted on %s", ep.Name)
+			if len(endpoints) > 1 {
+				logger.Warnf("[KiroAPI] Endpoint %s quota exhausted (429), trying next endpoint...", ep.Name)
+			}
+			lastErr = &upstreamQuotaError{endpoint: ep.Name, retryAfter: retryAfter}
 			continue
 		}
 
@@ -700,7 +804,6 @@ func collectUsageMaps(v interface{}, out *[]map[string]interface{}) {
 		}
 	}
 }
-
 
 func readTokenNumber(m map[string]interface{}, keys ...string) (int, bool) {
 	for _, k := range keys {

--- a/proxy/kiro.go
+++ b/proxy/kiro.go
@@ -474,6 +474,8 @@ func CallKiroAPI(account *config.Account, payload *KiroPayload, callback *KiroSt
 	isAPIKey := config.IsAPIKeyAccount(account)
 
 	var lastErr error
+	longestRetryAfter := time.Duration(0)
+	longestRetryAfterValue := ""
 	for _, ep := range endpoints {
 		// Update the origin field for the selected endpoint.
 		payload.ConversationState.CurrentMessage.UserInputMessage.Origin = ep.Origin
@@ -529,11 +531,15 @@ func CallKiroAPI(account *config.Account, payload *KiroPayload, callback *KiroSt
 
 		if resp.StatusCode == 429 {
 			retryAfter := strings.TrimSpace(resp.Header.Get("Retry-After"))
+			if cooldown := retryAfterDuration(retryAfter, time.Now()); cooldown > longestRetryAfter {
+				longestRetryAfter = cooldown
+				longestRetryAfterValue = retryAfter
+			}
 			resp.Body.Close()
 			if len(endpoints) > 1 {
 				logger.Warnf("[KiroAPI] Endpoint %s quota exhausted (429), trying next endpoint...", ep.Name)
 			}
-			lastErr = &upstreamQuotaError{endpoint: ep.Name, retryAfter: retryAfter}
+			lastErr = &upstreamQuotaError{endpoint: ep.Name, retryAfter: longestRetryAfterValue, retryFor: longestRetryAfter}
 			continue
 		}
 

--- a/proxy/kiro_test.go
+++ b/proxy/kiro_test.go
@@ -338,6 +338,52 @@ func TestCallKiroAPI429CarriesRetryAfter(t *testing.T) {
 	}
 }
 
+func TestCallKiroAPIPreservesLongestRetryAfterAcrossEndpoints(t *testing.T) {
+	if err := config.Init(filepath.Join(t.TempDir(), "config.json")); err != nil {
+		t.Fatalf("config.Init: %v", err)
+	}
+	serverLong := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "3600")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer serverLong.Close()
+	serverShort := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "10")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer serverShort.Close()
+
+	oldEndpoints := kiroEndpoints
+	kiroEndpoints = []kiroEndpoint{
+		{URL: serverLong.URL, Origin: "AI_EDITOR", Name: "long"},
+		{URL: serverShort.URL, Origin: "AI_EDITOR", Name: "short"},
+		{URL: serverShort.URL, Origin: "AI_EDITOR", Name: "short-duplicate"},
+	}
+	defer func() { kiroEndpoints = oldEndpoints }()
+	oldClient := kiroHttpStore.Load()
+	kiroHttpStore.Store(&http.Client{Timeout: time.Second, Transport: &http.Transport{}})
+	defer kiroHttpStore.Store(oldClient)
+
+	payload := &KiroPayload{}
+	payload.ConversationState.CurrentMessage.UserInputMessage = KiroUserInputMessage{
+		Content: "hello", ModelID: "claude-opus-5", Origin: "AI_EDITOR",
+	}
+	err := CallKiroAPI(&config.Account{
+		ID: "quota", Enabled: true, AccessToken: "token",
+		ProfileArn: "arn:aws:codewhisperer:profile/test",
+	}, payload, &KiroStreamCallback{})
+	var quotaErr *upstreamQuotaError
+	if !errors.As(err, &quotaErr) {
+		t.Fatalf("error=%v, want upstreamQuotaError", err)
+	}
+	if quotaErr.retryFor != time.Hour {
+		t.Fatalf("retryFor=%s, want 1h", quotaErr.retryFor)
+	}
+	if got := retryAfterHeader(err); got != "3600" {
+		t.Fatalf("Retry-After=%q, want 3600", got)
+	}
+}
+
 type rewriteRoundTripper struct {
 	target *url.URL
 	base   http.RoundTripper

--- a/proxy/kiro_test.go
+++ b/proxy/kiro_test.go
@@ -4,9 +4,12 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"kiro-go/config"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -199,7 +202,7 @@ func TestHandleToolUseEventReplacesGeneratedIDWhenRealIDArrives(t *testing.T) {
 }
 
 func TestBuildKiroTransportUsesExplicitProxyURL(t *testing.T) {
-	transport := buildKiroTransport("http://proxy.local:8080")
+	transport := buildKiroTransport("http://proxy.local:8080", true)
 	req := &http.Request{URL: mustParseURL(t, "https://q.us-east-1.amazonaws.com")}
 
 	got, err := transport.Proxy(req)
@@ -214,7 +217,7 @@ func TestBuildKiroTransportFallsBackToEnvironmentProxy(t *testing.T) {
 	t.Setenv("NO_PROXY", "")
 	t.Setenv("no_proxy", "")
 
-	transport := buildKiroTransport("")
+	transport := buildKiroTransport("", true)
 	req := &http.Request{URL: mustParseURL(t, "https://q.us-east-1.amazonaws.com")}
 
 	got, err := transport.Proxy(req)
@@ -224,18 +227,38 @@ func TestBuildKiroTransportFallsBackToEnvironmentProxy(t *testing.T) {
 	assertProxyURL(t, got, "http://env-proxy.local:2323")
 }
 
-func TestInitKiroHttpClientKeepsShortRestTimeout(t *testing.T) {
+// Streaming responses must not carry an overall client deadline: http.Client.Timeout
+// covers reading the body, so any cap severs a healthy in-progress SSE stream
+// mid-token. The header wait is bounded on the transport instead.
+func TestInitKiroHttpClientLeavesStreamingUnbounded(t *testing.T) {
 	InitKiroHttpClient("")
 	t.Cleanup(func() { InitKiroHttpClient("") })
 
 	streamClient := kiroHttpStore.Load()
 	restClient := kiroRestHttpStore.Load()
 
-	if streamClient.Timeout != 5*time.Minute {
-		t.Fatalf("expected streaming timeout to be 5m, got %s", streamClient.Timeout)
+	if streamClient.Timeout != 0 {
+		t.Fatalf("expected streaming client to have no overall timeout, got %s", streamClient.Timeout)
 	}
+	streamTransport, ok := streamClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected *http.Transport, got %T", streamClient.Transport)
+	}
+	if streamTransport.ResponseHeaderTimeout != streamResponseHeaderTimeout {
+		t.Fatalf("expected streaming header timeout %s, got %s",
+			streamResponseHeaderTimeout, streamTransport.ResponseHeaderTimeout)
+	}
+
 	if restClient.Timeout != 30*time.Second {
 		t.Fatalf("expected REST timeout to stay 30s, got %s", restClient.Timeout)
+	}
+	restTransport, ok := restClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected *http.Transport, got %T", restClient.Transport)
+	}
+	if restTransport.ResponseHeaderTimeout != 0 {
+		t.Fatalf("expected REST transport to rely on client timeout, got header timeout %s",
+			restTransport.ResponseHeaderTimeout)
 	}
 }
 
@@ -280,6 +303,51 @@ func TestEndpointsForAccountUsesCLIForAPIKey(t *testing.T) {
 	if got := cliRuntimeURL(&config.Account{Region: "eu-central-1"}); got != "https://runtime.eu-central-1.kiro.dev/" {
 		t.Fatalf("cli url = %q", got)
 	}
+}
+
+func TestCallKiroAPI429CarriesRetryAfter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "45")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	targetURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	originalClient := kiroHttpStore.Load()
+	kiroHttpStore.Store(&http.Client{Transport: rewriteRoundTripper{
+		target: targetURL,
+		base:   server.Client().Transport,
+	}})
+	t.Cleanup(func() { kiroHttpStore.Store(originalClient) })
+	if err := config.Init(filepath.Join(t.TempDir(), "config.json")); err != nil {
+		t.Fatalf("init config: %v", err)
+	}
+
+	account := &config.Account{AuthMethod: "api_key", KiroApiKey: "ksk_test", Region: "us-east-1"}
+	callErr := CallKiroAPI(account, &KiroPayload{}, nil)
+
+	var quotaErr *upstreamQuotaError
+	if !errors.As(callErr, &quotaErr) {
+		t.Fatalf("expected upstreamQuotaError, got %T: %v", callErr, callErr)
+	}
+	if quotaErr.retryAfter != "45" {
+		t.Fatalf("retry-after = %q, want 45", quotaErr.retryAfter)
+	}
+}
+
+type rewriteRoundTripper struct {
+	target *url.URL
+	base   http.RoundTripper
+}
+
+func (rt rewriteRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	clone.URL = rt.target
+	clone.Host = rt.target.Host
+	return rt.base.RoundTrip(clone)
 }
 
 func mustParseURL(t *testing.T, raw string) *url.URL {

--- a/proxy/quota_response_test.go
+++ b/proxy/quota_response_test.go
@@ -1,0 +1,57 @@
+package proxy
+
+import (
+	"io"
+	"kiro-go/config"
+	accountpool "kiro-go/pool"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type quotaRoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f quotaRoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestClaudeQuotaFailureReturns429AndRetryAfter(t *testing.T) {
+	if err := config.Init(filepath.Join(t.TempDir(), "config.json")); err != nil {
+		t.Fatalf("config.Init: %v", err)
+	}
+
+	account := config.Account{
+		ID: "quota", Enabled: true, AuthMethod: "api_key",
+		KiroApiKey: "ksk_quota", Region: "us-east-1",
+	}
+	p := accountpool.NewTestPool(account)
+	p.SetModelList("quota", []string{"claude-opus-5"})
+
+	oldClient := kiroHttpStore.Load()
+	kiroHttpStore.Store(&http.Client{Transport: quotaRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusTooManyRequests,
+			Header:     http.Header{"Retry-After": []string{"45"}},
+			Body:       io.NopCloser(strings.NewReader("quota")),
+			Request:    req,
+		}, nil
+	})})
+	t.Cleanup(func() { kiroHttpStore.Store(oldClient) })
+
+	h := &Handler{pool: p, promptCache: newPromptCacheTracker(defaultPromptCacheTTL)}
+	payload := &KiroPayload{}
+	payload.ConversationState.CurrentMessage.UserInputMessage = KiroUserInputMessage{
+		Content: "hi", ModelID: "claude-opus-5", Origin: "AI_EDITOR",
+	}
+	rec := httptest.NewRecorder()
+	h.handleClaudeNonStream(rec, nil, nil, nil, payload, "claude-opus-5", false, claudeThinkingResponseOptions{}, 1, nil, "", false)
+
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("status=%d body=%s, want 429", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Retry-After"); got != "45" {
+		t.Fatalf("Retry-After=%q, want 45", got)
+	}
+}

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -211,7 +211,8 @@ func (h *Handler) handleResponsesNonStream(
 		return
 	}
 	h.recordFailureWithDetails("responses", model, "", lastErr)
-	h.sendOpenAIError(w, 500, "server_error", lastErr.Error())
+	setRetryAfterHeader(w, lastErr)
+	h.sendOpenAIError(w, upstreamErrorHTTPStatus(lastErr), "server_error", lastErr.Error())
 }
 
 func buildResponsesObject(

--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -22,9 +22,10 @@ type modelMapping struct {
 }
 
 var modelAliases = []modelMapping{
+	{"claude-sonnet-5", "claude-sonnet-4.5"},
 	{"claude-sonnet-4-20250514", "claude-sonnet-4"},
 	{"claude-3-5-sonnet", "claude-sonnet-4.5"},
-	{"claude-3-opus", "claude-sonnet-4.5"},
+	{"claude-3-opus", "claude-opus-4.6"},
 	{"claude-3-sonnet", "claude-sonnet-4"},
 	{"claude-3-haiku", "claude-haiku-4.5"},
 	{"gpt-4-turbo", "claude-sonnet-4.5"},

--- a/proxy/translator_test.go
+++ b/proxy/translator_test.go
@@ -415,7 +415,9 @@ func TestParseModelAndThinking(t *testing.T) {
 		{"sonnet dot form", "claude-sonnet-4.6", "claude-sonnet-4.6", false},
 		{"haiku dash form", "claude-haiku-4-5", "claude-haiku-4.5", false},
 		{"haiku dot form", "claude-haiku-4.5", "claude-haiku-4.5", false},
-		{"future major bump", "claude-sonnet-5-0", "claude-sonnet-5.0", false},
+		{"sonnet 5 alias with version suffix", "claude-sonnet-5-0", "claude-sonnet-4.5", false},
+		{"opus 5 pass through", "claude-opus-5", "claude-opus-5", false},
+		{"opus 5 thinking pass through", "claude-opus-5-thinking", "claude-opus-5", true},
 
 		// Bare family name passes through (no minor to normalize).
 		{"bare sonnet 4", "claude-sonnet-4", "claude-sonnet-4", false},
@@ -425,7 +427,7 @@ func TestParseModelAndThinking(t *testing.T) {
 
 		// Cross-family legacy IDs.
 		{"claude 3.5 sonnet", "claude-3-5-sonnet", "claude-sonnet-4.5", false},
-		{"claude 3 opus", "claude-3-opus", "claude-sonnet-4.5", false},
+		{"claude 3 opus", "claude-3-opus", "claude-opus-4.6", false},
 		{"claude 3 sonnet", "claude-3-sonnet", "claude-sonnet-4", false},
 		{"claude 3 haiku", "claude-3-haiku", "claude-haiku-4.5", false},
 
@@ -526,6 +528,13 @@ func TestClaudeToolResultMixedTextAndImage(t *testing.T) {
 	req := &ClaudeRequest{
 		Model: "claude-opus-4.8",
 		Messages: []ClaudeMessage{
+			{Role: "user", Content: "hello"},
+			{
+				Role: "assistant",
+				Content: []map[string]interface{}{
+					{"type": "tool_use", "id": "tool_2", "name": "take_screenshot", "input": map[string]interface{}{}},
+				},
+			},
 			{
 				Role: "user",
 				Content: []interface{}{
@@ -626,13 +635,12 @@ func TestOpenAIToolResultImageCarriedWhenFollowedByUser(t *testing.T) {
 
 	var toolHistImages int
 	for _, h := range payload.ConversationState.History {
-		if h.UserInputMessage != nil && h.UserInputMessage.UserInputMessageContext != nil &&
-			len(h.UserInputMessage.UserInputMessageContext.ToolResults) > 0 {
+		if h.UserInputMessage != nil && len(h.UserInputMessage.Images) > 0 {
 			toolHistImages += len(h.UserInputMessage.Images)
 		}
 	}
 	if toolHistImages != 1 {
-		t.Fatalf("expected tool image carried on the flushed tool-result history entry, got %d", toolHistImages)
+		t.Fatalf("expected tool image carried on the history entry, got %d", toolHistImages)
 	}
 
 	cur := payload.ConversationState.CurrentMessage.UserInputMessage

--- a/proxy/websearch.go
+++ b/proxy/websearch.go
@@ -530,6 +530,7 @@ func (h *Handler) handleWebSearchRequest(w http.ResponseWriter, req *ClaudeReque
 			status = 429
 			errType = "rate_limit_error"
 		}
+		setRetryAfterHeader(w, err)
 		h.sendClaudeError(w, status, errType, "Web search failed: "+err.Error())
 		return
 	}

--- a/proxy/websearch_loop.go
+++ b/proxy/websearch_loop.go
@@ -67,6 +67,7 @@ func (h *Handler) runWebSearchLoop(w http.ResponseWriter, req *ClaudeRequest, th
 				status = 429
 				errType = "rate_limit_error"
 			}
+			setRetryAfterHeader(w, err)
 			h.sendClaudeError(w, status, errType, err.Error())
 			return
 		}
@@ -83,7 +84,8 @@ func (h *Handler) runWebSearchLoop(w http.ResponseWriter, req *ClaudeRequest, th
 			if searchErr != nil {
 				logger.Warnf("[WebSearchLoop] MCP search failed: %v", searchErr)
 				h.recordFailureWithDetails("claude", req.Model, lastAccountID, searchErr)
-				h.sendClaudeError(w, 502, "api_error", "Web search failed: "+searchErr.Error())
+				setRetryAfterHeader(w, searchErr)
+				h.sendClaudeError(w, upstreamErrorHTTPStatus(searchErr), "api_error", "Web search failed: "+searchErr.Error())
 				return
 			}
 			searchCount += roundSearchN
@@ -107,7 +109,8 @@ func (h *Handler) runWebSearchLoop(w http.ResponseWriter, req *ClaudeRequest, th
 			if sErr != nil {
 				logger.Warnf("[WebSearchLoop] final-round MCP search failed: %v", sErr)
 				h.recordFailureWithDetails("claude", req.Model, lastAccountID, sErr)
-				h.sendClaudeError(w, 502, "api_error", "Web search failed: "+sErr.Error())
+				setRetryAfterHeader(w, sErr)
+				h.sendClaudeError(w, upstreamErrorHTTPStatus(sErr), "api_error", "Web search failed: "+sErr.Error())
 				return
 			}
 			searched[i] = results

--- a/web/app.js
+++ b/web/app.js
@@ -1578,8 +1578,79 @@
     const d = await res.json();
     $('requireApiKey').checked = d.requireApiKey;
     $('allowOverUsage').checked = d.allowOverUsage || false;
-    await Promise.all([loadThinkingConfig(), loadEndpointConfig(), loadProxyConfig(), loadPromptFilter(), loadApiKeys()]);
+    await Promise.all([loadThinkingConfig(), loadEndpointConfig(), loadProxyConfig(), loadPromptFilter(), loadApiKeys(), loadExternalApiConfig()]);
     refreshCustomSelects();
+  }
+
+  async function loadExternalApiConfig() {
+    try {
+      const res = await api('/external-api');
+      const d = await res.json();
+      if ($('externalApiPriority')) $('externalApiPriority').checked = d.enabled || false;
+      if ($('externalBaseUrl')) $('externalBaseUrl').value = d.baseUrl || '';
+      if ($('externalApiKey')) $('externalApiKey').value = d.apiKey || d.authToken || '';
+      if ($('externalDefaultModel')) $('externalDefaultModel').value = d.defaultModel || 'opus';
+      if ($('externalOpusModel')) $('externalOpusModel').value = d.defaultOpusModel || 'claude-opus-5';
+      if ($('externalSonnetModel')) $('externalSonnetModel').value = d.defaultSonnetModel || 'claude-sonnet-4.5';
+      if ($('externalHaikuModel')) $('externalHaikuModel').value = d.defaultHaikuModel || 'claude-haiku-4.5';
+      updateExternalRoutingStatus();
+    } catch (e) {
+      console.error('Failed to load external API config', e);
+    }
+  }
+
+  function updateExternalRoutingStatus() {
+    const el = $('externalRoutingStatus');
+    if (!el) return;
+    const enabled = $('externalApiPriority') && $('externalApiPriority').checked;
+    const baseUrl = $('externalBaseUrl') ? $('externalBaseUrl').value.trim() : '';
+    if (enabled && baseUrl) {
+      el.textContent = 'Routing hiện tại: External API (' + baseUrl + '). Nếu lỗi mạng sẽ fallback về Account List Kiro.';
+    } else if (enabled) {
+      el.textContent = 'Routing hiện tại: External API đang bật nhưng chưa có URL.';
+    } else {
+      el.textContent = 'Routing hiện tại: Account List Kiro.';
+    }
+  }
+
+  async function saveExternalApiConfig() {
+    try {
+      const payload = {
+        enabled: $('externalApiPriority') ? $('externalApiPriority').checked : false,
+        baseUrl: $('externalBaseUrl') ? $('externalBaseUrl').value.trim() : '',
+        apiKey: $('externalApiKey') ? $('externalApiKey').value.trim() : '',
+        authToken: $('externalApiKey') ? $('externalApiKey').value.trim() : '',
+        defaultModel: $('externalDefaultModel') && $('externalDefaultModel').value.trim() ? $('externalDefaultModel').value.trim() : 'opus',
+        defaultOpusModel: $('externalOpusModel') && $('externalOpusModel').value.trim() ? $('externalOpusModel').value.trim() : 'claude-opus-5',
+        defaultSonnetModel: $('externalSonnetModel') && $('externalSonnetModel').value.trim() ? $('externalSonnetModel').value.trim() : 'claude-sonnet-4.5',
+        defaultHaikuModel: $('externalHaikuModel') && $('externalHaikuModel').value.trim() ? $('externalHaikuModel').value.trim() : 'claude-haiku-4.5',
+        disableNonessentialTraffic: true,
+        timeoutMs: 600000
+      };
+      const res = await api('/external-api', {
+        method: 'POST',
+        body: JSON.stringify(payload)
+      });
+      const d = await res.json();
+      if (d.success) {
+        updateExternalRoutingStatus();
+        toast('Lưu cấu hình Model & External API thành công!', 'success');
+      }
+      else toast('Lưu cấu hình thất bại: ' + (d.error || ''), 'error');
+    } catch (e) {
+      toast('Lưu cấu hình thất bại: ' + e.message, 'error');
+    }
+  }
+
+  function applyTuongTacFreePreset() {
+    if ($('externalApiPriority')) $('externalApiPriority').checked = true;
+    if ($('externalBaseUrl')) $('externalBaseUrl').value = 'https://api.tuongtacfree.vn/';
+    if ($('externalDefaultModel')) $('externalDefaultModel').value = 'opus';
+    if ($('externalOpusModel')) $('externalOpusModel').value = 'claude-opus-5';
+    if ($('externalSonnetModel')) $('externalSonnetModel').value = 'claude-sonnet-4.5';
+    if ($('externalHaikuModel')) $('externalHaikuModel').value = 'claude-haiku-4.5';
+    updateExternalRoutingStatus();
+    saveExternalApiConfig();
   }
   async function loadThinkingConfig() {
     const res = await api('/thinking');
@@ -3226,6 +3297,10 @@
   function bindSettingsEvents() {
     $('saveRequireApiKeyBtn').addEventListener('click', saveRequireApiKey);
     $('saveOverUsageBtn').addEventListener('click', saveOverUsageConfig);
+    if ($('saveExternalApiBtn')) $('saveExternalApiBtn').addEventListener('click', saveExternalApiConfig);
+    if ($('applyTuongTacFreePresetBtn')) $('applyTuongTacFreePresetBtn').addEventListener('click', applyTuongTacFreePreset);
+    if ($('externalApiPriority')) $('externalApiPriority').addEventListener('change', updateExternalRoutingStatus);
+    if ($('externalBaseUrl')) $('externalBaseUrl').addEventListener('input', updateExternalRoutingStatus);
     $('saveThinkingBtn').addEventListener('click', saveThinkingConfig);
     $('saveEndpointBtn').addEventListener('click', saveEndpointConfig);
     $('changePasswordBtn').addEventListener('click', changePassword);

--- a/web/index.html
+++ b/web/index.html
@@ -273,6 +273,47 @@
           <button class="btn btn-primary" id="saveOverUsageBtn" data-i18n="settings.saveUsage"></button>
         </div>
 
+        <!-- Custom Model & External API settings -->
+        <div class="card">
+          <div class="card-header"><span class="card-title"><i class="fa-solid fa-cloud-bolt"></i> Cấu hình Model & Priority Call URL</span></div>
+          <div class="form-group mb-3">
+            <label class="flex items-center gap-2 cursor-pointer">
+              <span class="switch"><input type="checkbox" id="externalApiPriority" /><span class="slider"></span></span>
+              <span class="font-semibold">Dùng External API thay cho Account List Kiro</span>
+            </label>
+            <small class="text-xs text-gray-500 block mt-1">Bật: gọi URL ngoài trước. Tắt: dùng Account List Kiro như cũ, không xoá hay tắt account nào.</small>
+            <div id="externalRoutingStatus" class="text-xs muted-text mt-2"></div>
+          </div>
+          <div class="form-group">
+            <label class="font-semibold">ANTHROPIC_BASE_URL (URL API ngoài)</label>
+            <input type="text" id="externalBaseUrl" placeholder="https://api.tuongtacfree.vn/" />
+          </div>
+          <div class="form-group">
+            <label class="font-semibold">ANTHROPIC_API_KEY / Auth Token</label>
+            <input type="password" id="externalApiKey" placeholder="sk-..." autocomplete="off" />
+          </div>
+          <div class="form-group">
+            <label class="font-semibold">Model Mặc Định (Default Model)</label>
+            <input type="text" id="externalDefaultModel" placeholder="opus" />
+          </div>
+          <div class="form-group">
+            <label class="text-xs font-semibold">Opus Model</label>
+            <input type="text" id="externalOpusModel" placeholder="claude-opus-5" />
+          </div>
+          <div class="form-group">
+            <label class="text-xs font-semibold">Sonnet Model</label>
+            <input type="text" id="externalSonnetModel" placeholder="claude-sonnet-4.5" />
+          </div>
+          <div class="form-group">
+            <label class="text-xs font-semibold">Haiku Model</label>
+            <input type="text" id="externalHaikuModel" placeholder="claude-haiku-4.5" />
+          </div>
+          <div class="flex flex-wrap gap-2 mt-4" style="display: flex; gap: 0.5rem; flex-wrap: wrap; margin-top: 1rem;">
+            <button class="btn btn-primary" id="saveExternalApiBtn"><i class="fa-solid fa-floppy-disk"></i> Lưu Cấu Hình Model & API</button>
+            <button class="btn btn-outline" id="applyTuongTacFreePresetBtn" type="button"><i class="fa-solid fa-wand-magic-sparkles"></i> Áp Dụng Preset TuongTacFree (không gồm API key)</button>
+          </div>
+        </div>
+
         <!-- Thinking settings -->
         <div class="card">
           <div class="card-header"><span class="card-title" data-i18n="settings.thinkingSettings"></span></div>


### PR DESCRIPTION
## Summary
- add configurable external Anthropic/OpenAI-compatible routing for Claude CLI
- fall back to the Kiro account pool on retryable external transport/408/425/429/5xx failures before committing a response
- add a bounded circuit breaker with one half-open probe
- respect Kiro account cooldowns and upstream Retry-After hints to prevent quota retry storms
- normalize Claude Code stop-hook JSON responses and preserve streaming compatibility

## Verification
- go test ./... -count=1
- go vet ./...
- go build .
- targeted race tests for account selection, Retry-After, and external circuit behavior
- isolated clean-worktree test/vet/build passed
- local API smoke: /health and /v1/models returned 200; Claude/OpenAI paths returned clean 503 when no account was configured

## Notes
- Docker build was not run because the local Docker daemon is not available.
