### PR TITLE
fix(stream): accept text-only CLI EOF without stop reason

### DIFF
--- a/proxy/account_failover.go
+++ b/proxy/account_failover.go
@@ -28,7 +28,7 @@ const maxAccountRetryAttempts = 3
 const maxSameAccountStreamRetries = 2
 
 // errUpstreamTruncatedResponse is a soft failure raised when a transport-clean
-// stream carried content but never a terminal signal. It is retryable on the
+// stream carried only reasoning without a terminal signal. It is retryable on the
 // same account and must not mark the account unhealthy.
 //
 // There is deliberately no empty-response error here. A stream that produced no
@@ -49,7 +49,8 @@ var errUpstreamTruncatedResponse = errors.New("upstream truncated response witho
 // match Kiro IDE, whose empty and truncation predicates each require
 // toolCallCount === 0.
 //
-// Truncated when content arrived without any terminal signal.
+// Ordinary assistant content is also complete after a transport-clean EOF:
+// the CLI runtime can omit terminal metadata even for a completed answer.
 //
 // Reasoning-only with no answer is STRICTER THAN THE IDE, deliberately. The
 // IDE's truncation predicate ends in (contentChars > 0 || !reasoningSeen), so
@@ -63,10 +64,10 @@ func classifyStreamIntegrity(contentChars, toolCallCount int, stopReason string,
 	if strings.TrimSpace(stopReason) != "" {
 		return nil
 	}
-	if toolCallCount > 0 {
+	if toolCallCount > 0 || contentChars > 0 {
 		return nil
 	}
-	if contentChars > 0 || sawReasoning {
+	if sawReasoning {
 		return errUpstreamTruncatedResponse
 	}
 	// No content, no reasoning, no tools: unreachable through the wired paths

--- a/proxy/kiro.go
+++ b/proxy/kiro.go
@@ -578,6 +578,7 @@ func parseEventStreamTracked(body io.Reader, callback *KiroStreamCallback) (emit
 	var totalCredits float64
 	var contextUsagePercentages []float64
 	var sawOutput bool
+	var sawAssistantContent, sawStopReason bool
 	pending := &pendingToolUses{}
 	trackedCallback := *callback
 	originalOnToolUse := trackedCallback.OnToolUse
@@ -644,10 +645,18 @@ func parseEventStreamTracked(body io.Reader, callback *KiroStreamCallback) (emit
 
 		inputTokens, outputTokens = updateTokensFromEvent(event, inputTokens, outputTokens)
 
+		if reason := findStopReason(event); reason != "" {
+			sawStopReason = true
+			if callback.OnStopReason != nil {
+				callback.OnStopReason(reason)
+			}
+		}
+
 		switch headers[":event-type"] {
 		case "assistantResponseEvent":
 			if content, ok := event["content"].(string); ok && content != "" {
 				sawOutput = true
+				sawAssistantContent = true
 				if callback.OnText != nil {
 					emitted = true
 					callback.OnText(content, false)
@@ -674,11 +683,12 @@ func parseEventStreamTracked(body io.Reader, callback *KiroStreamCallback) (emit
 				contextUsagePercentages = append(contextUsagePercentages, pct)
 			}
 		case "metadataEvent":
-			// stopReason rides inside metadataEvent on the wire; there is no
-			// standalone stop reason event type. Its absence after content is
-			// how callers detect a truncated stream.
-			if reason := firstStringField(event, "stopReason", "stop_reason"); reason != "" && callback.OnStopReason != nil {
-				callback.OnStopReason(reason)
+			// A metadata envelope is terminal even without an explicit reason.
+			if !sawStopReason {
+				sawStopReason = true
+				if callback.OnStopReason != nil {
+					callback.OnStopReason("end_turn")
+				}
 			}
 		}
 	}
@@ -689,6 +699,11 @@ func parseEventStreamTracked(body io.Reader, callback *KiroStreamCallback) (emit
 	}
 	if !sawOutput {
 		return emitted, errEmptyKiroStream
+	}
+	// Reached only after clean EOF and successful tool flushing. A read or
+	// frame error must never synthesize successful completion.
+	if sawAssistantContent && !sawStopReason && callback.OnStopReason != nil {
+		callback.OnStopReason("end_turn")
 	}
 	if callback.OnCredits != nil && totalCredits > 0 {
 		callback.OnCredits(totalCredits)
@@ -702,6 +717,31 @@ func parseEventStreamTracked(body io.Reader, callback *KiroStreamCallback) (emit
 		callback.OnComplete(inputTokens, outputTokens)
 	}
 	return emitted, nil
+}
+
+// findStopReason accepts terminal field variants inside decoded event envelopes.
+// String values are never decoded as JSON, so assistant text cannot supply a signal.
+func findStopReason(value interface{}) string {
+	switch value := value.(type) {
+	case map[string]interface{}:
+		for _, key := range []string{"stopReason", "stop_reason", "finishReason", "finish_reason"} {
+			if reason, ok := value[key].(string); ok && strings.TrimSpace(reason) != "" {
+				return reason
+			}
+		}
+		for _, nested := range value {
+			if reason := findStopReason(nested); reason != "" {
+				return reason
+			}
+		}
+	case []interface{}:
+		for _, nested := range value {
+			if reason := findStopReason(nested); reason != "" {
+				return reason
+			}
+		}
+	}
+	return ""
 }
 
 func updateTokensFromEvent(event map[string]interface{}, currentInputTokens, currentOutputTokens int) (int, int) {

--- a/proxy/stream_integrity_paths_test.go
+++ b/proxy/stream_integrity_paths_test.go
@@ -11,6 +11,56 @@ import (
 	"testing"
 )
 
+func TestHandlersAcceptTextOnlyCleanEOF(t *testing.T) {
+	for _, tc := range []struct {
+		name, path, body, terminal string
+	}{
+		{"Claude stream", "/v1/messages", `{"model":"claude-sonnet-4.5","max_tokens":100,"messages":[{"role":"user","content":"hi"}],"stream":true}`, `"stop_reason":"end_turn"`},
+		{"Claude buffered", "/v1/messages", `{"model":"claude-sonnet-4.5","max_tokens":100,"messages":[{"role":"user","content":"hi"}]}`, `"stop_reason":"end_turn"`},
+		{"Chat stream", "/v1/chat/completions", `{"model":"claude-sonnet-4.5","messages":[{"role":"user","content":"hi"}],"stream":true}`, `"finish_reason":"stop"`},
+		{"Chat buffered", "/v1/chat/completions", `{"model":"claude-sonnet-4.5","messages":[{"role":"user","content":"hi"}]}`, `"finish_reason":"stop"`},
+		{"Responses stream", "/v1/responses", `{"model":"claude-sonnet-4.5","input":"hi","stream":true,"store":false}`, "response.completed"},
+		{"Responses buffered", "/v1/responses", `{"model":"claude-sonnet-4.5","input":"hi","store":false}`, `"status":"completed"`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var hits atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				hits.Add(1)
+				for _, chunk := range []string{"complete ", "answer"} {
+					_, _ = w.Write(awsEventStreamFrame(t, "assistantResponseEvent", map[string]interface{}{"content": chunk}))
+				}
+				_, _ = w.Write(awsEventStreamFrame(t, "contextUsageEvent", map[string]interface{}{"contextUsagePercentage": 1}))
+				_, _ = w.Write(awsEventStreamFrame(t, "meteringEvent", map[string]interface{}{"usage": 1}))
+			}))
+			defer server.Close()
+			h := setupIntegrityPathTest(t, server)
+			req := httptest.NewRequest(http.MethodPost, tc.path, strings.NewReader(tc.body))
+			rec := httptest.NewRecorder()
+			switch tc.path {
+			case "/v1/messages":
+				h.handleClaudeMessages(rec, req)
+			case "/v1/chat/completions":
+				h.handleOpenAIChat(rec, req)
+			case "/v1/responses":
+				h.handleOpenAIResponses(rec, req)
+			}
+			body := rec.Body.String()
+			if rec.Code != http.StatusOK || !strings.Contains(body, "answer") || !strings.Contains(body, tc.terminal) {
+				t.Fatalf("status=%d body=%s", rec.Code, body)
+			}
+			if strings.Contains(body, `"type":"error"`) || strings.Contains(body, "response.failed") || strings.Contains(body, "upstream truncated") {
+				t.Fatalf("unexpected error: %s", body)
+			}
+			if tc.name == "Chat stream" && !strings.Contains(body, "[DONE]") {
+				t.Fatalf("missing DONE: %s", body)
+			}
+			if hits.Load() != 1 {
+				t.Fatalf("successful EOF must not retry: hits=%d", hits.Load())
+			}
+		})
+	}
+}
+
 // setupIntegrityPathTest installs a single-account config plus a fake upstream
 // and returns a handler wired to the reloaded pool.
 func setupIntegrityPathTest(t *testing.T, server *httptest.Server) *Handler {
@@ -42,7 +92,7 @@ func setupIntegrityPathTest(t *testing.T, server *httptest.Server) *Handler {
 	}
 }
 
-// truncatedUpstream serves content long enough to be flushed to the client but
+// truncatedUpstream serves reasoning long enough to be flushed to the client but
 // never sends a metadataEvent, i.e. a transport-successful truncated stream.
 func truncatedUpstream(t *testing.T, hits *atomic.Int32) *httptest.Server {
 	t.Helper()
@@ -51,8 +101,8 @@ func truncatedUpstream(t *testing.T, hits *atomic.Int32) *httptest.Server {
 			hits.Add(1)
 		}
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write(awsEventStreamFrame(t, "assistantResponseEvent", map[string]interface{}{
-			"content": strings.Repeat("partial answer ", 8),
+		_, _ = w.Write(awsEventStreamFrame(t, "reasoningContentEvent", map[string]interface{}{
+			"text": strings.Repeat("partial answer ", 8),
 		}))
 	}))
 }
@@ -66,7 +116,7 @@ func TestClaudeStreamEmitsErrorOnTruncatedStream(t *testing.T) {
 	h := setupIntegrityPathTest(t, server)
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{
-		"model":"claude-sonnet-4.5",
+		"model":"claude-sonnet-4.5-thinking",
 		"max_tokens":100,
 		"messages":[{"role":"user","content":"hello"}],
 		"stream":true
@@ -98,8 +148,8 @@ func TestClaudeNonStreamRetriesTruncatedStream(t *testing.T) {
 		n := hits.Add(1)
 		w.WriteHeader(http.StatusOK)
 		if n == 1 {
-			_, _ = w.Write(awsEventStreamFrame(t, "assistantResponseEvent", map[string]interface{}{
-				"content": "truncated attempt",
+			_, _ = w.Write(awsEventStreamFrame(t, "reasoningContentEvent", map[string]interface{}{
+				"text": "truncated attempt",
 			}))
 			return
 		}
@@ -114,7 +164,7 @@ func TestClaudeNonStreamRetriesTruncatedStream(t *testing.T) {
 	h := setupIntegrityPathTest(t, server)
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{
-		"model":"claude-sonnet-4.5",
+		"model":"claude-sonnet-4.5-thinking",
 		"max_tokens":100,
 		"messages":[{"role":"user","content":"hello"}]
 	}`))
@@ -151,7 +201,7 @@ func TestIntegrityFailureDoesNotBanAccount(t *testing.T) {
 	h := setupIntegrityPathTest(t, server)
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{
-		"model":"claude-sonnet-4.5",
+		"model":"claude-sonnet-4.5-thinking",
 		"max_tokens":100,
 		"messages":[{"role":"user","content":"hello"}],
 		"stream":true
@@ -186,7 +236,7 @@ func TestResponsesStreamEmitsFailedOnTruncatedStream(t *testing.T) {
 	h := setupIntegrityPathTest(t, server)
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
-		"model":"claude-sonnet-4.5",
+		"model":"claude-sonnet-4.5-thinking",
 		"input":"hello",
 		"stream":true,
 		"store":false
@@ -210,7 +260,7 @@ func TestOpenAIStreamEmitsErrorOnTruncatedStream(t *testing.T) {
 	h := setupIntegrityPathTest(t, server)
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{
-		"model":"claude-sonnet-4.5",
+		"model":"claude-sonnet-4.5-thinking",
 		"messages":[{"role":"user","content":"hello"}],
 		"stream":true
 	}`))
@@ -232,19 +282,16 @@ func TestOpenAIStreamEmitsErrorOnTruncatedStream(t *testing.T) {
 	}
 }
 
-// Regression for a defect the reference implementation does not cover: a short
-// unflushed chunk stays inside processClaudeText's tag buffer, so a retry that
-// does not clear it concatenates the previous attempt's text onto the new one.
+// Reasoning hidden in non-thinking mode must not leak into the recovered answer.
 func TestClaudeStreamRetryDoesNotLeakPreviousAttemptText(t *testing.T) {
 	var hits atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		n := hits.Add(1)
 		w.WriteHeader(http.StatusOK)
 		if n == 1 {
-			// Short enough to stay in the buffer: never flushed to the client,
-			// so the stream is still retryable.
-			_, _ = w.Write(awsEventStreamFrame(t, "assistantResponseEvent", map[string]interface{}{
-				"content": "LEAK",
+			// Reasoning is hidden in non-thinking mode, so retry remains safe.
+			_, _ = w.Write(awsEventStreamFrame(t, "reasoningContentEvent", map[string]interface{}{
+				"text": "LEAK",
 			}))
 			return
 		}

--- a/proxy/stream_integrity_test.go
+++ b/proxy/stream_integrity_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // classifyStreamIntegrity is the completeness rule: a stream that returned no
-// transport error is still incomplete when it carries no terminal signal.
+// transport error accepts ordinary text even without a terminal signal.
 // A stopReason of any value, or a delivered tool call, means complete.
 //
 // The reasoning-only case deliberately differs from Kiro IDE, which treats it
@@ -31,7 +31,8 @@ func TestClassifyStreamIntegrity(t *testing.T) {
 		{"complete with stop", 12, 0, "end_turn", false, nil},
 		{"complete with tools", 0, 1, "", false, nil},
 		{"complete with tools despite content", 12, 1, "", false, nil},
-		{"truncated content", 8, 0, "", false, errUpstreamTruncatedResponse},
+		{"text content with clean EOF", 8, 0, "", false, nil},
+		{"reasoning followed by answer", 8, 0, "", true, nil},
 		{"reasoning only stricter than ide", 0, 0, "", true, errUpstreamTruncatedResponse},
 		{"no signal at all", 0, 0, "", false, errUpstreamTruncatedResponse},
 	} {
@@ -95,7 +96,7 @@ func integrityTestPayload() *KiroPayload {
 	return payload
 }
 
-// A stream that delivered content but no stopReason is truncated, not failed:
+// A stream that delivered only reasoning but no stopReason is truncated, not failed:
 // the transport layer sees success and returns nil. The helper must catch that,
 // reset the caller's accumulators, and retry on the same account.
 //
@@ -109,9 +110,9 @@ func TestRunKiroWithIntegrityRetryRecoversTruncatedThenComplete(t *testing.T) {
 		n := hits.Add(1)
 		w.WriteHeader(http.StatusOK)
 		if n == 1 {
-			// Content but no metadataEvent => transport-successful truncation.
-			_, _ = w.Write(awsEventStreamFrame(t, "assistantResponseEvent", map[string]interface{}{
-				"content": "partial",
+			// Reasoning only without metadata => transport-successful truncation.
+			_, _ = w.Write(awsEventStreamFrame(t, "reasoningContentEvent", map[string]interface{}{
+				"text": "partial",
 			}))
 			return
 		}
@@ -126,19 +127,27 @@ func TestRunKiroWithIntegrityRetryRecoversTruncatedThenComplete(t *testing.T) {
 	defer setupIntegrityTestUpstream(t, server)()
 
 	var content string
+	var sawReasoning bool
 	var stopReason string
 	var resets int
 	err := runKiroWithIntegrityRetry(context.Background(), integrityTestAccount(), integrityTestPayload(),
 		&KiroStreamCallback{
-			OnText:       func(s string, _ bool) { content += s },
+			OnText: func(s string, reasoning bool) {
+				if reasoning {
+					sawReasoning = true
+				} else {
+					content += s
+				}
+			},
 			OnStopReason: func(r string) { stopReason = r },
 		},
 		func() (int, int, string, bool) {
-			return len(content), 0, stopReason, false
+			return len(content), 0, stopReason, sawReasoning
 		},
 		func() {
 			resets++
 			content = ""
+			sawReasoning = false
 			stopReason = ""
 		},
 		nil,
@@ -166,8 +175,8 @@ func TestRunKiroWithIntegrityRetrySkipsRetryAfterClientFlush(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		hits.Add(1)
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write(awsEventStreamFrame(t, "assistantResponseEvent", map[string]interface{}{
-			"content": "partial",
+		_, _ = w.Write(awsEventStreamFrame(t, "reasoningContentEvent", map[string]interface{}{
+			"text": "partial",
 		}))
 		// no metadataEvent/stopReason => truncated
 	}))
@@ -175,13 +184,20 @@ func TestRunKiroWithIntegrityRetrySkipsRetryAfterClientFlush(t *testing.T) {
 	defer setupIntegrityTestUpstream(t, server)()
 
 	var content string
+	var sawReasoning bool
 	flushed := true
 	err := runKiroWithIntegrityRetry(context.Background(), integrityTestAccount(), integrityTestPayload(),
 		&KiroStreamCallback{
-			OnText: func(s string, _ bool) { content += s },
+			OnText: func(s string, reasoning bool) {
+				if reasoning {
+					sawReasoning = true
+				} else {
+					content += s
+				}
+			},
 		},
-		func() (int, int, string, bool) { return len(content), 0, "", false },
-		func() { content = "" },
+		func() (int, int, string, bool) { return len(content), 0, "", sawReasoning },
+		func() { content = ""; sawReasoning = false },
 		func() bool { return !flushed },
 	)
 	if !isStreamIntegrityError(err) {
@@ -190,7 +206,7 @@ func TestRunKiroWithIntegrityRetrySkipsRetryAfterClientFlush(t *testing.T) {
 	if hits.Load() != 1 {
 		t.Fatalf("must not retry after flush, hits=%d", hits.Load())
 	}
-	if content != "partial" {
+	if content != "" || !sawReasoning {
 		t.Fatalf("content=%q", content)
 	}
 }
@@ -198,15 +214,15 @@ func TestRunKiroWithIntegrityRetrySkipsRetryAfterClientFlush(t *testing.T) {
 // A canceled client context must not drive an integrity retry. The turn is over,
 // so reissuing it would only burn upstream quota.
 //
-// The upstream here returns content with no stopReason, which classifies as
+// The upstream here returns reasoning with no stopReason, which classifies as
 // truncated and would otherwise be retried; cancellation must suppress that.
 func TestRunKiroWithIntegrityRetryStopsOnCanceledContext(t *testing.T) {
 	var hits atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		hits.Add(1)
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write(awsEventStreamFrame(t, "assistantResponseEvent", map[string]interface{}{
-			"content": "partial",
+		_, _ = w.Write(awsEventStreamFrame(t, "reasoningContentEvent", map[string]interface{}{
+			"text": "partial",
 		}))
 	}))
 	defer server.Close()
@@ -216,10 +232,17 @@ func TestRunKiroWithIntegrityRetryStopsOnCanceledContext(t *testing.T) {
 	cancel()
 
 	var content string
+	var sawReasoning bool
 	var resets int
 	err := runKiroWithIntegrityRetry(ctx, integrityTestAccount(), integrityTestPayload(),
-		&KiroStreamCallback{OnText: func(s string, _ bool) { content += s }},
-		func() (int, int, string, bool) { return len(content), 0, "", false },
+		&KiroStreamCallback{OnText: func(s string, reasoning bool) {
+			if reasoning {
+				sawReasoning = true
+			} else {
+				content += s
+			}
+		}},
+		func() (int, int, string, bool) { return len(content), 0, "", sawReasoning },
 		func() { resets++ },
 		nil,
 	)
@@ -246,19 +269,26 @@ func TestRunKiroWithIntegrityRetryStopsAfterBudgetExhausted(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		hits.Add(1)
 		w.WriteHeader(http.StatusOK)
-		// Always truncated: content with no terminal signal.
-		_, _ = w.Write(awsEventStreamFrame(t, "assistantResponseEvent", map[string]interface{}{
-			"content": "partial",
+		// Always truncated: reasoning with no terminal signal.
+		_, _ = w.Write(awsEventStreamFrame(t, "reasoningContentEvent", map[string]interface{}{
+			"text": "partial",
 		}))
 	}))
 	defer server.Close()
 	defer setupIntegrityTestUpstream(t, server)()
 
 	var content string
+	var sawReasoning bool
 	err := runKiroWithIntegrityRetry(context.Background(), integrityTestAccount(), integrityTestPayload(),
-		&KiroStreamCallback{OnText: func(s string, _ bool) { content += s }},
-		func() (int, int, string, bool) { return len(content), 0, "", false },
-		func() { content = "" },
+		&KiroStreamCallback{OnText: func(s string, reasoning bool) {
+			if reasoning {
+				sawReasoning = true
+			} else {
+				content += s
+			}
+		}},
+		func() (int, int, string, bool) { return len(content), 0, "", sawReasoning },
+		func() { content = ""; sawReasoning = false },
 		nil,
 	)
 	if !isStreamIntegrityError(err) {

--- a/proxy/tool_use_order_test.go
+++ b/proxy/tool_use_order_test.go
@@ -7,9 +7,83 @@ package proxy
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
+	"io"
 	"testing"
 )
+
+func TestParseEventStreamCompletionSignals(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		eventType string
+		payload   map[string]interface{}
+		want      string
+	}{
+		{"text only EOF", "", nil, "end_turn"},
+		{"empty metadata", "metadataEvent", map[string]interface{}{}, "end_turn"},
+		{"nested map", "metadataEvent", map[string]interface{}{"metadata": map[string]interface{}{"finish_reason": "MAX_TOKENS"}}, "MAX_TOKENS"},
+		{"nested array", "metadataEvent", map[string]interface{}{"events": []interface{}{map[string]interface{}{"finishReason": "MAX_TOKENS"}}}, "MAX_TOKENS"},
+		{"assistant terminal field", "assistantResponseEvent", map[string]interface{}{"content": "done", "finishReason": "MAX_TOKENS"}, "MAX_TOKENS"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var stream bytes.Buffer
+			stream.Write(awsEventStreamFrame(t, "assistantResponseEvent", map[string]interface{}{"content": "answer"}))
+			stream.Write(awsEventStreamFrame(t, "contextUsageEvent", map[string]interface{}{"contextUsagePercentage": 1}))
+			stream.Write(awsEventStreamFrame(t, "meteringEvent", map[string]interface{}{"usage": 1}))
+			if tc.eventType != "" {
+				stream.Write(awsEventStreamFrame(t, tc.eventType, tc.payload))
+			}
+			if tc.want == "MAX_TOKENS" {
+				stream.Write(awsEventStreamFrame(t, "metadataEvent", map[string]interface{}{}))
+			}
+			var reasons []string
+			completed := false
+			err := parseEventStream(&stream, &KiroStreamCallback{
+				OnStopReason: func(r string) { reasons = append(reasons, r) },
+				OnComplete: func(int, int) {
+					completed = true
+					if len(reasons) != 1 || reasons[0] != tc.want {
+						t.Errorf("reasons before completion=%v, want [%s]", reasons, tc.want)
+					}
+				},
+			})
+			if err != nil || !completed {
+				t.Fatalf("err=%v completed=%v", err, completed)
+			}
+		})
+	}
+}
+
+func TestParseEventStreamDoesNotSynthesizeCompletionForIncompleteOutput(t *testing.T) {
+	text := awsEventStreamFrame(t, "assistantResponseEvent", map[string]interface{}{"content": "partial"})
+	frame := awsEventStreamFrame(t, "assistantResponseEvent", map[string]interface{}{"content": "next"})
+	corrupt := append([]byte(nil), frame...)
+	corrupt[len(corrupt)-1] ^= 1
+	for _, tc := range []struct {
+		name    string
+		stream  []byte
+		wantErr error
+	}{
+		{"reasoning only", awsEventStreamFrame(t, "reasoningContentEvent", map[string]interface{}{"text": "thinking"}), nil},
+		{"reasoning with key-like text", awsEventStreamFrame(t, "reasoningContentEvent", map[string]interface{}{"text": `{"stopReason":"end_turn"}`}), nil},
+		{"empty", nil, errEmptyKiroStream},
+		{"partial prelude", append(append([]byte(nil), text...), frame[:5]...), io.ErrUnexpectedEOF},
+		{"partial payload", append(append([]byte(nil), text...), frame[:len(frame)-1]...), io.ErrUnexpectedEOF},
+		{"bad CRC", append(append([]byte(nil), text...), corrupt...), errInvalidKiroEventStream},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var reasons int
+			err := parseEventStream(bytes.NewReader(tc.stream), &KiroStreamCallback{OnStopReason: func(string) { reasons++ }})
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("err=%v want %v", err, tc.wantErr)
+			}
+			if reasons != 0 {
+				t.Fatalf("unexpected completion signal: %d", reasons)
+			}
+		})
+	}
+}
 
 // A tool that opens with both id and name, then continues with fragments that
 // carry only input and no id, must accumulate into the same entry. This is the
@@ -186,17 +260,15 @@ func TestParseEventStreamIDLessNameChangeOpensNewTool(t *testing.T) {
 	}
 }
 
-// stopReason rides inside metadataEvent. Upstream has been seen using both the
-// camelCase and snake_case spellings, and missing it means a truncated stream
-// is reported to the client as a normal end_turn.
+// Preserve explicit terminal reasons across supported field spellings.
 func TestParseEventStreamReadsStopReasonKeyVariants(t *testing.T) {
-	for _, key := range []string{"stopReason", "stop_reason"} {
+	for _, key := range []string{"stopReason", "stop_reason", "finishReason", "finish_reason"} {
 		t.Run(key, func(t *testing.T) {
 			var stream bytes.Buffer
 			stream.Write(awsEventStreamFrame(t, "assistantResponseEvent",
 				map[string]interface{}{"content": "done"}))
 			stream.Write(awsEventStreamFrame(t, "metadataEvent",
-				map[string]interface{}{key: "end_turn"}))
+				map[string]interface{}{key: "MAX_TOKENS"}))
 
 			var reason string
 			err := parseEventStream(bytes.NewReader(stream.Bytes()), &KiroStreamCallback{
@@ -206,8 +278,8 @@ func TestParseEventStreamReadsStopReasonKeyVariants(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected parse error: %v", err)
 			}
-			if reason != "end_turn" {
-				t.Fatalf("stop reason=%q, want end_turn", reason)
+			if reason != "MAX_TOKENS" {
+				t.Fatalf("stop reason=%q, want MAX_TOKENS", reason)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Accept ordinary assistant text followed by a transport-clean EOF when the Kiro CLI runtime omits terminal metadata. Previously, the integrity check introduced in #146 rejected this response with `upstream truncated response without stop reason`.

## Changes

- Synthesize `end_turn` after text-only clean EOF or metadata without an explicit terminal reason.
- Recognize `stopReason`, `stop_reason`, `finishReason`, and `finish_reason`, including nested event payloads, and preserve explicit reasons.
- Keep reasoning-only responses without a terminal signal incomplete and retryable; retain empty-stream and malformed-frame errors.
- Cover streaming and buffered Claude, Chat Completions, and Responses paths, plus retry, cancellation, terminal field variants, partial frames, and CRC failures.

The supplied runtime report describes assistant content followed by context usage and metering events, then clean EOF without metadata. This change was validated with mocked upstream streams; no live-account validation was performed here. Clean EOF is accepted for compatibility and cannot independently prove semantic answer completeness.

## Validation

- `go test ./...` — passed
- `go vet ./...` — passed
- `git diff --check` — passed
