### PR TITLE
feat: estimate local OpenAI cache usage

### DIFF
--- a/proxy/cache_tracker.go
+++ b/proxy/cache_tracker.go
@@ -125,6 +125,69 @@ func (t *promptCacheTracker) BuildClaudeProfile(req *ClaudeRequest, totalInputTo
 	}
 }
 
+// BuildOpenAIProfile creates a conservative, local-only cache profile for an
+// OpenAI request after it has been translated to Kiro's wire payload. Only
+// stable conversation material is fingerprinted: model, previous history,
+// tool definitions, and inference configuration. The current user message,
+// images, and current tool-result bodies are deliberately excluded so they are
+// never reported as cache hits.
+func (t *promptCacheTracker) BuildOpenAIProfile(payload *KiroPayload, totalInputTokens int) *promptCacheProfile {
+	if t == nil || payload == nil || totalInputTokens <= 0 {
+		return nil
+	}
+
+	current := payload.ConversationState.CurrentMessage.UserInputMessage
+	stable := map[string]interface{}{
+		"model":            current.ModelID,
+		"inference_config": payload.InferenceConfig,
+	}
+	if current.UserInputMessageContext != nil {
+		// Tools are stable prompt material. Tool results belong to the current
+		// dynamic turn and must not participate in a cache-hit estimate.
+		stable["tools"] = current.UserInputMessageContext.Tools
+	}
+
+	// Keep a cumulative breakpoint after every historic message. A follow-up
+	// request may append new history, but it can still reuse an earlier stable
+	// prefix. The current dynamic message is intentionally never appended.
+	hasher := sha256.New()
+	cumulativeTokens := 0
+	appendStableBlock := func(value interface{}) {
+		canonical := canonicalizeCacheValue(value)
+		writeHashChunk(hasher, canonical)
+		cumulativeTokens += estimateApproxTokens(canonical)
+	}
+	appendStableBlock(stable)
+
+	breakpoints := make([]promptCacheBreakpoint, 0, len(payload.ConversationState.History)+1)
+	appendBreakpoint := func() {
+		if cumulativeTokens < minCacheableTokensForModel(current.ModelID) {
+			return
+		}
+		fingerprint := [32]byte{}
+		copy(fingerprint[:], hasher.Sum(nil))
+		breakpoints = append(breakpoints, promptCacheBreakpoint{
+			Fingerprint:      fingerprint,
+			CumulativeTokens: minInt(cumulativeTokens, totalInputTokens),
+			TTL:              defaultPromptCacheTTL,
+		})
+	}
+	appendBreakpoint()
+	for _, historyMessage := range payload.ConversationState.History {
+		appendStableBlock(historyMessage)
+		appendBreakpoint()
+	}
+	if len(breakpoints) == 0 {
+		return nil
+	}
+
+	return &promptCacheProfile{
+		Breakpoints:      breakpoints,
+		TotalInputTokens: totalInputTokens,
+		Model:            current.ModelID,
+	}
+}
+
 func (t *promptCacheTracker) Compute(accountID string, profile *promptCacheProfile) promptCacheUsage {
 	if t == nil || profile == nil || len(profile.Breakpoints) == 0 || accountID == "" {
 		return promptCacheUsage{}

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -2132,6 +2132,7 @@ func (h *Handler) handleOpenAIStream(ctx context.Context, w http.ResponseWriter,
 		h.recordSuccessForApiKey(apiKeyID, inputTokens, outputTokens, credits)
 		h.pool.RecordSuccess(account.ID)
 		h.pool.UpdateStats(account.ID, inputTokens+outputTokens, credits)
+		cacheDetails := resolveOpenAICacheUsage(h.promptCache, account.ID, payload, inputTokens)
 		h.recordSuccessLog("openai", model, account.ID, inputTokens+outputTokens, credits, time.Since(reqStart).Milliseconds())
 		finishReason := mapOpenAIFinishReason(upstreamStopReason, len(toolCalls))
 
@@ -2145,11 +2146,7 @@ func (h *Handler) handleOpenAIStream(ctx context.Context, w http.ResponseWriter,
 				"delta":         map[string]interface{}{},
 				"finish_reason": finishReason,
 			}},
-			"usage": map[string]int{
-				"prompt_tokens":     inputTokens,
-				"completion_tokens": outputTokens,
-				"total_tokens":      inputTokens + outputTokens,
-			},
+			"usage": buildOpenAIUsage(inputTokens, outputTokens, cacheDetails),
 		}
 		data, _ := json.Marshal(chunk)
 		fmt.Fprintf(w, "data: %s\n\n", string(data))
@@ -2260,10 +2257,11 @@ func (h *Handler) handleOpenAINonStream(ctx context.Context, w http.ResponseWrit
 		h.recordSuccessForApiKey(apiKeyID, inputTokens, outputTokens, credits)
 		h.pool.RecordSuccess(account.ID)
 		h.pool.UpdateStats(account.ID, inputTokens+outputTokens, credits)
+		cacheDetails := resolveOpenAICacheUsage(h.promptCache, account.ID, payload, inputTokens)
 		h.recordSuccessLog("openai", model, account.ID, inputTokens+outputTokens, credits, time.Since(reqStart).Milliseconds())
 
 		thinkingFormat := config.GetThinkingConfig().OpenAIFormat
-		resp := KiroToOpenAIResponseWithReasoning(finalContent, reasoningContent, toolUses, inputTokens, outputTokens, model, thinkingFormat, upstreamStopReason)
+		resp := KiroToOpenAIResponseWithReasoning(finalContent, reasoningContent, toolUses, inputTokens, outputTokens, model, thinkingFormat, upstreamStopReason, cacheDetails)
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		json.NewEncoder(w).Encode(resp)
 		return

--- a/proxy/openai_usage.go
+++ b/proxy/openai_usage.go
@@ -1,0 +1,41 @@
+package proxy
+
+// OpenAITokenDetails contains the cache components OpenAI-compatible clients
+// understand. CachedTokens and CacheWriteTokens are subsets of the top-level
+// input/prompt token count.
+type OpenAITokenDetails struct {
+	CachedTokens     int `json:"cached_tokens"`
+	CacheWriteTokens int `json:"cache_write_tokens"`
+}
+
+func resolveOpenAICacheUsage(tracker *promptCacheTracker, accountID string, payload *KiroPayload, inputTokens int) *OpenAITokenDetails {
+	if tracker == nil {
+		return nil
+	}
+	profile := tracker.BuildOpenAIProfile(payload, inputTokens)
+	if profile == nil {
+		return nil
+	}
+	estimated := tracker.Compute(accountID, profile)
+	// Store only after a successful upstream response.
+	tracker.Update(accountID, profile)
+	if estimated.CacheReadInputTokens == 0 && estimated.CacheCreationInputTokens == 0 {
+		return nil
+	}
+	return &OpenAITokenDetails{
+		CachedTokens:     estimated.CacheReadInputTokens,
+		CacheWriteTokens: estimated.CacheCreationInputTokens,
+	}
+}
+
+func buildOpenAIUsage(inputTokens, outputTokens int, details *OpenAITokenDetails) map[string]interface{} {
+	usage := map[string]interface{}{
+		"prompt_tokens":     inputTokens,
+		"completion_tokens": outputTokens,
+		"total_tokens":      inputTokens + outputTokens,
+	}
+	if details != nil {
+		usage["prompt_tokens_details"] = details
+	}
+	return usage
+}

--- a/proxy/openai_usage_test.go
+++ b/proxy/openai_usage_test.go
@@ -1,0 +1,81 @@
+package proxy
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func estimatedOpenAIPayload(currentContent string) *KiroPayload {
+	payload := &KiroPayload{}
+	payload.ConversationState.CurrentMessage.UserInputMessage = KiroUserInputMessage{
+		Content: currentContent,
+		ModelID: "claude-sonnet-4.5",
+		Origin:  "AI_EDITOR",
+	}
+	payload.ConversationState.History = []KiroHistoryMessage{
+		{UserInputMessage: &KiroUserInputMessage{
+			Content: strings.Repeat("stable conversation prefix ", 260),
+			ModelID: "claude-sonnet-4.5",
+			Origin:  "AI_EDITOR",
+		}},
+		{AssistantResponseMessage: &KiroAssistantResponseMessage{
+			Content: strings.Repeat("stable assistant reply ", 80),
+		}},
+	}
+	return payload
+}
+
+func TestResolveOpenAICacheUsageEstimatedLifecycle(t *testing.T) {
+	tracker := newPromptCacheTracker(time.Hour)
+	firstPayload := estimatedOpenAIPayload("first dynamic user turn")
+
+	first := resolveOpenAICacheUsage(tracker, "account-a", firstPayload, 4096)
+	if first == nil {
+		t.Fatalf("first cache usage = %#v, want estimated details", first)
+	}
+	if first.CacheWriteTokens <= 0 || first.CachedTokens != 0 {
+		t.Fatalf("first cache details = %#v, want write-only estimate", first)
+	}
+
+	// Current message text is deliberately excluded from the stable-prefix
+	// fingerprint, so a subsequent turn can reuse the stored prefix.
+	secondPayload := estimatedOpenAIPayload("different dynamic user turn")
+	second := resolveOpenAICacheUsage(tracker, "account-a", secondPayload, 4096)
+	if second == nil {
+		t.Fatalf("second cache usage = %#v, want estimated details", second)
+	}
+	if second.CachedTokens <= 0 || second.CacheWriteTokens != 0 {
+		t.Fatalf("second cache details = %#v, want read-only estimate", second)
+	}
+
+	otherAccount := resolveOpenAICacheUsage(tracker, "account-b", secondPayload, 4096)
+	if otherAccount == nil || otherAccount.CachedTokens != 0 || otherAccount.CacheWriteTokens <= 0 {
+		t.Fatalf("other account cache details = %#v, want independent write-only estimate", otherAccount)
+	}
+}
+
+func TestResolveOpenAICacheUsageHitsEarlierPrefixWhenHistoryGrows(t *testing.T) {
+	tracker := newPromptCacheTracker(time.Hour)
+	firstPayload := estimatedOpenAIPayload("first dynamic user turn")
+	first := resolveOpenAICacheUsage(tracker, "account-a", firstPayload, 4096)
+	if first == nil || first.CacheWriteTokens <= 0 {
+		t.Fatalf("first cache usage = %#v, want write-only estimate", first)
+	}
+
+	// The next turn adds history after the already stored stable prefix. The
+	// current user turn remains excluded, so the tracker must still find the
+	// earlier cumulative history breakpoint.
+	grownPayload := estimatedOpenAIPayload("second dynamic user turn")
+	grownPayload.ConversationState.History = append(grownPayload.ConversationState.History,
+		KiroHistoryMessage{UserInputMessage: &KiroUserInputMessage{
+			Content: strings.Repeat("newer stable history ", 120),
+			ModelID: "claude-sonnet-4.5",
+			Origin:  "AI_EDITOR",
+		}},
+	)
+	got := resolveOpenAICacheUsage(tracker, "account-a", grownPayload, 6144)
+	if got == nil || got.CachedTokens <= 0 {
+		t.Fatalf("grown history cache usage = %#v, want read from earlier prefix", got)
+	}
+}

--- a/proxy/responses_handler.go
+++ b/proxy/responses_handler.go
@@ -217,9 +217,10 @@ func (h *Handler) handleResponsesNonStream(
 		h.recordSuccessForApiKey(apiKeyID, inputTokens, outputTokens, credits)
 		h.pool.RecordSuccess(account.ID)
 		h.pool.UpdateStats(account.ID, inputTokens+outputTokens, credits)
+		cacheDetails := resolveOpenAICacheUsage(h.promptCache, account.ID, payload, inputTokens)
 		h.recordSuccessLog("responses", model, account.ID, inputTokens+outputTokens, credits, time.Since(reqStart).Milliseconds())
 
-		respObj := buildResponsesObject(respID, model, finalContent, toolUses, inputTokens, outputTokens, req, upstreamStopReason)
+		respObj := buildResponsesObject(respID, model, finalContent, toolUses, inputTokens, outputTokens, req, upstreamStopReason, cacheDetails)
 		respObj.StoredInput = storedInput
 		respObj.Instructions = req.Instructions
 
@@ -255,7 +256,7 @@ func mapResponsesCompletion(reason string) (status, incompleteReason string) {
 
 func buildResponsesObject(
 	id, model, content string, toolUses []KiroToolUse,
-	inputTokens, outputTokens int, req *ResponsesRequest, upstreamStopReason string,
+	inputTokens, outputTokens int, req *ResponsesRequest, upstreamStopReason string, cacheDetails *OpenAITokenDetails,
 ) *ResponsesObject {
 	output := make([]ResponseOutputItem, 0, 1+len(toolUses))
 
@@ -310,7 +311,7 @@ func buildResponsesObject(
 		Status:             status,
 		Model:              model,
 		Output:             output,
-		Usage:              ResponsesUsage{InputTokens: inputTokens, OutputTokens: outputTokens, TotalTokens: inputTokens + outputTokens},
+		Usage:              ResponsesUsage{InputTokens: inputTokens, OutputTokens: outputTokens, TotalTokens: inputTokens + outputTokens, InputTokenDetails: cacheDetails},
 		PreviousResponseID: req.PreviousResponseID,
 		Metadata:           req.Metadata,
 		IncompleteDetails:  incompleteDetails,
@@ -612,9 +613,10 @@ func (h *Handler) handleResponsesStream(
 		h.recordSuccessForApiKey(apiKeyID, inputTokens, outputTokens, credits)
 		h.pool.RecordSuccess(account.ID)
 		h.pool.UpdateStats(account.ID, inputTokens+outputTokens, credits)
+		cacheDetails := resolveOpenAICacheUsage(h.promptCache, account.ID, payload, inputTokens)
 		h.recordSuccessLog("responses", model, account.ID, inputTokens+outputTokens, credits, time.Since(reqStart).Milliseconds())
 
-		respObj := buildResponsesObject(respID, model, finalContent, toolUses, inputTokens, outputTokens, req, upstreamStopReason)
+		respObj := buildResponsesObject(respID, model, finalContent, toolUses, inputTokens, outputTokens, req, upstreamStopReason, cacheDetails)
 		respObj.CreatedAt = createdAt
 		respObj.StoredInput = storedInput
 		respObj.Instructions = req.Instructions

--- a/proxy/responses_types.go
+++ b/proxy/responses_types.go
@@ -51,9 +51,10 @@ type ResponseContentPart struct {
 }
 
 type ResponsesUsage struct {
-	InputTokens  int `json:"input_tokens"`
-	OutputTokens int `json:"output_tokens"`
-	TotalTokens  int `json:"total_tokens"`
+	InputTokens       int                 `json:"input_tokens"`
+	OutputTokens      int                 `json:"output_tokens"`
+	TotalTokens       int                 `json:"total_tokens"`
+	InputTokenDetails *OpenAITokenDetails `json:"input_tokens_details,omitempty"`
 }
 
 type ResponsesError struct {

--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -1173,9 +1173,10 @@ type OpenAIChoice struct {
 }
 
 type OpenAIUsage struct {
-	PromptTokens     int `json:"prompt_tokens"`
-	CompletionTokens int `json:"completion_tokens"`
-	TotalTokens      int `json:"total_tokens"`
+	PromptTokens       int                 `json:"prompt_tokens"`
+	CompletionTokens   int                 `json:"completion_tokens"`
+	TotalTokens        int                 `json:"total_tokens"`
+	PromptTokenDetails *OpenAITokenDetails `json:"prompt_tokens_details,omitempty"`
 }
 
 // ==================== OpenAI -> Kiro 转换 ====================
@@ -2196,7 +2197,7 @@ func extractThinkingFromContent(content string) (string, string) {
 }
 
 // KiroToOpenAIResponseWithReasoning 带 reasoning_content 的 OpenAI 响应
-func KiroToOpenAIResponseWithReasoning(content, reasoningContent string, toolUses []KiroToolUse, inputTokens, outputTokens int, model, thinkingFormat, upstreamStopReason string) map[string]interface{} {
+func KiroToOpenAIResponseWithReasoning(content, reasoningContent string, toolUses []KiroToolUse, inputTokens, outputTokens int, model, thinkingFormat, upstreamStopReason string, cacheDetails *OpenAITokenDetails) map[string]interface{} {
 	finishReason := mapOpenAIFinishReason(upstreamStopReason, len(toolUses))
 
 	message := map[string]interface{}{
@@ -2245,10 +2246,6 @@ func KiroToOpenAIResponseWithReasoning(content, reasoningContent string, toolUse
 			"message":       message,
 			"finish_reason": finishReason,
 		}},
-		"usage": map[string]int{
-			"prompt_tokens":     inputTokens,
-			"completion_tokens": outputTokens,
-			"total_tokens":      inputTokens + outputTokens,
-		},
+		"usage": buildOpenAIUsage(inputTokens, outputTokens, cacheDetails),
 	}
 }

--- a/proxy/translator_test.go
+++ b/proxy/translator_test.go
@@ -378,7 +378,7 @@ func TestToolResultsContinuationIncludesInstructionPrefix(t *testing.T) {
 }
 
 func TestKiroToOpenAIResponseWithReasoningPreservesFinishReason(t *testing.T) {
-	response := KiroToOpenAIResponseWithReasoning("partial answer", "", nil, 10, 20, "claude-sonnet-4.5", "reasoning_content", "MAX_TOKENS")
+	response := KiroToOpenAIResponseWithReasoning("partial answer", "", nil, 10, 20, "claude-sonnet-4.5", "reasoning_content", "MAX_TOKENS", nil)
 	choices, ok := response["choices"].([]map[string]interface{})
 	if !ok || len(choices) != 1 {
 		t.Fatalf("unexpected choices: %#v", response["choices"])


### PR DESCRIPTION
## Summary
- Add account-scoped, five-minute local prompt-cache estimates for OpenAI Chat Completions and Responses API usage details.
- Return standard `cached_tokens` and `cache_write_tokens` fields when a stable translated Kiro prefix meets the existing cache threshold.
- Reuse the existing local prompt-cache tracker model: record only after upstream success; use cumulative history-prefix breakpoints so growing conversations can reuse earlier prefixes.

## Semantics
- These are local estimates, matching the existing Claude-side tracker approach; they are not Kiro upstream cache or billing telemetry.
- Estimates are isolated by Kiro account and exclude the current user message, current images, and current tool-result bodies.
- No Kiro request payload, account routing, session affinity, or billing behavior changes.

## Validation
- `go test ./...`